### PR TITLE
ab/ids37/Stack-removing-required-props 

### DIFF
--- a/src/components/layouts/Stack/index.jsx
+++ b/src/components/layouts/Stack/index.jsx
@@ -60,9 +60,9 @@ Stack.propTypes = {
     PropTypes.arrayOf(PropTypes.element),
   ]),
   wrap: PropTypes.oneOf(wrapControl),
-  direction: PropTypes.oneOf(directionAlignments).isRequired,
-  justifyContent: PropTypes.oneOf(flexAlignments).isRequired,
-  alignItems: PropTypes.oneOf(flexAlignments).isRequired,
+  direction: PropTypes.oneOf(directionAlignments),
+  justifyContent: PropTypes.oneOf(flexAlignments),
+  alignItems: PropTypes.oneOf(flexAlignments),
   gap: PropTypes.string,
 };
 

--- a/src/components/layouts/Stack/stories/Stack.Default.stories.js
+++ b/src/components/layouts/Stack/stories/Stack.Default.stories.js
@@ -34,10 +34,6 @@ export const Default = StackTemplate.bind({});
 
 Default.args = {
   children: [...Array(6 + 1).keys()].slice(1),
-  wrap: "nowrap",
-  direction: "row",
-  justifyContent: "flex-start",
-  alignItems: "flex-start",
   gap: "10px",
 };
 Default.argTypes = {


### PR DESCRIPTION
lt valuesIt is unnecessary to define a required constraint if a component has a default value for a prop. This RFC deletes the required constraint in some <Stack /> props. 