### PR TITLE
Adjust PropTypes of <Text />

### DIFF
--- a/src/components/data/Text/index.jsx
+++ b/src/components/data/Text/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import PropsType from "prop-types";
+import PropTypes from "prop-types";
 
 import { colors } from "../../../shared/colors/colors";
 import { typography } from "../../../shared/typography/typography";
@@ -99,20 +99,20 @@ const Text = (props) => {
 };
 
 Text.propTypes = {
-  children: PropsType.node,
-  align: PropsType.oneOf(alignsOptions),
-  margin: PropsType.oneOfType([
-    PropsType.string,
-    PropsType.oneOf(globalValuesPropertiesCss),
+  children: PropTypes.node,
+  align: PropTypes.oneOf(alignsOptions),
+  margin: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.oneOf(globalValuesPropertiesCss),
   ]),
-  padding: PropsType.oneOfType([
-    PropsType.string,
-    PropsType.oneOf(globalValuesPropertiesCss),
+  padding: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.oneOf(globalValuesPropertiesCss),
   ]),
-  as: PropsType.oneOf(htmlElements),
-  id: PropsType.string,
-  appearance: PropsType.oneOf(appearencesOptions),
-  typo: PropsType.oneOf(typosOptions),
+  as: PropTypes.oneOf(htmlElements),
+  id: PropTypes.string,
+  appearance: PropTypes.oneOf(appearencesOptions),
+  typo: PropTypes.oneOf(typosOptions),
 };
 
 export { Text, htmlElements, alignsOptions, appearencesOptions, typosOptions };

--- a/src/components/data/Text/stories/Text.Paragraphs.stories.js
+++ b/src/components/data/Text/stories/Text.Paragraphs.stories.js
@@ -13,7 +13,7 @@ import {
 } from "./props";
 
 const story = {
-  title: "components/data/Paragraphs",
+  title: "data/Text/Paragraphs",
   components: [Text],
   parameters,
 };

--- a/src/components/data/Text/stories/Text.Titles.stories.js
+++ b/src/components/data/Text/stories/Text.Titles.stories.js
@@ -16,7 +16,7 @@ import {
 } from "./props";
 
 const story = {
-  title: "components/data/Title",
+  title: "data/Text/Title",
   components: [Text],
   parameters,
 };


### PR DESCRIPTION
The library prop-types exports PropTypes to validate the props we define in our components. The <Text /> component is using PropsType, not PropTypes. 