### PR TITLE
Validate iconBefore or iconAfter in Button before rendering JSX

### DIFF
--- a/src/components/inputs/Button/index.jsx
+++ b/src/components/inputs/Button/index.jsx
@@ -46,18 +46,6 @@ const defaultSpacing = "wide";
 const defaultVariant = "filled";
 const defaultSpinnerSize = "small";
 
-const Icons = (props) => {
-  const { iconBefore, iconAfter, children, isDisabled, transformedVariant } =
-    props;
-  return (
-    <StyledSpan isDisabled={isDisabled} variant={transformedVariant}>
-      {iconBefore && <StyledIcon>{iconBefore}</StyledIcon>}
-      {children}
-      {iconAfter && <StyledIcon>{iconAfter}</StyledIcon>}
-    </StyledSpan>
-  );
-};
-
 const Button = (props) => {
   const {
     children,
@@ -108,14 +96,11 @@ const Button = (props) => {
           size={defaultSpinnerSize}
         />
       ) : (
-        <Icons
-          iconBefore={iconBefore}
-          iconAfter={iconAfter}
-          isDisabled={isDisabled}
-          variant={transformedVariant}
-        >
+        <StyledSpan isDisabled={isDisabled} variant={transformedVariant}>
+          {iconBefore && <StyledIcon id="mdIcon">{iconBefore}</StyledIcon>}
           {children}
-        </Icons>
+          {iconAfter && <StyledIcon id="mdIcon">{iconAfter}</StyledIcon>}
+        </StyledSpan>
       )}
     </StyledButton>
   );

--- a/src/components/inputs/Button/index.jsx
+++ b/src/components/inputs/Button/index.jsx
@@ -46,6 +46,18 @@ const defaultSpacing = "wide";
 const defaultVariant = "filled";
 const defaultSpinnerSize = "small";
 
+const Icons = (props) => {
+  const { iconBefore, iconAfter, children, isDisabled, transformedVariant } =
+    props;
+  return (
+    <StyledSpan isDisabled={isDisabled} variant={transformedVariant}>
+      {iconBefore && <StyledIcon>{iconBefore}</StyledIcon>}
+      {children}
+      {iconAfter && <StyledIcon>{iconAfter}</StyledIcon>}
+    </StyledSpan>
+  );
+};
+
 const Button = (props) => {
   const {
     children,
@@ -96,11 +108,14 @@ const Button = (props) => {
           size={defaultSpinnerSize}
         />
       ) : (
-        <StyledSpan isDisabled={isDisabled} variant={transformedVariant}>
-          <StyledIcon id="mdIcon">{iconBefore}</StyledIcon>
+        <Icons
+          iconBefore={iconBefore}
+          iconAfter={iconAfter}
+          isDisabled={isDisabled}
+          variant={transformedVariant}
+        >
           {children}
-          <StyledIcon id="mdIcon">{iconAfter}</StyledIcon>
-        </StyledSpan>
+        </Icons>
       )}
     </StyledButton>
   );

--- a/src/components/inputs/Button/stories/Button.Default.stories.js
+++ b/src/components/inputs/Button/stories/Button.Default.stories.js
@@ -33,7 +33,6 @@ export const Default = (args) => <ButtonController {...args} />;
 Default.args = {
   children: "Button",
   iconBefore: <MdAdd />,
-  handleClick: () => {},
 };
 Default.argTypes = {
   children,


### PR DESCRIPTION
Overview 

The return statement of the <Button /> component always includes an iconBefore and iconAfter markup, even if the implementer didn’t specify one. 

Goals 

If an implementer doesn’t pass through props an icon, it shouldn’t be a JSX for icons in the component’s markup. 