### PR TITLE
Remove pointer-events: none from `Blanket`

### DIFF
--- a/src/components/utils/Blanket/styles.js
+++ b/src/components/utils/Blanket/styles.js
@@ -12,7 +12,6 @@ const StyledBlanket = styled.div`
   right: 0%;
   background-color: ${colors.ref.palette.neutralAlpha.n100A};
   border: none;
-  pointer-events: none;
 `;
 
 export { StyledBlanket };


### PR DESCRIPTION
Elimina la propiedad `pointer-events`

The CSS pointer-events properties is an inheritable property, which means that all its children will inherit what you defined in it.

Since we have pointer-events: none, the DecisionModal or any other component nested inside will kill all the mouse-events on their element, making them useless.