### PR TITLE
`<Tabs />` are starting without left-padding for first `<Tab />`

### DIFF
--- a/src/components/navigation/Tabs/styles.js
+++ b/src/components/navigation/Tabs/styles.js
@@ -2,11 +2,12 @@ import styled from "styled-components";
 import { colors } from "../../../shared/colors/colors";
 
 const StyledTabs = styled.div`
+  box-sizing: border-box;
   overflow-x: auto;
   white-space: nowrap;
   width: 100%;
   border-bottom: 2px solid ${colors.ref.palette.neutral.n40};
-  padding: 0rem 1.5rem;
+  padding: 0px 16px;
 `;
 
 export { StyledTabs };

--- a/src/components/navigation/Tabs/styles.js
+++ b/src/components/navigation/Tabs/styles.js
@@ -6,6 +6,7 @@ const StyledTabs = styled.div`
   white-space: nowrap;
   width: 100%;
   border-bottom: 2px solid ${colors.ref.palette.neutral.n40};
+  padding-left: 1.5rem;
 `;
 
 export { StyledTabs };

--- a/src/components/navigation/Tabs/styles.js
+++ b/src/components/navigation/Tabs/styles.js
@@ -6,7 +6,7 @@ const StyledTabs = styled.div`
   white-space: nowrap;
   width: 100%;
   border-bottom: 2px solid ${colors.ref.palette.neutral.n40};
-  padding-left: 1.5rem;
+  padding: 0rem 1.5rem;
 `;
 
 export { StyledTabs };


### PR DESCRIPTION
`<Tabs />` should have a kind of left-padding for the first `<Tab />` to appear  you can see in the Figma components file that the first `<Tab />` should not be left-aligned right from the start.