### PR TITLE
`<Blanket />` should tend to be on top when rendered

### DIFF
--- a/src/components/utils/Blanket/styles.js
+++ b/src/components/utils/Blanket/styles.js
@@ -12,6 +12,7 @@ const StyledBlanket = styled.div`
   right: 0%;
   background-color: ${colors.ref.palette.neutralAlpha.n100A};
   border: none;
+  z-index: 1;
 `;
 
 export { StyledBlanket };


### PR DESCRIPTION
Currently the `<Blanket />` component doesn’t have the instruction to be on top of its stacking context. Since this is an absolute positioned component, it should also define something in its `z-index` property so that it is actually on top of the screen and not only in some parts of it.