### PR TITLE
When re-sizing the screen to test responsive, there is an error about a wrong prop type in `<User />`

### DIFF
--- a/src/components/layouts/Stack/index.jsx
+++ b/src/components/layouts/Stack/index.jsx
@@ -58,6 +58,7 @@ const Stack = (props) => {
 Stack.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.element,
+    PropTypes.node,
     PropTypes.arrayOf(PropTypes.element),
   ]),
   wrap: PropTypes.oneOf(wrapControl),


### PR DESCRIPTION
The types that the children can accept were updated by adding a new type (PropTypes.node) so that the stack component can receive nodes as children