### PR TITLE
Adjust height of `<TextField />` for "wide" and "compact" sizes

### DIFF
--- a/src/components/inputs/TextField/styles.js
+++ b/src/components/inputs/TextField/styles.js
@@ -3,7 +3,7 @@ import { colors } from "../../../shared/colors/colors";
 
 const sizeOptions = {
   compact: {
-    height: "27px",
+    height: "40px",
   },
   wide: {
     height: "48px",


### PR DESCRIPTION
adjust the height-property to a value of 40 pixels in the event that the textField size is designated as compact