### PR TITLE
Adjust the use of typography tokens in `<Button />`

### DIFF
--- a/src/components/inputs/Button/index.jsx
+++ b/src/components/inputs/Button/index.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { StyledButton, StyledSpan, StyledIcon } from "./styles";
+import { StyledButton, StyledIcon } from "./styles";
 import { Spinner } from "./../../feedback/Spinner";
 import { colors } from "../../../shared/colors/colors";
-
+import { Text } from "../../data/Text/index";
 const fixedColors = Object.assign({}, colors.sys.actions);
 delete fixedColors.disabled;
 export const appearances = Object.keys(fixedColors);
@@ -34,9 +34,44 @@ const spinnerColorHomologation = {
     help: "purple",
   },
 };
+
 const getSpinnerColor = (variant, appearance) => {
   return spinnerColorHomologation[variant][appearance];
 };
+
+const textAppearences = {
+  filled: {
+    normal: {
+      primary: "light",
+      secondary: "secondary",
+      confirm: "light",
+      warning: "dark",
+      remove: "light",
+      help: "light",
+      disabled: "disabled",
+    },
+    hover: "light",
+  },
+  outlined: {
+    normal: {
+      confirm: "success",
+      remove: "error",
+    },
+    hover: {
+      secondary: colors.ref.palette.neutral.n200,
+    },
+  },
+  none: {
+    normal: {
+      confirm: "success",
+      remove: "error",
+    },
+    hover: {
+      secondary: colors.ref.palette.neutral.n200,
+    },
+  },
+};
+
 export const types = ["text", "submit", "reset"];
 export const spacings = ["wide", "compact"];
 export const variants = ["filled", "outlined", "none"];
@@ -96,11 +131,19 @@ const Button = (props) => {
           size={defaultSpinnerSize}
         />
       ) : (
-        <StyledSpan isDisabled={isDisabled} variant={transformedVariant}>
+        <Text
+          as="span"
+          appearance={
+            textAppearences[transformedVariant].normal[transformedAppearance]
+          }
+          typo="labelLarge"
+          isDisabled={isDisabled}
+          variant={transformedVariant}
+        >
           {iconBefore && <StyledIcon id="mdIcon">{iconBefore}</StyledIcon>}
           {children}
           {iconAfter && <StyledIcon id="mdIcon">{iconAfter}</StyledIcon>}
-        </StyledSpan>
+        </Text>
       )}
     </StyledButton>
   );

--- a/src/components/inputs/Button/styles.js
+++ b/src/components/inputs/Button/styles.js
@@ -31,43 +31,6 @@ const hoverColors = {
   help: colors.ref.palette.purple.p300,
 };
 
-const textColors = {
-  filled: {
-    normal: {
-      primary: colors.ref.palette.neutral.n0,
-      secondary: colors.ref.palette.neutral.n300,
-      confirm: colors.ref.palette.neutral.n0,
-      warning: colors.ref.palette.neutral.n900,
-      remove: colors.ref.palette.neutral.n0,
-      help: colors.ref.palette.neutral.n0,
-      disabled: colors.sys.text.disabled,
-    },
-    hover: colors.ref.palette.neutral.n0,
-  },
-  outlined: {
-    normal: {
-      ...colors.sys.text,
-      confirm: colors.sys.text.success,
-      remove: colors.sys.text.error,
-    },
-    hover: {
-      ...hoverColors,
-      secondary: colors.ref.palette.neutral.n200,
-    },
-  },
-  none: {
-    normal: {
-      ...colors.sys.text,
-      confirm: colors.sys.text.success,
-      remove: colors.sys.text.error,
-    },
-    hover: {
-      ...hoverColors,
-      secondary: colors.ref.palette.neutral.n200,
-    },
-  },
-};
-
 const backgroundColor = {
   filled: {
     normal: {
@@ -109,20 +72,6 @@ const getPointer = (props) => {
   return cursors.pointer;
 };
 
-const getColor = (props) => {
-  const { isDisabled, variant, appearance, isHover } = props;
-
-  if (isDisabled) {
-    return textColors[variant].normal.disabled;
-  }
-
-  if (isHover) {
-    return textColors[variant].hover[appearance];
-  }
-
-  return textColors[variant].normal[appearance];
-};
-
 const getBorderColor = (props) => {
   const { isDisabled, variant, appearance, isHover } = props;
 
@@ -159,13 +108,6 @@ function getBackgroundColor(props) {
   return backgroundColor[variant].normal[appearance].filled;
 }
 
-const StyledSpan = styled.span`
-  display: flex;
-  justify-content: space-between;
-  gap: 4px;
-  overflow: hidden;
-`;
-
 const StyledButton = styled.button`
   display: flex;
   justify-content: center;
@@ -177,7 +119,6 @@ const StyledButton = styled.button`
   border-style: solid;
   border-width: 1px;
   font-family: ${typography.ref.typeface.brand};
-  color: ${getColor};
   background-color: ${getBackgroundColor};
   border-color: ${getBorderColor};
   width: ${(props) => (props.isFullWidth === true ? "100%" : "fit-content")};
@@ -185,8 +126,14 @@ const StyledButton = styled.button`
   cursor: ${getPointer};
   ${(props) => spacing[props.spacing]}
 
+  & > span {
+    display: flex;
+    justify-content: space-between;
+    gap: 4px;
+    overflow: hidden;
+  }
+
   &:hover {
-    color: ${(props) => getColor({ ...props, isHover: true })};
     border-color: ${(props) => getBorderColor({ ...props, isHover: true })};
     background-color: ${(props) =>
       getBackgroundColor({ ...props, isHover: true })};
@@ -197,4 +144,4 @@ const StyledIcon = styled.div`
   display: flex;
   align-items: center;
 `;
-export { StyledButton, StyledSpan, StyledIcon };
+export { StyledButton, StyledIcon };


### PR DESCRIPTION
The font-size in Buttons is not aligned with the mockups when the `<Button />`  has a “wide” sizing.

Nontheless, we can avoid using typography token in styled-components if we implement the `<Text />` component with the typo prop .