### PR TITLE
Delete `<ButtonController />` in `<Button />` stories

### DIFF
--- a/src/components/inputs/Button/stories/Button.Appearances.stories.js
+++ b/src/components/inputs/Button/stories/Button.Appearances.stories.js
@@ -3,7 +3,6 @@ import { BrowserRouter } from "react-router-dom";
 import { MdAdd } from "react-icons/md";
 
 import { Button, appearances } from "../index";
-import { ButtonController } from "./ButtonController";
 import { StyledFlex } from "./stories.styles";
 
 import {
@@ -38,7 +37,7 @@ const ButtonComponent = (props) => {
     <StyledFlex>
       {appearances.map((appearance) => (
         <div key={appearance}>
-          <ButtonController {...props} appearance={appearance} />
+          <Button {...props} appearance={appearance} />
         </div>
       ))}
     </StyledFlex>

--- a/src/components/inputs/Button/stories/Button.Default.stories.js
+++ b/src/components/inputs/Button/stories/Button.Default.stories.js
@@ -3,7 +3,6 @@ import { BrowserRouter } from "react-router-dom";
 import { MdAdd } from "react-icons/md";
 
 import { Button } from "../index";
-import { ButtonController } from "./ButtonController";
 
 import {
   children,
@@ -34,12 +33,13 @@ const story = {
   ],
 };
 
-export const Default = (args) => <ButtonController {...args} />;
+export const Default = (args) => <Button {...args} />;
 
 Default.args = {
   children: "Button",
   path: "/privilege",
   iconBefore: <MdAdd />,
+  handleClick: () => console.log("clicked from Default-story"),
 };
 Default.argTypes = {
   children,

--- a/src/components/inputs/Button/stories/Button.Disabled.stories.js
+++ b/src/components/inputs/Button/stories/Button.Disabled.stories.js
@@ -3,7 +3,6 @@ import { BrowserRouter } from "react-router-dom";
 import { MdAdd } from "react-icons/md";
 
 import { Button, appearances } from "../index";
-import { ButtonController } from "./ButtonController";
 import { StyledFlex } from "./stories.styles";
 
 import {
@@ -39,7 +38,7 @@ const ButtonComponent = (props) => {
     <StyledFlex>
       {appearances.map((appearance) => (
         <div key={appearance}>
-          <ButtonController {...props} isDisabled={true} />
+          <Button {...props} isDisabled={true} />
         </div>
       ))}
     </StyledFlex>

--- a/src/components/inputs/Button/stories/Button.FullWidth.stories.js
+++ b/src/components/inputs/Button/stories/Button.FullWidth.stories.js
@@ -3,7 +3,6 @@ import { BrowserRouter } from "react-router-dom";
 import { Button } from "../index";
 import { MdAdd } from "react-icons/md";
 
-import { ButtonController } from "./ButtonController";
 import { StyledFlex } from "./stories.styles";
 
 import {
@@ -37,7 +36,7 @@ const story = {
 const ButtonComponent = (props) => {
   return (
     <StyledFlex>
-      <ButtonController {...props} isFullWidth={true} />
+      <Button {...props} isFullWidth={true} />
     </StyledFlex>
   );
 };

--- a/src/components/inputs/Button/stories/Button.Icons.stories.js
+++ b/src/components/inputs/Button/stories/Button.Icons.stories.js
@@ -3,7 +3,6 @@ import { BrowserRouter } from "react-router-dom";
 import { MdAdd } from "react-icons/md";
 
 import { Button } from "../index";
-import { ButtonController } from "./ButtonController";
 import { StyledFlex } from "./stories.styles";
 
 import {
@@ -37,7 +36,7 @@ const ButtonComponent = (props) => {
     <StyledFlex>
       {[0, 1, 2].map((item) => (
         <div key={item}>
-          <ButtonController
+          <Button
             {...props}
             iconBefore={item === 0 ? <MdAdd /> : null}
             iconAfter={item === 1 ? <MdAdd /> : null}

--- a/src/components/inputs/Button/stories/Button.Loading.stories.js
+++ b/src/components/inputs/Button/stories/Button.Loading.stories.js
@@ -2,7 +2,6 @@ import React from "react";
 import { BrowserRouter } from "react-router-dom";
 
 import { Button, variants } from "../index";
-import { ButtonController } from "./ButtonController";
 import { StyledFlex } from "./stories.styles";
 
 import {
@@ -34,7 +33,7 @@ const ButtonComponent = (props) => {
     <StyledFlex>
       {variants.map((variant) => (
         <div key={variant}>
-          <ButtonController {...props} variant={variant} isLoading={true} />
+          <Button {...props} variant={variant} isLoading={true} />
         </div>
       ))}
     </StyledFlex>

--- a/src/components/inputs/Button/stories/Button.Spacing.stories.js
+++ b/src/components/inputs/Button/stories/Button.Spacing.stories.js
@@ -3,7 +3,6 @@ import { MdAdd } from "react-icons/md";
 import { BrowserRouter } from "react-router-dom";
 
 import { Button, spacings } from "../index";
-import { ButtonController } from "./ButtonController";
 import { StyledFlex } from "./stories.styles";
 
 import {
@@ -39,7 +38,7 @@ const ButtonComponent = (props) => {
     <StyledFlex>
       {spacings.map((spacing) => (
         <div key={spacing}>
-          <ButtonController {...props} spacing={spacing} />
+          <Button {...props} spacing={spacing} />
         </div>
       ))}
     </StyledFlex>

--- a/src/components/inputs/Button/stories/Button.Variants.stories.js
+++ b/src/components/inputs/Button/stories/Button.Variants.stories.js
@@ -3,7 +3,6 @@ import { BrowserRouter } from "react-router-dom";
 import { MdAdd } from "react-icons/md";
 
 import { Button, variants } from "../index";
-import { ButtonController } from "./ButtonController";
 import { StyledFlex } from "./stories.styles";
 
 import {
@@ -39,7 +38,7 @@ const ButtonComponent = (props) => {
     <StyledFlex>
       {variants.map((variant) => (
         <div key={variant}>
-          <ButtonController {...props} variant={variant} />
+          <Button {...props} variant={variant} />
         </div>
       ))}
     </StyledFlex>

--- a/src/components/inputs/Button/stories/ButtonController.jsx
+++ b/src/components/inputs/Button/stories/ButtonController.jsx
@@ -1,8 +1,0 @@
-import React from "react";
-import { Button } from "../index";
-
-const ButtonController = (props) => {
-  return <Button {...props} />;
-};
-
-export { ButtonController };


### PR DESCRIPTION
The aim of this resolution is to eliminate the superfluous utilization of the ButtonController. As there is currently no need for controlling the state above it, the ButtonController will be removed. 