### PR TITLE
Fix `<TextField />` component to implement new `readOnly` property

### DIFF
--- a/src/components/data/Text/index.jsx
+++ b/src/components/data/Text/index.jsx
@@ -3,11 +3,9 @@ import PropTypes from "prop-types";
 
 import { colors } from "../../../shared/colors/colors";
 import { typography } from "../../../shared/typography/typography";
+import { validateCssSpacing } from "../../../utils/validateCssSpacing";
 
 import { StyledText } from "./styles";
-
-/**it is validated that the values entered are in pixels and valid according to the css property margin and padding. */
-const regex = /^[0-9]+px$/;
 
 const globalValuesPropertiesCss = ["inherit", "initial", "unset", "auto"];
 
@@ -38,19 +36,6 @@ const defaultTypo = "bodyLarge";
 const defaultMargin = "0px";
 const defaultPadding = "0px";
 
-const isValidCssSpacing = (element) => {
-  let result = false;
-  const splitElement = element.split(" ");
-
-  if (element !== "" && splitElement.length > 0) {
-    const validatedElement = splitElement
-      .filter((spacing) => spacing !== "")
-      .every((i) => regex.test(i));
-    result = validatedElement === true && splitElement.length <= 4;
-  }
-  return result;
-};
-
 const Text = (props) => {
   const {
     children,
@@ -74,12 +59,12 @@ const Text = (props) => {
   const transformedTypo = typosOptions.includes(typo) ? typo : defaultTypo;
 
   const transformedMargin =
-    isValidCssSpacing(margin) || globalValuesPropertiesCss.includes(margin)
+    validateCssSpacing(margin) || globalValuesPropertiesCss.includes(margin)
       ? margin
       : defaultMargin;
 
   const transformedPadding =
-    isValidCssSpacing(padding) || globalValuesPropertiesCss.includes(padding)
+    validateCssSpacing(padding) || globalValuesPropertiesCss.includes(padding)
       ? padding
       : defaultPadding;
 

--- a/src/components/inputs/TextField/index.jsx
+++ b/src/components/inputs/TextField/index.jsx
@@ -36,6 +36,7 @@ const TextField = (props) => {
     isFullWidth = false,
     handleFocus,
     handleBlur,
+    readOnly,
   } = props;
 
   const [isFocused, setIsFocused] = useState(false);
@@ -67,6 +68,8 @@ const TextField = (props) => {
   const transformedIsFullWidth =
     typeof isFullWidth === "boolean" ? isFullWidth : defaultIsFullWidth;
 
+  const transformedReadOnly = typeof readOnly === "boolean" ? readOnly : false;
+
   return (
     <TextFieldUI
       label={label}
@@ -92,6 +95,7 @@ const TextField = (props) => {
       isFocused={isFocused}
       handleFocus={interceptFocus}
       handleBlur={interceptBlur}
+      readOnly={transformedReadOnly}
     />
   );
 };
@@ -119,6 +123,7 @@ TextFieldUI.propTypes = {
   isFullWidth: PropTypes.bool,
   handleFocus: PropTypes.func,
   handleBlur: PropTypes.func,
+  readOnly: PropTypes.bool,
 };
 
 export { TextField, inputTypes, sizes, states };

--- a/src/components/inputs/TextField/index.jsx
+++ b/src/components/inputs/TextField/index.jsx
@@ -42,7 +42,9 @@ const TextField = (props) => {
   const [isFocused, setIsFocused] = useState(false);
 
   const interceptFocus = (e) => {
-    setIsFocused(true);
+    if (!readOnly) {
+      setIsFocused(true);
+    }
     if (typeof handleFocus === "function") {
       handleFocus(e);
     }

--- a/src/components/inputs/TextField/interface.jsx
+++ b/src/components/inputs/TextField/interface.jsx
@@ -90,6 +90,7 @@ const TextFieldUI = (props) => {
     isFocused,
     handleFocus,
     handleBlur,
+    readOnly,
   } = props;
 
   const transformedIsInvalid = state === "invalid" ? true : false;
@@ -152,6 +153,7 @@ const TextFieldUI = (props) => {
           onChange={handleChange}
           onFocus={handleFocus}
           onBlur={handleBlur}
+          readOnly={readOnly}
         />
 
         {iconAfter && (

--- a/src/components/inputs/TextField/stories/TextField.Default.stories.jsx
+++ b/src/components/inputs/TextField/stories/TextField.Default.stories.jsx
@@ -18,6 +18,7 @@ import {
   max,
   min,
   size,
+  readOnly,
 } from "./props";
 
 const story = {
@@ -40,6 +41,7 @@ Default.args = {
   errorMessage: "Please enter only letters in this field",
   validMessage: "The field has been successfully validated",
   size: "wide",
+  readOnly: false,
 };
 
 Default.argTypes = {
@@ -56,6 +58,7 @@ Default.argTypes = {
   max,
   min,
   size,
+  readOnly,
 };
 
 export default story;

--- a/src/components/inputs/TextField/stories/TextField.Sizes.stories.jsx
+++ b/src/components/inputs/TextField/stories/TextField.Sizes.stories.jsx
@@ -26,6 +26,7 @@ import {
   errorMessage,
   validMessage,
   isFullWidth,
+  readOnly,
 } from "./props";
 
 const story = {
@@ -59,6 +60,7 @@ Size.args = {
   validMessage: "The field has been successfully validated",
   isFullWidth: false,
   isRequired: false,
+  readOnly: false,
 };
 
 Size.argTypes = {
@@ -81,6 +83,7 @@ Size.argTypes = {
   errorMessage,
   validMessage,
   isFullWidth,
+  readOnly,
 };
 
 export default story;

--- a/src/components/inputs/TextField/stories/props.js
+++ b/src/components/inputs/TextField/stories/props.js
@@ -119,6 +119,13 @@ const isFullWidth = {
   },
 };
 
+const readOnly = {
+  descriptions: "option to make the field read only",
+  table: {
+    defaultValue: { summary: false },
+  },
+};
+
 export {
   parameters,
   label,
@@ -141,4 +148,5 @@ export {
   validMessage,
   size,
   isFullWidth,
+  readOnly,
 };

--- a/src/utils/validateCssSpacing.js
+++ b/src/utils/validateCssSpacing.js
@@ -1,0 +1,16 @@
+/**it is validated that the values entered are in pixels and valid according to the css property margin and padding. */
+const regex = /^[0-9]+px$/;
+
+const validateCssSpacing = (element) => {
+  const splitElement = element.split(" ");
+  if (
+    splitElement === "" ||
+    splitElement.length === 0 ||
+    splitElement.length > 4
+  ) {
+    return false;
+  }
+  return splitElement.every((item) => regex.test(item));
+};
+
+export { validateCssSpacing };


### PR DESCRIPTION
This Pull Request addresses the current problem in the `<TextField />` component by implementing a solution that allows the addition of a new property called `readOnly`. With this new property, the read-only behaviour of the `<TextField />` can be controlled, providing the ability to enable or disable editing of the input field as needed.