### PR TITLE
Fix the font-weight property in `<TextField />` styles

### DIFF
--- a/src/components/inputs/TextField/styles.js
+++ b/src/components/inputs/TextField/styles.js
@@ -110,7 +110,7 @@ const StyledInput = styled.input`
   border-radius: 8px;
   font-family: ${typography.sys.typescale.bodyLarge.font};
   font-size: ${typography.sys.typescale.bodyLarge.size};
-  font-weight: ${typography.ref.typeface.weight.regular};
+  font-weight: ${typography.sys.typescale.bodyLarge.weight};
   line-height: ${typography.sys.typescale.bodyLarge.lineHeight};
   letter-spacing: ${typography.sys.typescale.bodyLarge.letterSpacing};
   color: ${({ isDisabled }) =>

--- a/src/components/inputs/TextField/styles.js
+++ b/src/components/inputs/TextField/styles.js
@@ -110,7 +110,7 @@ const StyledInput = styled.input`
   border-radius: 8px;
   font-family: ${typography.sys.typescale.bodyLarge.font};
   font-size: ${typography.sys.typescale.bodyLarge.size};
-  font-weight: ${typography.sys.typescale.bodyLarge.weight};
+  font-weight: ${typography.sys.typescale.bodyLarge.weight.regular};
   line-height: ${typography.sys.typescale.bodyLarge.lineHeight};
   letter-spacing: ${typography.sys.typescale.bodyLarge.letterSpacing};
   color: ${({ isDisabled }) =>

--- a/src/components/inputs/TextField/styles.js
+++ b/src/components/inputs/TextField/styles.js
@@ -110,7 +110,7 @@ const StyledInput = styled.input`
   border-radius: 8px;
   font-family: ${typography.sys.typescale.bodyLarge.font};
   font-size: ${typography.sys.typescale.bodyLarge.size};
-  font-weight: ${typography.sys.typescale.bodyLarge.weight.regular};
+  font-weight: ${typography.ref.typeface.weight.regular};
   line-height: ${typography.sys.typescale.bodyLarge.lineHeight};
   letter-spacing: ${typography.sys.typescale.bodyLarge.letterSpacing};
   color: ${({ isDisabled }) =>

--- a/src/shared/typography/typography.js
+++ b/src/shared/typography/typography.js
@@ -99,7 +99,7 @@ const sys = {
       lineHeight: "24px",
       size: "16px",
       tracking: "0.5px",
-      weight: ref.typeface.weight.medium,
+      weight: ref.typeface.weight.regular,
     },
     bodyMedium: {
       font: ref.typeface.brand,


### PR DESCRIPTION
This proposed pull request is intended to address the discrepancy in the 'font-weight' attribute. Presently, the value is set at 500, which is inconsistent with the design mockups. According to the latter, the 'font-weight' should be set to 400. The successful execution of this pull request will ensure conformity with the design specifications.