### PR TITLE
Fix the menu positioning when the `<ellipsisBreadCrumb/>` is clicked

### DIFF
--- a/src/components/navigation/BreadcrumbEllipsis/index.jsx
+++ b/src/components/navigation/BreadcrumbEllipsis/index.jsx
@@ -2,7 +2,11 @@ import React, { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import { Label } from "../../inputs/Label";
 import { BreadcrumbMenu } from "../../navigation/BreadcrumbMenu";
-import { StyledContainerEllipsis, StyledBreadcrumbEllipsis } from "./styles";
+import {
+  StyledContainerEllipsis,
+  StyledBreadcrumbEllipsis,
+  StyledRelativeContainer,
+} from "./styles";
 
 const typos = ["labelLarge", "labelSmall"];
 const defaultTypo = "labelLarge";
@@ -34,7 +38,7 @@ const BreadcrumbEllipsis = (props) => {
   };
 
   return (
-    <>
+    <StyledRelativeContainer>
       <StyledContainerEllipsis>
         <Label
           htmlFor="ellipsis"
@@ -49,7 +53,7 @@ const BreadcrumbEllipsis = (props) => {
         </Label>
       </StyledContainerEllipsis>
       {showMenu && <BreadcrumbMenu routes={routes} />}
-    </>
+    </StyledRelativeContainer>
   );
 };
 

--- a/src/components/navigation/BreadcrumbEllipsis/styles.js
+++ b/src/components/navigation/BreadcrumbEllipsis/styles.js
@@ -6,6 +6,7 @@ const StyledContainerEllipsis = styled.li`
 `;
 
 const StyledBreadcrumbEllipsis = styled.div`
+  user-select: none;
   text-decoration: none;
   color: ${colors.sys.text.secondary};
   &:hover {
@@ -15,4 +16,13 @@ const StyledBreadcrumbEllipsis = styled.div`
   }
 `;
 
-export { StyledContainerEllipsis, StyledBreadcrumbEllipsis };
+const StyledRelativeContainer = styled.div`
+  position: relative;
+  display: inline-block;
+`;
+
+export {
+  StyledContainerEllipsis,
+  StyledBreadcrumbEllipsis,
+  StyledRelativeContainer,
+};

--- a/src/components/navigation/BreadcrumbMenu/styles.js
+++ b/src/components/navigation/BreadcrumbMenu/styles.js
@@ -3,6 +3,7 @@ import { colors } from "../../../shared/colors/colors";
 
 const StyledBreadcrumbMenu = styled.div`
   position: absolute;
+  width: fit-content;
   max-width: 160px;
   min-width: 100px;
   box-shadow: 0px 2px 4px ${colors.ref.palette.neutralAlpha.n50A};

--- a/src/components/navigation/BreadcrumbMenu/styles.js
+++ b/src/components/navigation/BreadcrumbMenu/styles.js
@@ -5,6 +5,7 @@ const StyledBreadcrumbMenu = styled.div`
   position: absolute;
   max-width: 160px;
   box-shadow: 0px 2px 4px ${colors.ref.palette.neutralAlpha.n50A};
+  background-color: ${colors.ref.palette.neutral.n0};
   border-radius: 4px;
 `;
 

--- a/src/components/navigation/BreadcrumbMenu/styles.js
+++ b/src/components/navigation/BreadcrumbMenu/styles.js
@@ -4,6 +4,7 @@ import { colors } from "../../../shared/colors/colors";
 const StyledBreadcrumbMenu = styled.div`
   position: absolute;
   max-width: 160px;
+  min-width: 100px;
   box-shadow: 0px 2px 4px ${colors.ref.palette.neutralAlpha.n50A};
   background-color: ${colors.ref.palette.neutral.n0};
   border-radius: 4px;

--- a/src/components/navigation/Breadcrumbs/styles.js
+++ b/src/components/navigation/Breadcrumbs/styles.js
@@ -3,16 +3,14 @@ import styled from "styled-components";
 const StyledBreadcrumbs = styled.ul`
   padding: 0;
   margin: 0;
-  & > li:not(:last-child)::after {
+  & > li:not(:last-child)::after,
+  & > div:not(:last-child)::after {
     pointer-events: none;
     content: "/";
     margin: 0 8px;
   }
   & li > label {
     display: inherit;
-  }
-  & > div {
-    left: 7rem;
   }
 `;
 


### PR DESCRIPTION
We have restructured the ellipsis and adjusted its relationship with breadCrumbMenu to ensure persistent correct alignment. Furthermore, we've modified the styles of breadCrumbMenu to establish its consistent positioning above other elements.
![image](https://github.com/selsa-inube/design-system/assets/45011420/32963f69-2fa5-4ee6-8245-dae0d0960424)
