### PR TITLE
Fix `<breadCrumb/>` redirection in mobile devices

### DIFF
--- a/src/components/navigation/BreadcrumbEllipsis/index.jsx
+++ b/src/components/navigation/BreadcrumbEllipsis/index.jsx
@@ -18,9 +18,13 @@ const BreadcrumbEllipsis = (props) => {
   const transformedTypos = typos.includes(typo) ? typo : defaultTypo;
 
   const containerRef = useRef(null);
-
+  const menuRef = useRef(null);
   const handleClickOutside = (event) => {
-    if (containerRef.current && !containerRef.current.contains(event.target)) {
+    if (
+      containerRef.current &&
+      !containerRef.current.contains(event.target) &&
+      (!menuRef.current || !menuRef.current.contains(event.target))
+    ) {
       setShowMenu(false);
     }
   };
@@ -52,13 +56,19 @@ const BreadcrumbEllipsis = (props) => {
           </StyledBreadcrumbEllipsis>
         </Label>
       </StyledContainerEllipsis>
-      {showMenu && <BreadcrumbMenu routes={routes} />}
+      {showMenu && (
+        <BreadcrumbMenu
+          ref={menuRef}
+          routes={routes}
+          onOptionClick={handleEllipsisClick}
+        />
+      )}
     </StyledRelativeContainer>
   );
 };
 
 BreadcrumbEllipsis.propTypes = {
-  typo: PropTypes.oneOf(["labelLarge", "labelSmall"]),
+  typo: PropTypes.oneOf(typos),
   routes: PropTypes.array.isRequired,
 };
 

--- a/src/components/navigation/BreadcrumbEllipsis/index.jsx
+++ b/src/components/navigation/BreadcrumbEllipsis/index.jsx
@@ -60,7 +60,7 @@ const BreadcrumbEllipsis = (props) => {
         <BreadcrumbMenu
           ref={menuRef}
           routes={routes}
-          onOptionClick={handleEllipsisClick}
+          handleClick={handleEllipsisClick}
         />
       )}
     </StyledRelativeContainer>

--- a/src/components/navigation/BreadcrumbEllipsis/index.jsx
+++ b/src/components/navigation/BreadcrumbEllipsis/index.jsx
@@ -18,51 +18,36 @@ const BreadcrumbEllipsis = (props) => {
   const transformedTypos = typos.includes(typo) ? typo : defaultTypo;
 
   const containerRef = useRef(null);
-  const menuRef = useRef(null);
-  const handleClickOutside = (event) => {
-    if (
-      containerRef.current &&
-      !containerRef.current.contains(event.target) &&
-      (!menuRef.current || !menuRef.current.contains(event.target))
-    ) {
+
+  const closeEllipsisMenu = (event) => {
+    if (!containerRef.current.contains(event.target)) {
       setShowMenu(false);
     }
   };
 
   useEffect(() => {
-    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("click", closeEllipsisMenu);
 
     return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("click", closeEllipsisMenu);
     };
   }, [containerRef]);
 
-  const handleEllipsisClick = () => {
+  const toggleEllipsisMenu = () => {
     setShowMenu(!showMenu);
   };
 
   return (
-    <StyledRelativeContainer>
+    <StyledRelativeContainer ref={containerRef} onClick={toggleEllipsisMenu}>
       <StyledContainerEllipsis>
         <Label
           htmlFor="ellipsis"
           typo={typos.includes(typo) ? typo : transformedTypos}
         >
-          <StyledBreadcrumbEllipsis
-            ref={containerRef}
-            onClick={handleEllipsisClick}
-          >
-            ...
-          </StyledBreadcrumbEllipsis>
+          <StyledBreadcrumbEllipsis>...</StyledBreadcrumbEllipsis>
         </Label>
       </StyledContainerEllipsis>
-      {showMenu && (
-        <BreadcrumbMenu
-          ref={menuRef}
-          routes={routes}
-          handleClick={handleEllipsisClick}
-        />
-      )}
+      {showMenu && <BreadcrumbMenu routes={routes} />}
     </StyledRelativeContainer>
   );
 };

--- a/src/components/navigation/BreadcrumbMenu/index.jsx
+++ b/src/components/navigation/BreadcrumbMenu/index.jsx
@@ -4,11 +4,11 @@ import { Stack } from "../../layouts/Stack";
 import { BreadcrumbMenuLink } from "../BreadcrumbMenuLink";
 import { StyledBreadcrumbMenu } from "./styles";
 
-const BreadcrumbMenu = React.forwardRef((props, ref) => {
-  const { routes, handleClick } = props;
+const BreadcrumbMenu = (props) => {
+  const { routes } = props;
 
   return (
-    <StyledBreadcrumbMenu ref={ref}>
+    <StyledBreadcrumbMenu>
       <Stack direction="column" justifyContent="space-between">
         {routes.map((route) => (
           <BreadcrumbMenuLink
@@ -16,13 +16,12 @@ const BreadcrumbMenu = React.forwardRef((props, ref) => {
             id={route.id}
             path={route.path}
             label={route.label}
-            onClick={handleClick}
           />
         ))}
       </Stack>
     </StyledBreadcrumbMenu>
   );
-});
+};
 
 BreadcrumbMenu.propTypes = {
   routes: PropTypes.arrayOf(
@@ -32,7 +31,6 @@ BreadcrumbMenu.propTypes = {
       label: PropTypes.string.isRequired,
     })
   ).isRequired,
-  handleClick: PropTypes.func,
 };
 
 export { BreadcrumbMenu };

--- a/src/components/navigation/BreadcrumbMenu/index.jsx
+++ b/src/components/navigation/BreadcrumbMenu/index.jsx
@@ -5,7 +5,7 @@ import { BreadcrumbMenuLink } from "../BreadcrumbMenuLink";
 import { StyledBreadcrumbMenu } from "./styles";
 
 const BreadcrumbMenu = React.forwardRef((props, ref) => {
-  const { routes, onOptionClick } = props;
+  const { routes, handleClick } = props;
 
   return (
     <StyledBreadcrumbMenu ref={ref}>
@@ -16,7 +16,7 @@ const BreadcrumbMenu = React.forwardRef((props, ref) => {
             id={route.id}
             path={route.path}
             label={route.label}
-            onClick={onOptionClick}
+            onClick={handleClick}
           />
         ))}
       </Stack>
@@ -32,6 +32,7 @@ BreadcrumbMenu.propTypes = {
       label: PropTypes.string.isRequired,
     })
   ).isRequired,
+  handleClick: PropTypes.func,
 };
 
 export { BreadcrumbMenu };

--- a/src/components/navigation/BreadcrumbMenu/index.jsx
+++ b/src/components/navigation/BreadcrumbMenu/index.jsx
@@ -4,11 +4,11 @@ import { Stack } from "../../layouts/Stack";
 import { BreadcrumbMenuLink } from "../BreadcrumbMenuLink";
 import { StyledBreadcrumbMenu } from "./styles";
 
-const BreadcrumbMenu = (props) => {
-  const { routes } = props;
+const BreadcrumbMenu = React.forwardRef((props, ref) => {
+  const { routes, onOptionClick } = props;
 
   return (
-    <StyledBreadcrumbMenu>
+    <StyledBreadcrumbMenu ref={ref}>
       <Stack direction="column" justifyContent="space-between">
         {routes.map((route) => (
           <BreadcrumbMenuLink
@@ -16,12 +16,13 @@ const BreadcrumbMenu = (props) => {
             id={route.id}
             path={route.path}
             label={route.label}
+            onClick={onOptionClick}
           />
         ))}
       </Stack>
     </StyledBreadcrumbMenu>
   );
-};
+});
 
 BreadcrumbMenu.propTypes = {
   routes: PropTypes.arrayOf(

--- a/src/components/navigation/BreadcrumbMenu/styles.js
+++ b/src/components/navigation/BreadcrumbMenu/styles.js
@@ -9,6 +9,12 @@ const StyledBreadcrumbMenu = styled.div`
   box-shadow: 0px 2px 4px ${colors.ref.palette.neutralAlpha.n50A};
   background-color: ${colors.ref.palette.neutral.n0};
   border-radius: 4px;
+  a {
+    &:hover {
+      cursor: pointer;
+      background-color: ${colors.ref.palette.neutral.n30};
+    }
+  }
 `;
 
 export { StyledBreadcrumbMenu };

--- a/src/components/navigation/BreadcrumbMenuLink/index.jsx
+++ b/src/components/navigation/BreadcrumbMenuLink/index.jsx
@@ -10,11 +10,11 @@ const typos = ["labelLarge", "labelMedium", "labelSmall"];
 const defaultTypo = "labelLarge";
 
 const BreadcrumbMenuLink = (props) => {
-  const { label, path, id, typo = defaultTypo, onClick } = props;
+  const { label, path, id, typo = defaultTypo } = props;
   const transformedTypos = typos.includes(typo) ? typo : defaultTypo;
 
   return (
-    <StyledBreadcrumbMenuLink to={path} onClick={onClick}>
+    <StyledBreadcrumbMenuLink to={path}>
       <StyledContainerLink id={id}>
         <Stack alignItems="center">
           <Label htmlFor={id} typo={transformedTypos}>

--- a/src/components/navigation/BreadcrumbMenuLink/index.jsx
+++ b/src/components/navigation/BreadcrumbMenuLink/index.jsx
@@ -10,18 +10,19 @@ const typos = ["labelLarge", "labelMedium", "labelSmall"];
 const defaultTypo = "labelLarge";
 
 const BreadcrumbMenuLink = (props) => {
-  const { label, path, id, typo = defaultTypo } = props;
-
+  const { label, path, id, typo = defaultTypo, onClick } = props;
   const transformedTypos = typos.includes(typo) ? typo : defaultTypo;
 
   return (
-    <StyledContainerLink id={id}>
-      <Stack alignItems="center">
-        <Label htmlFor={id} typo={transformedTypos}>
-          <StyledBreadcrumbMenuLink to={path}>{label}</StyledBreadcrumbMenuLink>
-        </Label>
-      </Stack>
-    </StyledContainerLink>
+    <StyledBreadcrumbMenuLink to={path} onClick={onClick}>
+      <StyledContainerLink id={id}>
+        <Stack alignItems="center">
+          <Label htmlFor={id} typo={transformedTypos}>
+            {label}
+          </Label>
+        </Stack>
+      </StyledContainerLink>
+    </StyledBreadcrumbMenuLink>
   );
 };
 

--- a/src/components/navigation/BreadcrumbMenuLink/styles.js
+++ b/src/components/navigation/BreadcrumbMenuLink/styles.js
@@ -7,13 +7,10 @@ const StyledContainerLink = styled.li`
   > * {
     height: 32px;
     > label {
+      color: ${colors.sys.text.secondary};
       cursor: pointer;
       padding: 8px 12px 8px 12px;
     }
-  }
-  &:hover {
-    cursor: pointer;
-    background-color: ${colors.ref.palette.neutral.n30};
   }
 `;
 


### PR DESCRIPTION
In this PR, we have implemented the requisite code modifications to enable the 'breadCrumbEllipsis' functionality. This modification now allows for the 'BreadcrumbMenu' to close, while concurrently facilitating navigation towards the anticipated route.

![image](https://github.com/selsa-inube/design-system/assets/45011420/06a40de6-5d52-4ed3-96b0-6dc454340794)
![image](https://github.com/selsa-inube/design-system/assets/45011420/fb94d47a-92ab-4d15-8a78-16c872463404)
![image](https://github.com/selsa-inube/design-system/assets/45011420/8cc9b947-d3ce-4489-a507-e9974ceed588)
![image](https://github.com/selsa-inube/design-system/assets/45011420/af53b292-e628-4ceb-8ab8-a6dfa8ee7dce)
