### PR TITLE
Fix `<Tabs/>` in order to add a `padding-right`

### DIFF
--- a/src/components/navigation/Tab/styles.js
+++ b/src/components/navigation/Tab/styles.js
@@ -5,7 +5,6 @@ const StyledTab = styled.li`
   width: fit-content;
   user-select: none;
   list-style-type: none;
-  padding: 0px 16px;
   border-bottom: ${({ isSelected, isDisabled }) =>
     isSelected &&
     !isDisabled &&

--- a/src/components/navigation/Tab/styles.js
+++ b/src/components/navigation/Tab/styles.js
@@ -5,7 +5,7 @@ const StyledTab = styled.li`
   width: fit-content;
   user-select: none;
   list-style-type: none;
-
+  padding: 0px 16px;
   border-bottom: ${({ isSelected, isDisabled }) =>
     isSelected &&
     !isDisabled &&

--- a/src/components/navigation/Tabs/styles.js
+++ b/src/components/navigation/Tabs/styles.js
@@ -8,6 +8,10 @@ const StyledTabs = styled.div`
   width: 100%;
   border-bottom: 2px solid ${colors.ref.palette.neutral.n40};
   padding: 0px 16px;
+
+  > div:last-child > *:last-child {
+    padding-right: 16px;
+  }
 `;
 
 export { StyledTabs };

--- a/src/components/navigation/Tabs/styles.js
+++ b/src/components/navigation/Tabs/styles.js
@@ -7,6 +7,7 @@ const StyledTabs = styled.div`
   white-space: nowrap;
   width: 100%;
   border-bottom: 2px solid ${colors.ref.palette.neutral.n40};
+  padding: 0px 16px;
 
   & > div {
     width: fit-content;

--- a/src/components/navigation/Tabs/styles.js
+++ b/src/components/navigation/Tabs/styles.js
@@ -8,8 +8,8 @@ const StyledTabs = styled.div`
   width: 100%;
   border-bottom: 2px solid ${colors.ref.palette.neutral.n40};
 
-  & > div > li:last-child {
-    padding-right: 16px;
+  & > div {
+    width: fit-content;
   }
 `;
 

--- a/src/components/navigation/Tabs/styles.js
+++ b/src/components/navigation/Tabs/styles.js
@@ -7,6 +7,10 @@ const StyledTabs = styled.div`
   white-space: nowrap;
   width: 100%;
   border-bottom: 2px solid ${colors.ref.palette.neutral.n40};
+
+  & > div > li:last-child {
+    padding-right: 16px;
+  }
 `;
 
 export { StyledTabs };

--- a/src/components/navigation/Tabs/styles.js
+++ b/src/components/navigation/Tabs/styles.js
@@ -7,11 +7,6 @@ const StyledTabs = styled.div`
   white-space: nowrap;
   width: 100%;
   border-bottom: 2px solid ${colors.ref.palette.neutral.n40};
-  padding: 0px 16px;
-
-  > div:last-child > *:last-child {
-    padding-right: 16px;
-  }
 `;
 
 export { StyledTabs };


### PR DESCRIPTION
An issue related to the `<Tabs /> ` component has been addressed. In the current implementation, when passing a list of tabs to the component, the first `<Tab /> ` has padding on the left, which is correct. However, when the screen is tablet or mobile sized, the last `<Tab />` is displayed close to the right edge of the tab container, which is undesirable. The aim of this PR is to solve this problem by ensuring that the last tab also has proper padding on the right.