### PR TITLE
Search `<Label />` with htmlFor when no `<input />`

### DIFF
--- a/src/components/navigation/BreadcrumbEllipsis/index.jsx
+++ b/src/components/navigation/BreadcrumbEllipsis/index.jsx
@@ -2,8 +2,6 @@ import React, { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 
 import { BreadcrumbMenu } from "../../navigation/BreadcrumbMenu";
-import { Label } from "../../inputs/Label";
-
 import { Text } from "../../data/Text/index";
 
 import {

--- a/src/components/navigation/BreadcrumbEllipsis/index.jsx
+++ b/src/components/navigation/BreadcrumbEllipsis/index.jsx
@@ -1,7 +1,11 @@
 import React, { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
-import { Label } from "../../inputs/Label";
+
 import { BreadcrumbMenu } from "../../navigation/BreadcrumbMenu";
+import { Label } from "../../inputs/Label";
+
+import { Text } from "../../data/Text/index";
+
 import {
   StyledContainerEllipsis,
   StyledBreadcrumbEllipsis,
@@ -40,12 +44,9 @@ const BreadcrumbEllipsis = (props) => {
   return (
     <StyledRelativeContainer ref={containerRef} onClick={toggleEllipsisMenu}>
       <StyledContainerEllipsis>
-        <Label
-          htmlFor="ellipsis"
-          typo={typos.includes(typo) ? typo : transformedTypos}
-        >
+        <Text typo={typos.includes(typo) ? typo : transformedTypos}>
           <StyledBreadcrumbEllipsis>...</StyledBreadcrumbEllipsis>
-        </Label>
+        </Text>
       </StyledContainerEllipsis>
       {showMenu && <BreadcrumbMenu routes={routes} />}
     </StyledRelativeContainer>

--- a/src/components/navigation/BreadcrumbEllipsis/styles.js
+++ b/src/components/navigation/BreadcrumbEllipsis/styles.js
@@ -5,7 +5,7 @@ const StyledContainerEllipsis = styled.li`
   display: inline-block;
 `;
 
-const StyledBreadcrumbEllipsis = styled.div`
+const StyledBreadcrumbEllipsis = styled.span`
   user-select: none;
   text-decoration: none;
   color: ${colors.sys.text.secondary};

--- a/src/components/navigation/BreadcrumbLink/index.jsx
+++ b/src/components/navigation/BreadcrumbLink/index.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { Label } from "../../inputs/Label";
+import { Text } from "../../data/Text";
 
 import { StyledContainerLink, StyledBreadcrumbLink } from "./styles";
 
@@ -25,11 +25,11 @@ const BreadcrumbLink = (props) => {
 
   return (
     <StyledContainerLink id={id} onClick={handleClick}>
-      <Label htmlFor={id} typo={transformedTypos}>
+      <Text typo={transformedTypos} appearance="secondary">
         <StyledBreadcrumbLink to={path} data-is-active={transformedIsActive}>
           {label}
         </StyledBreadcrumbLink>
-      </Label>
+      </Text>
     </StyledContainerLink>
   );
 };

--- a/src/components/navigation/BreadcrumbMenu/styles.js
+++ b/src/components/navigation/BreadcrumbMenu/styles.js
@@ -3,7 +3,7 @@ import { colors } from "../../../shared/colors/colors";
 
 const StyledBreadcrumbMenu = styled.div`
   position: absolute;
-  width: fit-content;
+  width: max-content;
   max-width: 160px;
   min-width: 100px;
   box-shadow: 0px 2px 4px ${colors.ref.palette.neutralAlpha.n50A};

--- a/src/components/navigation/BreadcrumbMenu/styles.js
+++ b/src/components/navigation/BreadcrumbMenu/styles.js
@@ -3,7 +3,7 @@ import { colors } from "../../../shared/colors/colors";
 
 const StyledBreadcrumbMenu = styled.div`
   position: absolute;
-  width: max-content;
+  width: fit-content;
   max-width: 160px;
   min-width: 100px;
   box-shadow: 0px 2px 4px ${colors.ref.palette.neutralAlpha.n50A};

--- a/src/components/navigation/BreadcrumbMenuLink/index.jsx
+++ b/src/components/navigation/BreadcrumbMenuLink/index.jsx
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { Label } from "../../inputs/Label";
 import { Stack } from "../../layouts/Stack";
+import { Text } from "../../data/Text";
 
 import { StyledContainerLink, StyledBreadcrumbMenuLink } from "./styles";
 
@@ -17,9 +17,13 @@ const BreadcrumbMenuLink = (props) => {
     <StyledBreadcrumbMenuLink to={path}>
       <StyledContainerLink id={id}>
         <Stack alignItems="center">
-          <Label htmlFor={id} typo={transformedTypos}>
+          <Text
+            typo={transformedTypos}
+            appearance="secondary"
+            padding="8px 12px"
+          >
             {label}
-          </Label>
+          </Text>
         </Stack>
       </StyledContainerLink>
     </StyledBreadcrumbMenuLink>

--- a/src/components/navigation/Breadcrumbs/index.jsx
+++ b/src/components/navigation/Breadcrumbs/index.jsx
@@ -1,11 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { StyledBreadcrumbs } from "./styles";
-
 import { BreadcrumbLink } from "../../navigation/BreadcrumbLink";
-import { useMediaQuery } from "../../../hooks/useMediaQuery";
 import { BreadcrumbEllipsis, typos } from "../../navigation/BreadcrumbEllipsis";
+
+import { useMediaQuery } from "../../../hooks/useMediaQuery";
+
+import { StyledBreadcrumbs } from "./styles";
 
 function getBreadcrumbItems(crumbs) {
   const breadcrumbItems = [

--- a/src/components/navigation/Breadcrumbs/styles.js
+++ b/src/components/navigation/Breadcrumbs/styles.js
@@ -9,7 +9,7 @@ const StyledBreadcrumbs = styled.ul`
     content: "/";
     margin: 0 8px;
   }
-  & li > label {
+  & li > p {
     display: inherit;
   }
 `;

--- a/src/components/navigation/Tab/index.jsx
+++ b/src/components/navigation/Tab/index.jsx
@@ -3,6 +3,8 @@ import PropTypes from "prop-types";
 
 import { Label } from "../../inputs/Label";
 
+import { Text } from "../../data/Text";
+
 import { StyledTab } from "./styles";
 
 const Tab = (props) => {
@@ -14,15 +16,25 @@ const Tab = (props) => {
     label,
   } = props;
 
+  const appearance = (isSelected, isDisabled) => {
+    if (isSelected && !isDisabled) {
+      return "primary";
+    }
+    if (isDisabled) {
+      return "disabled";
+    }
+    return "dark";
+  };
+
   return (
     <StyledTab
       onClick={handleClick}
       isDisabled={isDisabled}
       isSelected={isSelected}
     >
-      <Label htmlFor={id} isFocused={isSelected} isDisabled={isDisabled}>
+      <Text id={id} appearance={appearance(isSelected, isDisabled)}>
         {label}
-      </Label>
+      </Text>
     </StyledTab>
   );
 };

--- a/src/components/navigation/Tab/index.jsx
+++ b/src/components/navigation/Tab/index.jsx
@@ -1,8 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { Label } from "../../inputs/Label";
-
 import { Text } from "../../data/Text";
 
 import { StyledTab } from "./styles";

--- a/src/components/navigation/Tab/styles.js
+++ b/src/components/navigation/Tab/styles.js
@@ -10,7 +10,7 @@ const StyledTab = styled.li`
     !isDisabled &&
     `4px solid ${colors.sys.actions.primary.filled}`};
 
-  & > label {
+  & > p {
     cursor: ${({ isDisabled }) => (isDisabled ? "not-allowed" : "pointer")};
   }
 `;


### PR DESCRIPTION
We have a console error about a label component used with the htmlFor prop but with no input with the same id.

If we are using a Label without a relationship with an input, its better to use a Text with its corresponding typo token.