### PR TITLE
Add `margin` and `padding` props to `<Stack />`

### DIFF
--- a/src/components/layouts/Stack/index.jsx
+++ b/src/components/layouts/Stack/index.jsx
@@ -1,5 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
+
+import { validateBoxModelMeasure } from "../../../utilities/validateBoxModelMeasure";
 import { StyledFlex } from "./styles";
 
 export const directionAlignments = ["row", "column"];
@@ -18,6 +20,9 @@ const defaultDirection = "row";
 const defaultJustifyContent = "flex-start";
 const defaultAlignItems = "stretch";
 const defaultWrapControl = "nowrap";
+const defaultGap = "0px";
+const defaultMargin = "0px";
+const defaultPadding = "0px";
 
 const Stack = (props) => {
   const {
@@ -26,7 +31,9 @@ const Stack = (props) => {
     direction = defaultDirection,
     justifyContent = defaultJustifyContent,
     alignItems = defaultAlignItems,
-    gap = "0px",
+    gap,
+    margin,
+    padding,
   } = props;
 
   const transformedDirection = directionAlignments.includes(direction)
@@ -42,13 +49,25 @@ const Stack = (props) => {
     ? wrap
     : defaultWrapControl;
 
+  const transformedMeasure = (valueBoxModel, defaultValue) => {
+    try {
+      validateBoxModelMeasure(valueBoxModel);
+    } catch (error) {
+      console.error(error);
+      return defaultValue;
+    }
+    return valueBoxModel;
+  };
+
   return (
     <StyledFlex
       direction={transformedDirection}
       justifyContent={transformedJustifyContent}
       alignItems={transformedAlignItems}
       wrap={transformedWrap}
-      gap={gap}
+      gap={transformedMeasure(gap, defaultGap)}
+      margin={transformedMeasure(margin, defaultMargin)}
+      padding={transformedMeasure(padding, defaultPadding)}
     >
       {children}
     </StyledFlex>
@@ -66,6 +85,8 @@ Stack.propTypes = {
   justifyContent: PropTypes.oneOf(flexAlignments),
   alignItems: PropTypes.oneOf(flexAlignments),
   gap: PropTypes.string,
+  margin: PropTypes.string,
+  padding: PropTypes.string,
 };
 
 export { Stack };

--- a/src/components/layouts/Stack/stories/Stack.Default.stories.jsx
+++ b/src/components/layouts/Stack/stories/Stack.Default.stories.jsx
@@ -9,6 +9,8 @@ import {
   justifyContent,
   alignItems,
   gap,
+  margin,
+  padding,
 } from "./props";
 
 const story = {
@@ -35,6 +37,8 @@ export const Default = StackTemplate.bind({});
 Default.args = {
   children: [...Array(6 + 1).keys()].slice(1),
   gap: "10px",
+  margin: "0px",
+  padding: "0px",
 };
 Default.argTypes = {
   children,
@@ -43,6 +47,8 @@ Default.argTypes = {
   justifyContent,
   alignItems,
   gap,
+  margin,
+  padding,
 };
 
 export default story;

--- a/src/components/layouts/Stack/stories/props.js
+++ b/src/components/layouts/Stack/stories/props.js
@@ -55,4 +55,32 @@ const gap = {
     defaultValue: { summary: "0px" },
   },
 };
-export { children, wrap, direction, justifyContent, alignItems, gap };
+
+const margin = {
+  type: { name: "string", required: false },
+  description:
+    "Sets the margin in px or global values for all four sides of the component",
+  table: {
+    defaultValue: { summary: "0px" },
+  },
+};
+
+const padding = {
+  type: { name: "string", required: false },
+  description:
+    "Sets the padding in px p global values for all four sides of the component",
+  table: {
+    defaultValue: { summary: "0px" },
+  },
+};
+
+export {
+  children,
+  wrap,
+  direction,
+  justifyContent,
+  alignItems,
+  gap,
+  margin,
+  padding,
+};

--- a/src/components/layouts/Stack/styles.js
+++ b/src/components/layouts/Stack/styles.js
@@ -7,6 +7,8 @@ const StyledFlex = styled.div`
   flex-direction: ${({ direction }) => direction};
   flex-wrap: ${({ wrap }) => wrap};
   gap: ${({ gap }) => gap};
+  margin: ${({ margin }) => margin};
+  padding: ${({ padding }) => padding};
 `;
 
 export { StyledFlex };


### PR DESCRIPTION
The accessories that `<Stack />` exposes are extended to allow implementers to define margins and padding.