### PR TITLE
Adjust the `<Switch/>` to eliminate unnecessary space between elements when a label is not present

### DIFF
--- a/src/components/inputs/Switch/index.jsx
+++ b/src/components/inputs/Switch/index.jsx
@@ -23,11 +23,14 @@ const Switch = (props) => {
   } = props;
 
   const transformedSize = sizes.includes(size) ? size : defaultSize;
-  const tranformedGap = label ? "10px" : "0px";
+  const tranformedGap = label.trim().length === 0 ? "10px" : "0px";
+  const transformedAlignment =
+    label.trim().length === 0 ? "space-between" : "center";
+
   return (
     <Stack
       direction={"row"}
-      justifyContent="space-between"
+      justifyContent={transformedAlignment}
       alignItems="center"
       gap={tranformedGap}
     >

--- a/src/components/inputs/Switch/index.jsx
+++ b/src/components/inputs/Switch/index.jsx
@@ -23,9 +23,8 @@ const Switch = (props) => {
   } = props;
 
   const transformedSize = sizes.includes(size) ? size : defaultSize;
-  const tranformedGap = label.trim().length === 0 ? "10px" : "0px";
-  const transformedAlignment =
-    label.trim().length === 0 ? "space-between" : "center";
+  const tranformedGap = label ? "10px" : "0px";
+  const transformedAlignment = label ? "space-between" : "center";
 
   return (
     <Stack

--- a/src/components/inputs/Switch/index.jsx
+++ b/src/components/inputs/Switch/index.jsx
@@ -23,13 +23,13 @@ const Switch = (props) => {
   } = props;
 
   const transformedSize = sizes.includes(size) ? size : defaultSize;
-
+  const tranformedGap = label ? "10px" : "0px";
   return (
     <Stack
       direction={"row"}
       justifyContent="space-between"
       alignItems="center"
-      gap="10px"
+      gap={tranformedGap}
     >
       <StyledContainer size={transformedSize}>
         <StyledInput
@@ -54,9 +54,11 @@ const Switch = (props) => {
           )}
         </StyledSpan>
       </StyledContainer>
-      <Label htmlFor={id} isDisabled={isDisabled} onClick={handleChange}>
-        {label}
-      </Label>
+      {label && (
+        <Label htmlFor={id} isDisabled={isDisabled} onClick={handleChange}>
+          {label}
+        </Label>
+      )}
     </Stack>
   );
 };

--- a/src/components/inputs/Switch/index.jsx
+++ b/src/components/inputs/Switch/index.jsx
@@ -24,12 +24,12 @@ const Switch = (props) => {
 
   const transformedSize = sizes.includes(size) ? size : defaultSize;
   const tranformedGap = label ? "10px" : "0px";
-  const transformedAlignment = label ? "space-between" : "center";
+  const transformedJustify = label ? "space-between" : "center";
 
   return (
     <Stack
       direction={"row"}
-      justifyContent={transformedAlignment}
+      justifyContent={transformedJustify}
       alignItems="center"
       gap={tranformedGap}
     >


### PR DESCRIPTION
In the present pull request, we have fine-tuned the spacing for the <Switch/> component, specifically for those scenarios when it is used in conjunction with the 'label' property. This adjustment will enhance its adaptability to centralize as a standalone element, even when there is no requirement for a 'label' accompanying the switch.

![Screenshot from 2023-06-01 12-32-04](https://github.com/selsa-inube/design-system/assets/45011420/86061367-b65a-4d51-8b62-96af62382e33)

