### PR TITLE
Add 'button' type and prevent redirection in `<Button />`

### DIFF
--- a/src/components/inputs/Button/index.jsx
+++ b/src/components/inputs/Button/index.jsx
@@ -40,11 +40,11 @@ const getSpinnerColor = (variant, appearance) => {
   return spinnerColorHomologation[variant][appearance];
 };
 
-export const types = ["text", "submit", "reset", "link"];
+export const types = ["button", "submit", "reset", "link"];
 export const spacings = ["wide", "compact"];
 export const variants = ["filled", "outlined", "none"];
 const defaultAppearance = "primary";
-const defaultType = "text";
+const defaultType = "button";
 const defaultSpacing = "wide";
 const defaultVariant = "filled";
 const defaultSpinnerSize = "small";

--- a/src/components/inputs/Button/stories/Button.Appearances.stories.jsx
+++ b/src/components/inputs/Button/stories/Button.Appearances.stories.jsx
@@ -50,7 +50,7 @@ Appearances.args = {
   isLoading: false,
   isDisabled: false,
   iconBefore: <MdAdd />,
-  type: "text",
+  type: "button",
   spacing: "wide",
   variant: "filled",
   isFullWidth: false,

--- a/src/components/inputs/Button/stories/Button.Disabled.stories.jsx
+++ b/src/components/inputs/Button/stories/Button.Disabled.stories.jsx
@@ -50,7 +50,7 @@ Disabled.args = {
   children: "Button",
   isLoading: false,
   iconBefore: <MdAdd />,
-  type: "text",
+  type: "button",
   spacing: "wide",
   variant: "filled",
   isFullWidth: false,

--- a/src/components/inputs/Button/stories/Button.FullWidth.stories.jsx
+++ b/src/components/inputs/Button/stories/Button.FullWidth.stories.jsx
@@ -48,7 +48,7 @@ FullWidth.args = {
   isLoading: false,
   isDisabled: false,
   iconBefore: <MdAdd />,
-  type: "text",
+  type: "button",
   spacing: "wide",
   variant: "filled",
   handleClick: () => console.log("clicked"),

--- a/src/components/inputs/Button/stories/Button.Icons.stories.jsx
+++ b/src/components/inputs/Button/stories/Button.Icons.stories.jsx
@@ -53,7 +53,7 @@ Icons.args = {
   appearance: "primary",
   isLoading: false,
   isDisabled: false,
-  type: "text",
+  type: "button",
   spacing: "wide",
   variant: "filled",
   isFullWidth: false,

--- a/src/components/inputs/Button/stories/Button.Loading.stories.jsx
+++ b/src/components/inputs/Button/stories/Button.Loading.stories.jsx
@@ -45,7 +45,7 @@ Loading.args = {
   children: "Button",
   appearance: "primary",
   isDisabled: false,
-  type: "text",
+  type: "button",
   spacing: "wide",
   variant: "filled",
   isFullWidth: false,

--- a/src/components/inputs/Button/stories/Button.Spacing.stories.jsx
+++ b/src/components/inputs/Button/stories/Button.Spacing.stories.jsx
@@ -52,7 +52,7 @@ Spacing.args = {
   isLoading: false,
   isDisabled: false,
   iconBefore: <MdAdd />,
-  type: "text",
+  type: "button",
   variant: "filled",
   isFullWidth: false,
   handleClick: () => console.log("clicked"),

--- a/src/components/inputs/Button/stories/Button.Variants.stories.jsx
+++ b/src/components/inputs/Button/stories/Button.Variants.stories.jsx
@@ -52,7 +52,7 @@ Variants.args = {
   isLoading: false,
   isDisabled: false,
   iconBefore: <MdAdd />,
-  type: "text",
+  type: "button",
   spacing: "wide",
   isFullWidth: false,
   handleClick: () => console.log("clicked"),

--- a/src/components/inputs/Button/stories/props.js
+++ b/src/components/inputs/Button/stories/props.js
@@ -45,7 +45,7 @@ const type = {
   control: { type: "select" },
   description: "pass type down to a button",
   table: {
-    defaultValue: { summary: "text" },
+    defaultValue: { summary: "button" },
   },
 };
 const spacing = {


### PR DESCRIPTION
Currently among the types of buttons that has the `<Button />` component is not the "button", however there is the "text", according to HTML standard would be ideal that there is the "button" instead of the "text" and additionally that this type of button has the ability to avoid the redirection behavior when the `</Button />` is inside a form.