### PR TITLE
Adjust the `<TextField/>` `blur`; it only works when the 'required' property is enabled.

### DIFF
--- a/src/components/inputs/TextField/index.jsx
+++ b/src/components/inputs/TextField/index.jsx
@@ -52,7 +52,7 @@ const TextField = (props) => {
 
   const interceptBlur = (e) => {
     setIsFocused(false);
-    if (typeof handleBlur === "function" && isRequired) {
+    if (typeof handleBlur === "function") {
       handleBlur(e);
     }
   };


### PR DESCRIPTION
The function of the `onBlur` event has been modified so that it is executed even when the `<Input />` of the `<TextField />` component is empty. This change was made because previously a value was required for the event to fire, which limited its usability. With this adjustment, the restriction of requiring a value has been removed, allowing the event to be used more flexibly.