### PR TITLE
Adjust the `<FullscreenNav/>` to include a scroll function for when the screen becomes too small

### DIFF
--- a/src/components/navigation/FullscreenNav/styles.js
+++ b/src/components/navigation/FullscreenNav/styles.js
@@ -25,7 +25,7 @@ const StyledFullscreenNav = styled.nav`
   background-color: ${colors.ref.palette.neutral.n10};
   padding: 0px 16px;
   z-index: 2;
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
 

--- a/src/components/navigation/FullscreenNav/styles.js
+++ b/src/components/navigation/FullscreenNav/styles.js
@@ -25,6 +25,9 @@ const StyledFullscreenNav = styled.nav`
   background-color: ${colors.ref.palette.neutral.n10};
   padding: 0px 16px;
   z-index: 2;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
 
   & > div:nth-child(2) {
     & > div:nth-child(n + 2) {
@@ -54,7 +57,6 @@ const StyledSeparatorLine = styled.div`
 
 const StyledFooter = styled.footer`
   display: flex;
-  width: 100%;
   height: 100%;
   flex-direction: column;
   justify-content: flex-end;


### PR DESCRIPTION
The current functionality of `<FullscreenNav/>` presents a problem when the screen height is less than `630px`, as it does not show all the navigation content. To solve this, a solution based on CSS properties has been implemented, providing a more native experience.