### PR TITLE
Adjust `<Header/>` in order to include props that manage the BusinessUnit

### DIFF
--- a/src/components/data/User/index.jsx
+++ b/src/components/data/User/index.jsx
@@ -41,7 +41,7 @@ const User = (props) => {
 
 User.propTypes = {
   userName: PropTypes.string.isRequired,
-  businessUnit: PropTypes.string.isRequired,
+  businessUnit: PropTypes.string,
   size: PropTypes.oneOf(sizes),
 };
 

--- a/src/components/navigation/Header/index.jsx
+++ b/src/components/navigation/Header/index.jsx
@@ -33,12 +33,19 @@ const LogoAndNav = (props) => {
 };
 
 const Header = (props) => {
-  const { portalId, navigation, logoutPath, logo, userName, businessUnit } =
-    props;
+  const {
+    portalId,
+    navigation,
+    logoutPath,
+    logo,
+    userName,
+    businessUnit,
+    isBusinessUnit = false,
+  } = props;
   const matches = useMediaQueries([SMALL_SCREEN, MEDIUM_SCREEN, LARGE_SCREEN]);
   const shouldDisplayLogoAndNav =
     !matches[LARGE_SCREEN] && shouldDisplayNav(matches);
-
+  const transformedBusinessUnit = isBusinessUnit ? businessUnit : null;
   return (
     <StyledHeader alignItems="center" justifyContent="space-between">
       <LogoAndNav
@@ -50,7 +57,7 @@ const Header = (props) => {
       />
       <User
         userName={userName}
-        businessUnit={businessUnit}
+        businessUnit={transformedBusinessUnit}
         size={getScreenSize(matches)}
       />
     </StyledHeader>
@@ -63,7 +70,8 @@ Header.propTypes = {
   logo: PropTypes.node.isRequired,
   logoutPath: PropTypes.string.isRequired,
   userName: PropTypes.string.isRequired,
-  businessUnit: PropTypes.string.isRequired,
+  businessUnit: PropTypes.string,
+  isBusinessUnit: PropTypes.bool,
 };
 
 export { Header };

--- a/src/components/navigation/Header/stories/Header.Default.stories.jsx
+++ b/src/components/navigation/Header/stories/Header.Default.stories.jsx
@@ -19,6 +19,7 @@ import {
   logoutPath,
   userName,
   businessUnit,
+  isBusinessUnit,
 } from "./props";
 import { Logo } from "./logo";
 
@@ -116,6 +117,7 @@ Default.argTypes = {
   logoutPath,
   userName,
   businessUnit,
+  isBusinessUnit,
 };
 
 export default story;

--- a/src/components/navigation/Header/stories/Header.Default.stories.jsx
+++ b/src/components/navigation/Header/stories/Header.Default.stories.jsx
@@ -108,6 +108,7 @@ Default.args = {
   logo: <Logo />,
   userName: "Leonardo Garzón",
   businessUnit: "Sistemas Enlínea S.A",
+  isBusinessUnit: true,
 };
 
 Default.argTypes = {

--- a/src/components/navigation/Header/stories/props.js
+++ b/src/components/navigation/Header/stories/props.js
@@ -31,4 +31,17 @@ const portalId = {
   description: "id of the portal element",
 };
 
-export { portalId, navigation, logo, logoutPath, userName, businessUnit };
+const isBusinessUnit = {
+  description:
+    "ascertain whether the 'header-component' displays the attribute 'businessUnit' or not",
+};
+
+export {
+  portalId,
+  navigation,
+  logo,
+  logoutPath,
+  userName,
+  businessUnit,
+  isBusinessUnit,
+};


### PR DESCRIPTION
This Pull Request (PR) introduces modifications to the `<Header/>` component, enabling it to manage properties associated with the BusinessUnit.

The proposed changes will allow the `<Header/>` component to receive props pertinent to the BusinessUnit, thereby enhancing the flexibility and usability of the component. These props can be adjusted as per the requirements of the BusinessUnit, resulting in a more efficient and dynamic header management.