### PR TITLE
 Adjust `<Table/>` component such that it incorporates the modal in responsive mode and the 'open' attribute is set to true

### DIFF
--- a/src/components/data/Table/DisplayEntry/index.jsx
+++ b/src/components/data/Table/DisplayEntry/index.jsx
@@ -4,8 +4,7 @@ import { MdOpenInNew } from "react-icons/md";
 import PropTypes from "prop-types";
 
 function DisplayEntry(props) {
-  const { entry, actions, title, titleLabels } = props;
-
+  const { entry, actions, title, titleLabels, infoTitle, actionsTitle } = props;
   const [showModal, setShowModal] = useState(false);
 
   const handleToggleModal = () => {
@@ -23,6 +22,8 @@ function DisplayEntry(props) {
           infoData={entry}
           actions={actions}
           labels={titleLabels}
+          infoTitle={infoTitle}
+          actionsTitle={actionsTitle}
         />
       )}
     </>

--- a/src/components/data/Table/DisplayEntry/index.jsx
+++ b/src/components/data/Table/DisplayEntry/index.jsx
@@ -1,6 +1,7 @@
-import { InteractiveModal } from "@components/feedback/InteractiveModal";
+import { InteractiveModal } from "../../../feedback/InteractiveModal";
 import { useState } from "react";
 import { MdOpenInNew } from "react-icons/md";
+import PropTypes from "prop-types";
 
 function DisplayEntry(props) {
   const { entry, actions, title, titleLabels } = props;
@@ -16,6 +17,7 @@ function DisplayEntry(props) {
       <MdOpenInNew onClick={handleToggleModal} />
       {showModal && (
         <InteractiveModal
+          portalId="portals"
           title={title}
           closeModal={handleToggleModal}
           infoData={entry}
@@ -26,5 +28,12 @@ function DisplayEntry(props) {
     </>
   );
 }
+
+DisplayEntry.propTypes = {
+  entry: PropTypes.object.isRequired,
+  actions: PropTypes.array.isRequired,
+  title: PropTypes.string.isRequired,
+  titleLabels: PropTypes.array.isRequired,
+};
 
 export { DisplayEntry };

--- a/src/components/data/Table/DisplayEntry/index.jsx
+++ b/src/components/data/Table/DisplayEntry/index.jsx
@@ -1,0 +1,30 @@
+import { InteractiveModal } from "@components/feedback/InteractiveModal";
+import { useState } from "react";
+import { MdOpenInNew } from "react-icons/md";
+
+function DisplayEntry(props) {
+  const { entry, actions, title, titleLabels } = props;
+
+  const [showModal, setShowModal] = useState(false);
+
+  const handleToggleModal = () => {
+    setShowModal(!showModal);
+  };
+
+  return (
+    <>
+      <MdOpenInNew onClick={handleToggleModal} />
+      {showModal && (
+        <InteractiveModal
+          title={title}
+          closeModal={handleToggleModal}
+          infoData={entry}
+          actions={actions}
+          labels={titleLabels}
+        />
+      )}
+    </>
+  );
+}
+
+export { DisplayEntry };

--- a/src/components/data/Table/DisplayEntry/index.jsx
+++ b/src/components/data/Table/DisplayEntry/index.jsx
@@ -4,7 +4,15 @@ import { MdOpenInNew } from "react-icons/md";
 import PropTypes from "prop-types";
 
 function DisplayEntry(props) {
-  const { entry, actions, title, titleLabels, infoTitle, actionsTitle } = props;
+  const {
+    portalId,
+    entry,
+    actions,
+    title,
+    titleLabels,
+    infoTitle,
+    actionsTitle,
+  } = props;
   const [showModal, setShowModal] = useState(false);
 
   const handleToggleModal = () => {
@@ -16,7 +24,7 @@ function DisplayEntry(props) {
       <MdOpenInNew onClick={handleToggleModal} />
       {showModal && (
         <InteractiveModal
-          portalId="portals"
+          portalId={portalId}
           title={title}
           closeModal={handleToggleModal}
           infoData={entry}
@@ -31,10 +39,13 @@ function DisplayEntry(props) {
 }
 
 DisplayEntry.propTypes = {
+  portalId: PropTypes.string,
   entry: PropTypes.object.isRequired,
   actions: PropTypes.array.isRequired,
   title: PropTypes.string.isRequired,
   titleLabels: PropTypes.array.isRequired,
+  infoTitle: PropTypes.string,
+  actionsTitle: PropTypes.string,
 };
 
 export { DisplayEntry };

--- a/src/components/data/Table/index.jsx
+++ b/src/components/data/Table/index.jsx
@@ -8,6 +8,7 @@ import { Stack } from "../../layouts/Stack";
 
 const Table = (props) => {
   const {
+    id,
     titles,
     actions,
     entries,
@@ -73,32 +74,36 @@ const Table = (props) => {
   }
 
   return (
-    <Stack direction="column">
-      <TableUI
-        titles={titles}
-        actions={actions}
-        entries={getPageEntries()}
-        breakpoints={breakpoints}
-        modalTitle={modalTitle}
-        infoTitle={infoTitle}
-        actionsTitle={actionsTitle}
-      />
-      {filteredEntries.length > pageLength && (
-        <Pagination
-          firstEntryInPage={firstEntryInPage}
-          lastEntryInPage={lastEntryInPage}
-          totalRecords={filteredEntries.length}
-          handleStartPage={goToFirstPage}
-          handlePrevPage={prevPage}
-          handleNextPage={nextPage}
-          handleEndPage={goToEndPage}
+    <div id={id}>
+      <Stack direction="column">
+        <TableUI
+          portalId={id}
+          titles={titles}
+          actions={actions}
+          entries={getPageEntries()}
+          breakpoints={breakpoints}
+          modalTitle={modalTitle}
+          infoTitle={infoTitle}
+          actionsTitle={actionsTitle}
         />
-      )}
-    </Stack>
+        {filteredEntries.length > pageLength && (
+          <Pagination
+            firstEntryInPage={firstEntryInPage}
+            lastEntryInPage={lastEntryInPage}
+            totalRecords={filteredEntries.length}
+            handleStartPage={goToFirstPage}
+            handlePrevPage={prevPage}
+            handleNextPage={nextPage}
+            handleEndPage={goToEndPage}
+          />
+        )}
+      </Stack>
+    </div>
   );
 };
 
 Table.propTypes = {
+  id: PropTypes.string.isRequired,
   titles: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
@@ -115,7 +120,7 @@ Table.propTypes = {
     })
   ).isRequired,
   entries: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.string })),
-  filte: PropTypes.string,
+  filter: PropTypes.string,
   pageLength: PropTypes.number,
   breakpoints: PropTypes.arrayOf(
     PropTypes.shape({
@@ -123,5 +128,9 @@ Table.propTypes = {
       totalColumns: PropTypes.number.isRequired,
     })
   ),
+  modalTitle: PropTypes.string,
+  infoTitle: PropTypes.string,
+  actionsTitle: PropTypes.string,
 };
+
 export { Table };

--- a/src/components/data/Table/index.jsx
+++ b/src/components/data/Table/index.jsx
@@ -14,6 +14,7 @@ const Table = (props) => {
     filter = "",
     pageLength = 10,
     breakpoints,
+    modalTitle,
   } = props;
 
   const filteredEntries = useMemo(() => {
@@ -76,6 +77,7 @@ const Table = (props) => {
         actions={actions}
         entries={getPageEntries()}
         breakpoints={breakpoints}
+        modalTitle={modalTitle}
       />
       {filteredEntries.length > pageLength && (
         <Pagination

--- a/src/components/data/Table/index.jsx
+++ b/src/components/data/Table/index.jsx
@@ -15,6 +15,8 @@ const Table = (props) => {
     pageLength = 10,
     breakpoints,
     modalTitle,
+    infoTitle,
+    actionsTitle,
   } = props;
 
   const filteredEntries = useMemo(() => {
@@ -78,6 +80,8 @@ const Table = (props) => {
         entries={getPageEntries()}
         breakpoints={breakpoints}
         modalTitle={modalTitle}
+        infoTitle={infoTitle}
+        actionsTitle={actionsTitle}
       />
       {filteredEntries.length > pageLength && (
         <Pagination

--- a/src/components/data/Table/interface.jsx
+++ b/src/components/data/Table/interface.jsx
@@ -50,7 +50,15 @@ function showActionTitle(actionTitle, mediaQuery) {
   );
 }
 
-function ShowAction(actionContent, entry, mediaQuery, modalTitle, titleLabels) {
+function ShowAction(
+  actionContent,
+  entry,
+  mediaQuery,
+  modalTitle,
+  titleLabels,
+  infoTitle,
+  actionsTitle
+) {
   return !mediaQuery ? (
     <>
       {actionContent.map((action) => (
@@ -66,13 +74,24 @@ function ShowAction(actionContent, entry, mediaQuery, modalTitle, titleLabels) {
         title={modalTitle}
         actions={actionContent}
         titleLabels={titleLabels}
+        infoTitle={infoTitle}
+        actionsTitle={actionsTitle}
       />
     </StyledTd>
   );
 }
 
 const TableUI = (props) => {
-  const { titles, actions, entries, breakpoints, modalTitle } = props;
+  const {
+    titles,
+    actions,
+    entries,
+    breakpoints,
+    modalTitle,
+    infoTitle,
+    actionsTitle,
+  } = props;
+
   const mediaActionOpen = useMediaQuery("(max-width: 850px)");
 
   const queriesArray = useMemo(
@@ -113,7 +132,15 @@ const TableUI = (props) => {
                 <Text typo="bodySmall">{entry[title.id]}</Text>
               </StyledTd>
             ))}
-            {ShowAction(actions, entry, mediaActionOpen, modalTitle, titles)}
+            {ShowAction(
+              actions,
+              entry,
+              mediaActionOpen,
+              modalTitle,
+              titles,
+              infoTitle,
+              actionsTitle
+            )}
           </StyledTr>
         ))}
       </StyledTbody>

--- a/src/components/data/Table/interface.jsx
+++ b/src/components/data/Table/interface.jsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from "react";
-import { MdOpenInNew } from "react-icons/md";
-
+import { DisplayEntry } from "./DisplayEntry";
 import {
   StyledTable,
   StyledThead,
@@ -51,7 +50,7 @@ function showActionTitle(actionTitle, mediaQuery) {
   );
 }
 
-function ShowAction(actionContent, entry, mediaQuery) {
+function ShowAction(actionContent, entry, mediaQuery, modalTitle, titleLabels) {
   return !mediaQuery ? (
     <>
       {actionContent.map((action) => (
@@ -62,13 +61,18 @@ function ShowAction(actionContent, entry, mediaQuery) {
     </>
   ) : (
     <StyledTd>
-      <MdOpenInNew />
+      <DisplayEntry
+        entry={entry}
+        title={modalTitle}
+        actions={actionContent}
+        titleLabels={titleLabels}
+      />
     </StyledTd>
   );
 }
 
 const TableUI = (props) => {
-  const { titles, actions, entries, breakpoints } = props;
+  const { titles, actions, entries, breakpoints, modalTitle } = props;
   const mediaActionOpen = useMediaQuery("(max-width: 850px)");
 
   const queriesArray = useMemo(
@@ -109,7 +113,7 @@ const TableUI = (props) => {
                 <Text typo="bodySmall">{entry[title.id]}</Text>
               </StyledTd>
             ))}
-            {ShowAction(actions, entry, mediaActionOpen)}
+            {ShowAction(actions, entry, mediaActionOpen, modalTitle, titles)}
           </StyledTr>
         ))}
       </StyledTbody>

--- a/src/components/data/Table/interface.jsx
+++ b/src/components/data/Table/interface.jsx
@@ -51,6 +51,7 @@ function showActionTitle(actionTitle, mediaQuery) {
 }
 
 function ShowAction(
+  portalId,
   actionContent,
   entry,
   mediaQuery,
@@ -70,6 +71,7 @@ function ShowAction(
   ) : (
     <StyledTd>
       <DisplayEntry
+        portalId={portalId}
         entry={entry}
         title={modalTitle}
         actions={actionContent}
@@ -83,6 +85,7 @@ function ShowAction(
 
 const TableUI = (props) => {
   const {
+    portalId,
     titles,
     actions,
     entries,
@@ -133,6 +136,7 @@ const TableUI = (props) => {
               </StyledTd>
             ))}
             {ShowAction(
+              portalId,
               actions,
               entry,
               mediaActionOpen,

--- a/src/components/data/Table/stories/Table.Default.stories.jsx
+++ b/src/components/data/Table/stories/Table.Default.stories.jsx
@@ -10,6 +10,8 @@ import {
   breakpoints,
   filter,
   pageLength,
+  infoTitle,
+  actionsTitle,
 } from "./props";
 
 const story = {
@@ -55,6 +57,9 @@ Default.args = {
   filter: "",
   pageLength: 10,
   breakpoints: breakPointsMuck,
+  modalTitle: "Formulario",
+  infoTitle: "Informacion",
+  actionsTitle: "Acciones",
 };
 
 Default.argTypes = {
@@ -64,6 +69,8 @@ Default.argTypes = {
   breakpoints,
   filter,
   pageLength,
+  infoTitle,
+  actionsTitle,
 };
 
 export default story;

--- a/src/components/data/Table/stories/Table.Default.stories.jsx
+++ b/src/components/data/Table/stories/Table.Default.stories.jsx
@@ -4,6 +4,7 @@ import { titlesMuck, actionsMuck, breakPointsMuck } from "./mucks";
 
 import {
   parameters,
+  id,
   titles,
   actions,
   entries,
@@ -22,6 +23,7 @@ const story = {
 
 const Default = (args) => <Table {...args} />;
 Default.args = {
+  id: "tableId",
   titles: titlesMuck,
   actions: actionsMuck,
   entries: [
@@ -57,12 +59,13 @@ Default.args = {
   filter: "",
   pageLength: 10,
   breakpoints: breakPointsMuck,
-  modalTitle: "Formulario",
-  infoTitle: "Informacion",
-  actionsTitle: "Acciones",
+  modalTitle: "Form",
+  infoTitle: "Information",
+  actionsTitle: "Actions",
 };
 
 Default.argTypes = {
+  id,
   titles,
   actions,
   entries,

--- a/src/components/data/Table/stories/Table.Paginations.stories.jsx
+++ b/src/components/data/Table/stories/Table.Paginations.stories.jsx
@@ -4,6 +4,7 @@ import { Table } from "../index";
 
 import {
   parameters,
+  id,
   titles,
   actions,
   entries,
@@ -22,6 +23,7 @@ const story = {
 
 const Paginations = (args) => <Table {...args} />;
 Paginations.args = {
+  id: "tableId",
   titles: titlesMuck,
   actions: actionsMuck,
   entries: [
@@ -239,12 +241,13 @@ Paginations.args = {
   filter: "",
   pageLength: 10,
   breakpoints: breakPointsMuck,
-  modalTitle: "Formulario",
-  infoTitle: "Informacion",
-  actionsTitle: "Acciones",
+  modalTitle: "Form",
+  infoTitle: "Information",
+  actionsTitle: "Actions",
 };
 
 Paginations.argTypes = {
+  id,
   titles,
   actions,
   entries,

--- a/src/components/data/Table/stories/Table.Paginations.stories.jsx
+++ b/src/components/data/Table/stories/Table.Paginations.stories.jsx
@@ -10,6 +10,8 @@ import {
   breakpoints,
   filter,
   pageLength,
+  infoTitle,
+  actionsTitle,
 } from "./props";
 
 const story = {
@@ -237,6 +239,9 @@ Paginations.args = {
   filter: "",
   pageLength: 10,
   breakpoints: breakPointsMuck,
+  modalTitle: "Formulario",
+  infoTitle: "Informacion",
+  actionsTitle: "Acciones",
 };
 
 Paginations.argTypes = {
@@ -246,6 +251,8 @@ Paginations.argTypes = {
   filter,
   pageLength,
   breakpoints,
+  infoTitle,
+  actionsTitle,
 };
 
 export default story;

--- a/src/components/data/Table/stories/props.js
+++ b/src/components/data/Table/stories/props.js
@@ -7,6 +7,10 @@ const parameters = {
   },
 };
 
+const id = {
+  description: "uniquely identifies the **Table Component**.",
+};
+
 const titles = {
   description:
     "(Array[objects]): shall be designed to accept an array of objects with a predetermined structure and it’ll be the titles for the table, as specified below: Each object shall contain the following attributes (keys):",
@@ -87,6 +91,7 @@ const actionsTitle = {
 
 export {
   parameters,
+  id,
   titles,
   actions,
   entries,

--- a/src/components/data/Table/stories/props.js
+++ b/src/components/data/Table/stories/props.js
@@ -75,6 +75,16 @@ const pageLength = {
     "(number), shall be the number of the entries that will be displayed on the table",
 };
 
+const infoTitle = {
+  control: { type: "text" },
+  description: "custom title for information that displays in modal",
+};
+
+const actionsTitle = {
+  control: { type: "text" },
+  description: "custom title for actions that displays in modal",
+};
+
 export {
   parameters,
   titles,
@@ -83,4 +93,6 @@ export {
   breakpoints,
   filter,
   pageLength,
+  infoTitle,
+  actionsTitle,
 };

--- a/src/components/feedback/InteractiveModal/index.jsx
+++ b/src/components/feedback/InteractiveModal/index.jsx
@@ -1,0 +1,105 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Blanket } from "../../utils/Blanket";
+import { Stack } from "../../layouts/Stack";
+import { Text } from "../../data/Text";
+import { TextField } from "../../inputs/TextField";
+import { useMediaQuery } from "../../../hooks/useMediaQuery";
+import { createPortal } from "react-dom";
+import { MdClear } from "react-icons/md";
+import { StyledActionContainer, StyledModal } from "./styles";
+
+const InteractiveModal = (props) => {
+  const { portalId, title, closeModal, infoData, actions, labels } = props;
+
+  const smallScreen = useMediaQuery("(max-width: 580px)");
+
+  const hasActions = actions && actions.length > 0;
+
+  const hasLabels = labels && labels.length > 0;
+
+  const node = document.getElementById(portalId);
+
+  if (node === null) {
+    throw new Error(
+      "The portal node is not defined. This can occur when the specific node used to render the portal has not been defined correctly."
+    );
+  }
+
+  return createPortal(
+    <Blanket>
+      <StyledModal smallScreen={smallScreen}>
+        <Stack direction="column" gap="24px">
+          <Stack direction="column" gap="16px">
+            <Stack alignItems="center" justifyContent="space-between">
+              <Text typo="headlineSmall">{title}</Text>
+              <MdClear size={24} cursor="pointer" onClick={closeModal} />
+            </Stack>
+            {hasActions && <Text typo="titleMedium">Información</Text>}
+            {hasLabels
+              ? labels.map(
+                  (field, id) =>
+                    infoData[field.id] && (
+                      <TextField
+                        key={id}
+                        label={field.titleName}
+                        name={field.id}
+                        id={field.id}
+                        placeholder={field.titleName}
+                        value={infoData[field.id]}
+                        isFullWidth={true}
+                        type="text"
+                        size="compact"
+                        readOnly={true}
+                      />
+                    )
+                )
+              : Object.keys(infoData).map((key, id) => (
+                  <TextField
+                    key={id}
+                    label={key}
+                    name={key}
+                    id={key}
+                    placeholder={key}
+                    value={infoData[key]}
+                    isFullWidth={true}
+                    type="text"
+                    size="compact"
+                    readOnly={true}
+                  />
+                ))}
+          </Stack>
+          {hasActions && (
+            <Stack direction="column" gap="16px">
+              <Text typo="titleMedium">Acciones</Text>
+              {actions.map((action) => (
+                <Stack key={action.id} gap="10px">
+                  <StyledActionContainer>
+                    {typeof action.content === "function"
+                      ? action.content(infoData)
+                      : action.content}
+                  </StyledActionContainer>
+                  <Text typo="labelLarge" appearance="secondary">
+                    {action.actionName}
+                  </Text>
+                </Stack>
+              ))}
+            </Stack>
+          )}
+        </Stack>
+      </StyledModal>
+    </Blanket>,
+    node
+  );
+};
+
+InteractiveModal.propTypes = {
+  portalId: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  closeModal: PropTypes.func.isRequired,
+  infoData: PropTypes.object.isRequired,
+  actions: PropTypes.array,
+  labels: PropTypes.array,
+};
+
+export { InteractiveModal };

--- a/src/components/feedback/InteractiveModal/index.jsx
+++ b/src/components/feedback/InteractiveModal/index.jsx
@@ -10,7 +10,16 @@ import { MdClear } from "react-icons/md";
 import { StyledActionContainer, StyledModal } from "./styles";
 
 const InteractiveModal = (props) => {
-  const { portalId, title, closeModal, infoData, actions, labels } = props;
+  const {
+    portalId,
+    title,
+    closeModal,
+    infoData,
+    actions,
+    labels,
+    infoTitle,
+    actionsTitle,
+  } = props;
 
   const smallScreen = useMediaQuery("(max-width: 580px)");
 
@@ -35,7 +44,7 @@ const InteractiveModal = (props) => {
               <Text typo="headlineSmall">{title}</Text>
               <MdClear size={24} cursor="pointer" onClick={closeModal} />
             </Stack>
-            {hasActions && <Text typo="titleMedium">Información</Text>}
+            {hasActions && <Text typo="titleMedium">{infoTitle}</Text>}
             {hasLabels
               ? labels.map(
                   (field, id) =>
@@ -71,7 +80,7 @@ const InteractiveModal = (props) => {
           </Stack>
           {hasActions && (
             <Stack direction="column" gap="16px">
-              <Text typo="titleMedium">Acciones</Text>
+              <Text typo="titleMedium">{actionsTitle}</Text>
               {actions.map((action) => (
                 <Stack key={action.id} gap="10px">
                   <StyledActionContainer>
@@ -100,6 +109,8 @@ InteractiveModal.propTypes = {
   infoData: PropTypes.object.isRequired,
   actions: PropTypes.array,
   labels: PropTypes.array,
+  infoTitle: PropTypes.string,
+  actionsTitle: PropTypes.string,
 };
 
 export { InteractiveModal };

--- a/src/components/feedback/InteractiveModal/stories/InteractiveModal.Default.stories.jsx
+++ b/src/components/feedback/InteractiveModal/stories/InteractiveModal.Default.stories.jsx
@@ -1,6 +1,6 @@
 import { action } from "@storybook/addon-actions";
 import { InteractiveModal } from "../index";
-import { BrowserRouter } from "react-router-dom";
+
 import { portalId, title, closeModal, infoData } from "./props";
 const story = {
   title: "feedback/InteractiveModal/Default",
@@ -8,9 +8,7 @@ const story = {
   decorators: [
     (Story) => (
       <div style={{ margin: "3em" }}>
-        <BrowserRouter>
-          <Story />
-        </BrowserRouter>
+        <Story />
       </div>
     ),
   ],

--- a/src/components/feedback/InteractiveModal/stories/InteractiveModal.Default.stories.jsx
+++ b/src/components/feedback/InteractiveModal/stories/InteractiveModal.Default.stories.jsx
@@ -1,0 +1,48 @@
+import { action } from "@storybook/addon-actions";
+import { InteractiveModal } from "../index";
+import { BrowserRouter } from "react-router-dom";
+import { portalId, title, closeModal, infoData } from "./props";
+const story = {
+  title: "feedback/InteractiveModal/Default",
+  components: [InteractiveModal],
+  decorators: [
+    (Story) => (
+      <div style={{ margin: "3em" }}>
+        <BrowserRouter>
+          <Story />
+        </BrowserRouter>
+      </div>
+    ),
+  ],
+};
+
+const data = {
+  id: 10,
+  userID: "45645",
+  username: "David Leonardo Garzón",
+  mail: "lgarzon@gmail.com",
+  invitationDate: "11/JUN/2022",
+  status: "Sent",
+};
+
+const Template = (args) => <InteractiveModal {...args} />;
+
+const closeInteractiveModal = () => {
+  action("InteractiveModal closed");
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  portalId: "portals",
+  title: "User Information",
+  closeModal: closeInteractiveModal,
+  infoData: data,
+};
+Default.argTypes = {
+  portalId,
+  title,
+  closeModal,
+  infoData,
+};
+
+export default story;

--- a/src/components/feedback/InteractiveModal/stories/InteractiveModal.Default.stories.jsx
+++ b/src/components/feedback/InteractiveModal/stories/InteractiveModal.Default.stories.jsx
@@ -1,7 +1,14 @@
 import { action } from "@storybook/addon-actions";
 import { InteractiveModal } from "../index";
 
-import { portalId, title, closeModal, infoData } from "./props";
+import {
+  portalId,
+  title,
+  closeModal,
+  infoData,
+  infoTitle,
+  actionsTitle,
+} from "./props";
 const story = {
   title: "feedback/InteractiveModal/Default",
   components: [InteractiveModal],
@@ -35,12 +42,16 @@ Default.args = {
   title: "User Information",
   closeModal: closeInteractiveModal,
   infoData: data,
+  infoTitle: "Información",
+  actionsTitle: "Acciones",
 };
 Default.argTypes = {
   portalId,
   title,
   closeModal,
   infoData,
+  infoTitle,
+  actionsTitle,
 };
 
 export default story;

--- a/src/components/feedback/InteractiveModal/stories/InteractiveModal.WithActions.stories.jsx
+++ b/src/components/feedback/InteractiveModal/stories/InteractiveModal.WithActions.stories.jsx
@@ -13,6 +13,8 @@ import {
   infoData,
   actions,
   labels,
+  infoTitle,
+  actionsTitle,
 } from "./props";
 
 const story = {
@@ -99,6 +101,8 @@ WithActions.args = {
   infoData: data,
   actions: actionsArray,
   labels: labelsArray,
+  infoTitle: "Información",
+  actionsTitle: "Acciones",
 };
 WithActions.argTypes = {
   portalId,
@@ -107,6 +111,8 @@ WithActions.argTypes = {
   infoData,
   actions,
   labels,
+  infoTitle,
+  actionsTitle,
 };
 
 export default story;

--- a/src/components/feedback/InteractiveModal/stories/InteractiveModal.WithActions.stories.jsx
+++ b/src/components/feedback/InteractiveModal/stories/InteractiveModal.WithActions.stories.jsx
@@ -5,7 +5,7 @@ import {
   MdOutlineShortcut,
 } from "react-icons/md";
 import { InteractiveModal } from "../index";
-import { BrowserRouter } from "react-router-dom";
+
 import {
   portalId,
   title,
@@ -21,9 +21,7 @@ const story = {
   decorators: [
     (Story) => (
       <div style={{ margin: "3em" }}>
-        <BrowserRouter>
-          <Story />
-        </BrowserRouter>
+        <Story />
       </div>
     ),
   ],

--- a/src/components/feedback/InteractiveModal/stories/InteractiveModal.WithActions.stories.jsx
+++ b/src/components/feedback/InteractiveModal/stories/InteractiveModal.WithActions.stories.jsx
@@ -1,0 +1,114 @@
+import { action } from "@storybook/addon-actions";
+import {
+  MdOutlineAssignmentTurnedIn,
+  MdOutlineDelete,
+  MdOutlineShortcut,
+} from "react-icons/md";
+import { InteractiveModal } from "../index";
+import { BrowserRouter } from "react-router-dom";
+import {
+  portalId,
+  title,
+  closeModal,
+  infoData,
+  actions,
+  labels,
+} from "./props";
+
+const story = {
+  title: "feedback/InteractiveModal/WithActions",
+  components: [InteractiveModal],
+  decorators: [
+    (Story) => (
+      <div style={{ margin: "3em" }}>
+        <BrowserRouter>
+          <Story />
+        </BrowserRouter>
+      </div>
+    ),
+  ],
+};
+
+const data = {
+  id: 10,
+  userID: "45645",
+  username: "David Leonardo Garzón",
+  mail: "lgarzon@gmail.com",
+  invitationDate: "11/JUN/2022",
+  status: "Sent",
+};
+
+const Template = (args) => <InteractiveModal {...args} />;
+
+const closeInteractiveModal = () => {
+  action("InteractiveModal closed");
+};
+
+const actionsArray = [
+  {
+    id: 1,
+    actionName: "Complete",
+    content: <MdOutlineAssignmentTurnedIn />,
+    type: "secondary",
+  },
+  {
+    id: 2,
+    actionName: "Resend",
+    content: <MdOutlineShortcut />,
+    type: "primary",
+  },
+  {
+    id: 3,
+    actionName: "Delete",
+    content: <MdOutlineDelete />,
+    type: "remove",
+  },
+];
+
+const labelsArray = [
+  {
+    id: "userID",
+    titleName: "User Id",
+    priority: 0,
+  },
+  {
+    id: "username",
+    titleName: "Username",
+    priority: 1,
+  },
+  {
+    id: "mail",
+    titleName: "Mail",
+    priority: 2,
+  },
+  {
+    id: "invitationDate",
+    titleName: "Invitation Date",
+    priority: 3,
+  },
+  {
+    id: "status",
+    titleName: "Status",
+    priority: 4,
+  },
+];
+
+export const WithActions = Template.bind({});
+WithActions.args = {
+  portalId: "portals",
+  title: "User Information",
+  closeModal: closeInteractiveModal,
+  infoData: data,
+  actions: actionsArray,
+  labels: labelsArray,
+};
+WithActions.argTypes = {
+  portalId,
+  title,
+  closeModal,
+  infoData,
+  actions,
+  labels,
+};
+
+export default story;

--- a/src/components/feedback/InteractiveModal/stories/InteractiveModal.WithLabels.stories.jsx
+++ b/src/components/feedback/InteractiveModal/stories/InteractiveModal.WithLabels.stories.jsx
@@ -1,0 +1,79 @@
+import { action } from "@storybook/addon-actions";
+import { InteractiveModal } from "../index";
+import { BrowserRouter } from "react-router-dom";
+import { portalId, title, closeModal, infoData, labels } from "./props";
+const story = {
+  title: "feedback/InteractiveModal/WithLabels",
+  components: [InteractiveModal],
+  decorators: [
+    (Story) => (
+      <div style={{ margin: "3em" }}>
+        <BrowserRouter>
+          <Story />
+        </BrowserRouter>
+      </div>
+    ),
+  ],
+};
+
+const data = {
+  id: 10,
+  userID: "45645",
+  username: "David Leonardo Garzón",
+  mail: "lgarzon@gmail.com",
+  invitationDate: "11/JUN/2022",
+  status: "Sent",
+};
+
+const Template = (args) => <InteractiveModal {...args} />;
+
+const closeInteractiveModal = () => {
+  action("InteractiveModal closed");
+};
+
+const labelsArray = [
+  {
+    id: "userID",
+    titleName: "User Id",
+    priority: 0,
+  },
+  {
+    id: "username",
+    titleName: "Username",
+    priority: 1,
+  },
+  {
+    id: "mail",
+    titleName: "Mail",
+    priority: 2,
+  },
+  {
+    id: "invitationDate",
+    titleName: "Invitation Date",
+    priority: 3,
+  },
+  {
+    id: "status",
+    titleName: "Status",
+    priority: 4,
+  },
+];
+
+export const WithLabels = Template.bind({});
+WithLabels.args = {
+  portalId: "portals",
+  title: "User Information",
+  closeModal: closeInteractiveModal,
+  infoData: data,
+  labels: labelsArray,
+};
+
+WithLabels.argTypes = {
+  portalId,
+  title,
+  closeModal,
+  infoData,
+  labels,
+};
+
+export default story;

--- a/src/components/feedback/InteractiveModal/stories/InteractiveModal.WithLabels.stories.jsx
+++ b/src/components/feedback/InteractiveModal/stories/InteractiveModal.WithLabels.stories.jsx
@@ -1,6 +1,5 @@
 import { action } from "@storybook/addon-actions";
 import { InteractiveModal } from "../index";
-import { BrowserRouter } from "react-router-dom";
 import { portalId, title, closeModal, infoData, labels } from "./props";
 const story = {
   title: "feedback/InteractiveModal/WithLabels",
@@ -8,9 +7,7 @@ const story = {
   decorators: [
     (Story) => (
       <div style={{ margin: "3em" }}>
-        <BrowserRouter>
-          <Story />
-        </BrowserRouter>
+        <Story />
       </div>
     ),
   ],

--- a/src/components/feedback/InteractiveModal/stories/InteractiveModal.WithLabels.stories.jsx
+++ b/src/components/feedback/InteractiveModal/stories/InteractiveModal.WithLabels.stories.jsx
@@ -1,6 +1,15 @@
 import { action } from "@storybook/addon-actions";
 import { InteractiveModal } from "../index";
-import { portalId, title, closeModal, infoData, labels } from "./props";
+import {
+  portalId,
+  title,
+  closeModal,
+  infoData,
+  labels,
+  infoTitle,
+  actionsTitle,
+} from "./props";
+
 const story = {
   title: "feedback/InteractiveModal/WithLabels",
   components: [InteractiveModal],
@@ -63,6 +72,8 @@ WithLabels.args = {
   closeModal: closeInteractiveModal,
   infoData: data,
   labels: labelsArray,
+  infoTitle: "Información",
+  actionsTitle: "Acciones",
 };
 
 WithLabels.argTypes = {
@@ -71,6 +82,8 @@ WithLabels.argTypes = {
   closeModal,
   infoData,
   labels,
+  infoTitle,
+  actionsTitle,
 };
 
 export default story;

--- a/src/components/feedback/InteractiveModal/stories/props.js
+++ b/src/components/feedback/InteractiveModal/stories/props.js
@@ -1,0 +1,31 @@
+const portalId = {
+  control: { type: "text" },
+  description: "the ID of the portal",
+};
+
+const title = {
+  control: { type: "text" },
+  description: "the title of the interactive modal",
+};
+
+const closeModal = {
+  control: { type: "function" },
+  description: "callback function to close the interactive modal",
+};
+
+const infoData = {
+  control: { type: "object" },
+  description: "data containing user information",
+};
+
+const actions = {
+  control: { type: "array" },
+  description: "actions available for the interactive modal",
+};
+
+const labels = {
+  control: { type: "object" },
+  description: "custom labels for the interactive modal",
+};
+
+export { portalId, title, closeModal, infoData, actions, labels };

--- a/src/components/feedback/InteractiveModal/stories/props.js
+++ b/src/components/feedback/InteractiveModal/stories/props.js
@@ -28,4 +28,23 @@ const labels = {
   description: "custom labels for the interactive modal",
 };
 
-export { portalId, title, closeModal, infoData, actions, labels };
+const infoTitle = {
+  control: { type: "text" },
+  description: "custom title for information that displays in modal",
+};
+
+const actionsTitle = {
+  control: { type: "text" },
+  description: "custom title for actions that displays in modal",
+};
+
+export {
+  portalId,
+  title,
+  closeModal,
+  infoData,
+  actions,
+  labels,
+  infoTitle,
+  actionsTitle,
+};

--- a/src/components/feedback/InteractiveModal/styles.js
+++ b/src/components/feedback/InteractiveModal/styles.js
@@ -1,0 +1,19 @@
+import { colors } from "../../../shared/colors/colors";
+import styled from "styled-components";
+
+const StyledModal = styled.div`
+  background-color: ${colors.ref.palette.neutral.n10};
+  min-width: ${(props) => (props.smallScreen ? "100%" : "450px")};
+  min-height: ${(props) => (props.smallScreen ? "100%" : "auto")};
+  border-radius: ${(props) => (props.smallScreen ? "0" : "8px")};
+  & > div {
+    padding: ${(props) => (props.smallScreen ? "24px" : "32px")};
+  }
+`;
+
+const StyledActionContainer = styled.div`
+  background-color: ${colors.ref.palette.neutral.n10};
+  margin-left: 20px;
+`;
+
+export { StyledActionContainer, StyledModal };


### PR DESCRIPTION
This PR aims to enhance the `<Table/>` component by incorporating a modal in responsive mode and ensuring that the 'open' attribute is set to true. By implementing this improvement, users will have a seamless and user-friendly experience when viewing and interacting with the table on various screen sizes.