### PR TITLE
Add margin and padding props to `<Switch/>`

### DIFF
--- a/src/components/inputs/Switch/index.jsx
+++ b/src/components/inputs/Switch/index.jsx
@@ -6,9 +6,12 @@ import { Stack } from "../../layouts/Stack";
 import { Label } from "../Label";
 
 import { StyledContainer, StyledInput, StyledSpan, StyledIcon } from "./styles";
+import { transformedMeasure } from "../../../utilities/transformedMeasure";
 
 export const sizes = ["small", "large"];
 const defaultSize = "small";
+const defaultMargin = "0px";
+const defaultPadding = "0px";
 
 const Switch = (props) => {
   const {
@@ -20,6 +23,8 @@ const Switch = (props) => {
     checked = false,
     handleChange,
     label,
+    margin,
+    padding,
   } = props;
 
   const transformedSize = sizes.includes(size) ? size : defaultSize;
@@ -32,6 +37,8 @@ const Switch = (props) => {
       justifyContent={transformedJustify}
       alignItems="center"
       gap={tranformedGap}
+      margin={transformedMeasure(margin, defaultMargin)}
+      padding={transformedMeasure(padding, defaultPadding)}
     >
       <StyledContainer size={transformedSize}>
         <StyledInput
@@ -74,6 +81,8 @@ Switch.propTypes = {
   checked: PropTypes.bool,
   handleChange: PropTypes.func.isRequired,
   label: PropTypes.string,
+  margin: PropTypes.string,
+  padding: PropTypes.string,
 };
 
 export { Switch };

--- a/src/components/inputs/Switch/stories/Switch.Checks.stories.jsx
+++ b/src/components/inputs/Switch/stories/Switch.Checks.stories.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Switch } from "../index";
 import { SwitchController } from "./SwitchController";
-import { id, isDisabled, name, handleChange } from "./props";
+import { id, isDisabled, name, handleChange, margin, padding } from "./props";
 
 import { Stack } from "../../../layouts/Stack";
 const story = {
@@ -40,12 +40,16 @@ Checks.args = {
   name: "nameValue",
   checked: false,
   handleChange: () => {},
+  margin: "0px",
+  padding: "0px",
 };
 Checks.argTypes = {
   id,
   isDisabled,
   name,
   handleChange,
+  margin,
+  padding,
 };
 
 export default story;

--- a/src/components/inputs/Switch/stories/Switch.Default.stories.jsx
+++ b/src/components/inputs/Switch/stories/Switch.Default.stories.jsx
@@ -10,6 +10,8 @@ import {
   checked,
   handleChange,
   size,
+  margin,
+  padding,
 } from "./props";
 
 const story = {
@@ -33,6 +35,8 @@ Default.args = {
   checked: false,
   size: "small",
   handleChange: () => {},
+  margin: "0px",
+  padding: "0px",
 };
 Default.argTypes = {
   id,
@@ -42,6 +46,8 @@ Default.argTypes = {
   checked,
   handleChange,
   size,
+  margin,
+  padding,
 };
 
 export default story;

--- a/src/components/inputs/Switch/stories/Switch.Disabled.stories.jsx
+++ b/src/components/inputs/Switch/stories/Switch.Disabled.stories.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Switch } from "../index";
 import { SwitchController } from "./SwitchController";
-import { id, isDisabled, name, handleChange } from "./props";
+import { id, isDisabled, name, handleChange, margin, padding } from "./props";
 
 import { Stack } from "../../../layouts/Stack";
 
@@ -37,12 +37,16 @@ Disabled.args = {
   isDisabled: true,
   name: "nameState",
   handleChange: () => {},
+  margin: "0px",
+  padding: "0px",
 };
 Disabled.argTypes = {
   id,
   isDisabled,
   name,
   handleChange,
+  margin,
+  padding,
 };
 
 export default story;

--- a/src/components/inputs/Switch/stories/Switch.Sizes.stories.jsx
+++ b/src/components/inputs/Switch/stories/Switch.Sizes.stories.jsx
@@ -2,7 +2,16 @@ import React from "react";
 
 import { Switch, sizes } from "../index";
 import { SwitchController } from "./SwitchController";
-import { id, isDisabled, name, value, checked, handleChange } from "./props";
+import {
+  id,
+  isDisabled,
+  name,
+  value,
+  checked,
+  handleChange,
+  margin,
+  padding,
+} from "./props";
 
 import { Stack } from "../../../layouts/Stack";
 
@@ -43,6 +52,8 @@ Sizes.args = {
   value: "as",
   checked: false,
   handleChange: () => {},
+  margin: "0px",
+  padding: "0px",
 };
 Sizes.argTypes = {
   id,
@@ -51,6 +62,8 @@ Sizes.argTypes = {
   value,
   checked,
   handleChange,
+  margin,
+  padding,
 };
 
 export default story;

--- a/src/components/inputs/Switch/stories/Switch.WithLabel.stories.jsx
+++ b/src/components/inputs/Switch/stories/Switch.WithLabel.stories.jsx
@@ -2,7 +2,15 @@ import React from "react";
 
 import { Switch } from "../index";
 import { SwitchController } from "./SwitchController";
-import { id, isDisabled, name, handleChange, label } from "./props";
+import {
+  id,
+  isDisabled,
+  name,
+  handleChange,
+  label,
+  margin,
+  padding,
+} from "./props";
 
 import { Stack } from "../../../layouts/Stack";
 
@@ -42,6 +50,8 @@ WithLabel.args = {
   checked: false,
   handleChange: () => {},
   label: "Label",
+  margin: "0px",
+  padding: "0px",
 };
 WithLabel.argTypes = {
   id,
@@ -49,6 +59,8 @@ WithLabel.argTypes = {
   name,
   handleChange,
   label,
+  margin,
+  padding,
 };
 
 export default story;

--- a/src/components/inputs/Switch/stories/props.js
+++ b/src/components/inputs/Switch/stories/props.js
@@ -6,6 +6,7 @@ const id = {
   description:
     "this element can have a label on it, so this id allows us to connect the label with the switch",
 };
+
 const isDisabled = {
   options: [true, false],
   control: { type: "boolean" },
@@ -15,6 +16,7 @@ const isDisabled = {
     defaultValue: { summary: "false" },
   },
 };
+
 const checked = {
   options: [true, false],
   control: { type: "boolean" },
@@ -23,22 +25,26 @@ const checked = {
     defaultValue: { summary: false },
   },
 };
+
 const name = {
   options: ["name"],
   control: { type: "select" },
   description: "descriptive name for value property to be submitted in a form",
 };
+
 const value = {
   options: ["switchTest1", "switchTest2", "switchTest3", "switchTest4"],
   control: { type: "select" },
   description: "value to be submitted in a form",
 };
+
 const handleChange = {
   options: ["logState"],
   control: { type: "func" },
   description:
     "is a function that the component receives and that can be executed every time the switch state is modified",
 };
+
 const size = {
   options: sizes,
   control: { type: "select" },
@@ -47,7 +53,37 @@ const size = {
     defaultValue: { summary: "small" },
   },
 };
+
 const label = {
   description: "component text content",
 };
-export { id, isDisabled, name, value, checked, handleChange, size, label };
+
+const margin = {
+  type: { name: "string", required: false },
+  description:
+    "Sets the margin in px or global values for all four sides of the component",
+  table: {
+    defaultValue: { summary: "0px" },
+  },
+};
+
+const padding = {
+  type: { name: "string", required: false },
+  description:
+    "Sets the padding in px p global values for all four sides of the component",
+  table: {
+    defaultValue: { summary: "0px" },
+  },
+};
+export {
+  id,
+  isDisabled,
+  name,
+  value,
+  checked,
+  handleChange,
+  size,
+  label,
+  margin,
+  padding,
+};

--- a/src/components/inputs/Switch/styles.js
+++ b/src/components/inputs/Switch/styles.js
@@ -60,6 +60,8 @@ const StyledContainer = styled.label`
   position: relative;
   display: inline-block;
   ${(props) => sizes[props.size]}
+  margin: ${({ margin }) => margin};
+  padding: ${({ padding }) => padding};
 `;
 
 const StyledInput = styled.input`


### PR DESCRIPTION
This Pull Request introduces the addition of margin and padding properties to the `<Switch/>` component. With this update, developers will be able to customize the space around this component more effectively, enhancing layout flexibility and user interface design.