### PR TITLE
decouple the `<Button />` component in multiple components

### DIFF
--- a/src/components/data/Avatar/index.tsx
+++ b/src/components/data/Avatar/index.tsx
@@ -2,7 +2,7 @@ import { IAvatarProps } from "./interfaces/Avatar.interface";
 import { MdPersonOutline } from "react-icons/md";
 
 import { StyledAvatar } from "./styles";
-
+//prueba
 export const defaultIcon = <MdPersonOutline />;
 
 const Avatar = (props: IAvatarProps) => {

--- a/src/components/inputs/Button/ButtonError/index.tsx
+++ b/src/components/inputs/Button/ButtonError/index.tsx
@@ -1,0 +1,95 @@
+import { IButtonProps } from "../interfaces/Button.interface";
+
+import { Spinner } from "@src/components/feedback/Spinner";
+import {
+  StyledErrorButton,
+  StyledIcon,
+  StyledSpan,
+  StyledLink,
+} from "./styles";
+import { Variant } from "../types/Button.Variants.type";
+
+const defaultSpinnerSize = "small";
+
+const getSpinnerColor = (variant: Variant) => {
+  if (variant === "filled") {
+    return "white";
+  } else return "red";
+};
+
+const ErrorButon = (props: IButtonProps) => {
+  const {
+    children,
+    appearance,
+    isLoading,
+    isDisabled,
+    iconBefore,
+    iconAfter,
+    type,
+    spacing,
+    variant,
+    isFullWidth,
+    handleClick,
+    path,
+  } = props;
+
+  const transformedTransparentSpinner = variant === "filled";
+
+  if (type === "link") {
+    return (
+      <StyledLink
+        to={path}
+        isDisabled={isDisabled}
+        variant={variant}
+        appearance={appearance}
+        isFullWidth={isFullWidth}
+      >
+        <StyledErrorButton
+          appearance={appearance}
+          isDisabled={isDisabled}
+          spacing={spacing}
+          variant={variant}
+          isFullWidth={isFullWidth}
+          onClick={handleClick}
+        >
+          <StyledSpan isDisabled={isDisabled} variant={variant}>
+            {iconBefore && <StyledIcon id="mdIcon">{iconBefore}</StyledIcon>}
+            {children}
+            {iconAfter && <StyledIcon id="mdIcon">{iconAfter}</StyledIcon>}
+          </StyledSpan>
+        </StyledErrorButton>
+      </StyledLink>
+    );
+  }
+
+  return (
+    <StyledErrorButton
+      appearance={appearance}
+      isLoading={isLoading}
+      isDisabled={isDisabled}
+      variant={variant}
+      iconBefore={iconBefore}
+      iconAfter={iconAfter}
+      type={type}
+      spacing={spacing}
+      isFullWidth={isFullWidth}
+      onClick={handleClick}
+    >
+      {isLoading && !isDisabled ? (
+        <Spinner
+          appearance={getSpinnerColor(variant!)}
+          isTransparent={transformedTransparentSpinner}
+          size={defaultSpinnerSize}
+        />
+      ) : (
+        <StyledSpan isDisabled={isDisabled} variant={variant}>
+          {iconBefore && <StyledIcon id="mdIcon">{iconBefore}</StyledIcon>}
+          {children}
+          {iconAfter && <StyledIcon id="mdIcon">{iconAfter}</StyledIcon>}
+        </StyledSpan>
+      )}
+    </StyledErrorButton>
+  );
+};
+
+export { ErrorButon };

--- a/src/components/inputs/Button/ButtonError/styles.ts
+++ b/src/components/inputs/Button/ButtonError/styles.ts
@@ -1,0 +1,96 @@
+import styled, { css } from "styled-components";
+import { Link } from "react-router-dom";
+
+import { IButtonProps } from "../interfaces/Button.interface";
+
+import { typography } from "@src/shared/typography/typography";
+import { colors } from "@src/shared/colors/colors";
+
+function getBackgroundColor(props: IButtonProps) {
+  const { isDisabled, variant } = props;
+
+  if (isDisabled) {
+    return colors.sys.actions.disabled.filled;
+  }
+
+  if (variant !== "filled" && !isDisabled) {
+    return colors.ref.palette.neutral.n10;
+  }
+  return colors.sys.actions.remove.filled;
+}
+
+function getColor(props: IButtonProps) {
+  const { isDisabled, variant } = props;
+
+  if (isDisabled) {
+    return colors.sys.text.disabled;
+  }
+
+  if (variant !== "filled" && !isDisabled) {
+    return colors.sys.text.error;
+  }
+  return colors.ref.palette.neutral.n10;
+}
+
+function getWidth(props: IButtonProps) {
+  const { isFullWidth } = props;
+  if (isFullWidth) {
+    return "100%";
+  }
+
+  return "fit-content";
+}
+
+const getSpacing = (props: IButtonProps) => {
+  const { spacing } = props;
+  if (spacing === "compact") {
+    return "28px; min-width: 93px;";
+  }
+  return "36px; min-width: 101px;";
+};
+
+const containerStyles = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: all 0.3s ease;
+  border-radius: 8px;
+  border: none;
+  border-width: 1px;
+  text-decoration: none;
+  font-family: ${typography.ref.typeface.brand};
+  font-size: ${typography.sys.typescale.labelLarge.size};
+  font-weight: ${typography.sys.typescale.labelLarge.weight};
+  line-height: ${typography.sys.typescale.labelLarge.lineHeight};
+  letter-spacing: ${typography.sys.typescale.labelLarge.tracking};
+`;
+
+const StyledErrorButton = styled.button`
+  padding: 0px 16px;
+  background-color: ${(props: IButtonProps) => getBackgroundColor(props)};
+  ${(props: IButtonProps) => console.log(props)}
+  color: ${(props: IButtonProps) => getColor(props)};
+  ${containerStyles}
+  width: ${(props: IButtonProps) => getWidth(props)};
+  height: ${(props: IButtonProps) => getSpacing(props)};
+`;
+
+const StyledSpan = styled.span`
+  display: flex;
+  justify-content: space-between;
+  gap: 4px;
+  overflow: hidden;
+`;
+
+const StyledIcon = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledLink = styled(Link)`
+  width: ${(props: IButtonProps) => getWidth(props)};
+  height: ${(props: IButtonProps) => getSpacing(props)};
+  ${containerStyles};
+`;
+
+export { StyledErrorButton, StyledIcon, StyledSpan, StyledLink };

--- a/src/components/inputs/Button/ButtonError/styles.ts
+++ b/src/components/inputs/Button/ButtonError/styles.ts
@@ -41,6 +41,20 @@ function getWidth(props: IButtonProps) {
   return "fit-content";
 }
 
+const getBorderColor = (props: IButtonProps) => {
+  const { isDisabled, variant } = props;
+
+  if (isDisabled) {
+    return `1px solid ${colors.sys.actions.disabled.stroke}`;
+  }
+
+  if (variant === "none") {
+    return "none";
+  }
+
+  return `1px solid ${colors.sys.actions.remove.filled}`;
+};
+
 const getSpacing = (props: IButtonProps) => {
   const { spacing } = props;
   if (spacing === "compact") {
@@ -66,13 +80,13 @@ const containerStyles = css`
 `;
 
 const StyledErrorButton = styled.button`
+  ${containerStyles}
   padding: 0px 16px;
   background-color: ${(props: IButtonProps) => getBackgroundColor(props)};
-  ${(props: IButtonProps) => console.log(props)}
   color: ${(props: IButtonProps) => getColor(props)};
-  ${containerStyles}
   width: ${(props: IButtonProps) => getWidth(props)};
   height: ${(props: IButtonProps) => getSpacing(props)};
+  border: ${(props: IButtonProps) => getBorderColor(props)};
 `;
 
 const StyledSpan = styled.span`

--- a/src/components/inputs/Button/ButtonPrimary/index.tsx
+++ b/src/components/inputs/Button/ButtonPrimary/index.tsx
@@ -1,0 +1,84 @@
+import { IButtonProps } from "../interfaces/Button.interface";
+import { Variant } from "../types/Button.Variants.type";
+
+import { Spinner } from "@src/components/feedback/Spinner";
+import {
+  StyledPrimaryButton,
+  StyledIcon,
+  StyledSpan,
+  StyledLink,
+} from "./styles";
+
+const getSpinnerColor = (variant: Variant) => {
+  if (variant === "filled") {
+    return "white";
+  } else return "blue";
+};
+
+const defaultSpinnerSize = "small";
+
+const ButtonPrimary = (props: IButtonProps) => {
+  const {
+    children,
+    appearance,
+    isLoading,
+    isDisabled,
+    iconBefore,
+    iconAfter,
+    type,
+    spacing,
+    variant,
+    isFullWidth,
+    handleClick,
+    path,
+  } = props;
+
+  const transformedTransparentSpinner = variant === "filled";
+
+  if (type === "link") {
+    return (
+      <StyledLink
+        to={path}
+        isDisabled={isDisabled}
+        variant={variant}
+        appearance={appearance}
+        isFullWidth={isFullWidth}
+      >
+        <StyledPrimaryButton
+          appearance={appearance}
+          isDisabled={isDisabled}
+          spacing={spacing}
+          variant={variant}
+          isFullWidth={isFullWidth}
+          onClick={handleClick}
+        >
+          <StyledSpan isDisabled={isDisabled} variant={variant}>
+            {iconBefore && <StyledIcon id="mdIcon">{iconBefore}</StyledIcon>}
+            {children}
+            {iconAfter && <StyledIcon id="mdIcon">{iconAfter}</StyledIcon>}
+          </StyledSpan>
+        </StyledPrimaryButton>
+      </StyledLink>
+    );
+  }
+
+  return (
+    <StyledPrimaryButton>
+      {isLoading && !isDisabled ? (
+        <Spinner
+          appearance={getSpinnerColor(variant!)}
+          isTransparent={transformedTransparentSpinner}
+          size={defaultSpinnerSize}
+        />
+      ) : (
+        <StyledSpan isDisabled={isDisabled} variant={variant}>
+          {iconBefore && <StyledIcon id="mdIcon">{iconBefore}</StyledIcon>}
+          {children}
+          {iconAfter && <StyledIcon id="mdIcon">{iconAfter}</StyledIcon>}
+        </StyledSpan>
+      )}
+    </StyledPrimaryButton>
+  );
+};
+
+export { ButtonPrimary };

--- a/src/components/inputs/Button/ButtonPrimary/styles.ts
+++ b/src/components/inputs/Button/ButtonPrimary/styles.ts
@@ -1,0 +1,25 @@
+import { Link } from "react-router-dom";
+import { colors } from "@src/shared/colors/colors";
+import styled from "styled-components";
+
+const StyledPrimaryButton = styled.button`
+  padding: 0px 16px;
+  background-color: ${colors.sys.actions.primary.filled};
+  color: ${colors.ref.palette.neutral.n10};
+`;
+
+const StyledSpan = styled.span`
+  display: flex;
+  justify-content: space-between;
+  gap: 4px;
+  overflow: hidden;
+`;
+
+const StyledIcon = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledLink = styled(Link)``;
+
+export { StyledPrimaryButton, StyledIcon, StyledSpan, StyledLink };

--- a/src/components/inputs/Button/index.tsx
+++ b/src/components/inputs/Button/index.tsx
@@ -1,59 +1,14 @@
-import { StyledButton, StyledSpan, StyledIcon, StyledLink } from "./styles";
-import { Spinner } from "../../feedback/Spinner";
-import { colors } from "../../../shared/colors/colors";
 import { IButtonProps } from "./interfaces/Button.interface";
 import { Appearance, appearances } from "./types/Button.Appearances.type";
 import { Type, types } from "./types/Button.Types.type";
 import { Spacing, spacings } from "./types/Button.Spacings.type";
 import { Variant, variants } from "./types/Button.Variants.type";
-import { SpinnerColorHomologation } from "./types/Button.SpinnerColorHomologation.type";
-import { SpinnerColor } from "./types/Button.SpinnerColor.type";
-
-const fixedColors: { [key: string]: any } = Object.assign(
-  {},
-  colors.sys.actions
-);
-delete fixedColors.disabled;
-
-const spinnerColorHomologation: SpinnerColorHomologation = {
-  filled: {
-    primary: "white",
-    secondary: "dark",
-    confirm: "white",
-    warning: "dark",
-    remove: "white",
-    help: "white",
-  },
-  outlined: {
-    primary: "blue",
-    secondary: "dark",
-    confirm: "green",
-    warning: "yellow",
-    remove: "red",
-    help: "purple",
-  },
-  none: {
-    primary: "blue",
-    secondary: "dark",
-    confirm: "green",
-    warning: "yellow",
-    remove: "red",
-    help: "purple",
-  },
-};
-
-const getSpinnerColor = (
-  variant: Variant,
-  appearance: Appearance
-): SpinnerColor => {
-  return spinnerColorHomologation[variant][appearance] as SpinnerColor;
-};
+import { ButtonUI } from "./interfaz";
 
 const defaultAppearance: Appearance = "primary";
 const defaultType: Type = "button";
 const defaultSpacing: Spacing = "wide";
 const defaultVariant: Variant = "filled";
-const defaultSpinnerSize = "small";
 
 const Button = (props: IButtonProps) => {
   const {
@@ -85,43 +40,10 @@ const Button = (props: IButtonProps) => {
     ? variant
     : defaultVariant;
 
-  const transformedTransparentSpinner = transformedVariant === "filled";
-
   const transformedHandleClick = isDisabled ? null : handleClick;
 
-  if (type === "link" && !path) {
-    console.warn("You must provide a path to use a link button");
-  }
-
-  if (type === "link") {
-    return (
-      <StyledLink
-        to={path}
-        isdisabled={+isDisabled}
-        variant={transformedVariant}
-        appearance={transformedAppearance}
-        isfullwidth={+isFullWidth}
-        onClick={transformedHandleClick}
-      >
-        <StyledButton
-          appearance={transformedAppearance}
-          isDisabled={isDisabled}
-          spacing={transformedSpacing}
-          variant={transformedVariant}
-          isFullWidth={isFullWidth}
-        >
-          <StyledSpan isDisabled={isDisabled} variant={transformedVariant}>
-            {iconBefore && <StyledIcon id="mdIcon">{iconBefore}</StyledIcon>}
-            {children}
-            {iconAfter && <StyledIcon id="mdIcon">{iconAfter}</StyledIcon>}
-          </StyledSpan>
-        </StyledButton>
-      </StyledLink>
-    );
-  }
-
   return (
-    <StyledButton
+    <ButtonUI
       appearance={transformedAppearance}
       isLoading={isLoading}
       isDisabled={isDisabled}
@@ -131,25 +53,11 @@ const Button = (props: IButtonProps) => {
       spacing={transformedSpacing}
       variant={transformedVariant}
       isFullWidth={isFullWidth}
-      onClick={transformedHandleClick}
+      handleClick={transformedHandleClick!}
+      path={path}
     >
-      {isLoading && !isDisabled ? (
-        <Spinner
-          appearance={getSpinnerColor(
-            transformedVariant,
-            transformedAppearance
-          )}
-          isTransparent={transformedTransparentSpinner}
-          size={defaultSpinnerSize}
-        />
-      ) : (
-        <StyledSpan isDisabled={isDisabled} variant={transformedVariant}>
-          {iconBefore && <StyledIcon id="mdIcon">{iconBefore}</StyledIcon>}
-          {children}
-          {iconAfter && <StyledIcon id="mdIcon">{iconAfter}</StyledIcon>}
-        </StyledSpan>
-      )}
-    </StyledButton>
+      {children}
+    </ButtonUI>
   );
 };
 

--- a/src/components/inputs/Button/interfaces/Button.interface.ts
+++ b/src/components/inputs/Button/interfaces/Button.interface.ts
@@ -17,4 +17,5 @@ export interface IButtonProps {
   isFullWidth?: boolean;
   handleClick?: () => void;
   path?: string;
+  buttonRef?: string;
 }

--- a/src/components/inputs/Button/interfaz.tsx
+++ b/src/components/inputs/Button/interfaz.tsx
@@ -1,0 +1,62 @@
+import { IButtonProps } from "./interfaces/Button.interface";
+import { ButtonPrimary } from "./ButtonPrimary";
+import { ErrorButon } from "./ButtonError";
+
+const ButtonUI = (props: IButtonProps) => {
+  const {
+    children,
+    appearance,
+    isLoading,
+    isDisabled,
+    iconBefore,
+    iconAfter,
+    type,
+    spacing,
+    variant,
+    isFullWidth,
+    handleClick,
+    path,
+  } = props;
+
+  if (appearance === "primary") {
+    return (
+      <ButtonPrimary
+        appearance={appearance}
+        isLoading={isLoading}
+        isDisabled={isDisabled}
+        iconBefore={iconBefore}
+        iconAfter={iconAfter}
+        type={type}
+        spacing={spacing}
+        variant={variant}
+        isFullWidth={isFullWidth}
+        handleClick={handleClick}
+        path={path}
+      >
+        {children}
+      </ButtonPrimary>
+    );
+  }
+
+  if (appearance === "remove") {
+    return (
+      <ErrorButon
+        appearance={appearance}
+        isLoading={isLoading}
+        isDisabled={isDisabled}
+        iconBefore={iconBefore}
+        iconAfter={iconAfter}
+        type={type}
+        spacing={spacing}
+        variant={variant}
+        isFullWidth={isFullWidth}
+        handleClick={handleClick}
+        path={path}
+      >
+        {children}
+      </ErrorButon>
+    );
+  }
+};
+
+export { ButtonUI };

--- a/src/components/inputs/Button/stories/Button.Default.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Default.stories.tsx
@@ -40,6 +40,7 @@ Default.args = {
   path: "/privilege",
   iconBefore: <MdAdd />,
   handleClick: () => console.log("clicked from Default-story"),
+  appearance: "remove",
 };
 Default.argTypes = {
   children,


### PR DESCRIPTION
Decouple the <Button /> component by splitting it based on its appearance, in order to improve the maintainability and scalability of the component. It's important to note that this division into subcomponents won't affect the user experience, as only one final <Button /> component will be exported for use.