### PR TITLE
Adjust `<Blanket/>` to eliminate undesirable characteristics

### DIFF
--- a/src/components/feedback/InteractiveModal/index.jsx
+++ b/src/components/feedback/InteractiveModal/index.jsx
@@ -37,63 +37,61 @@ const InteractiveModal = (props) => {
 
   return createPortal(
     <Blanket>
-      <Stack alignItems="center" justifyContent="center">
-        <StyledModal smallScreen={smallScreen}>
-          <Stack direction="column" gap="24px">
-            <Stack direction="column" gap="16px">
-              <Stack alignItems="center" justifyContent="space-between">
-                <Text typo="headlineSmall">{title}</Text>
-                <MdClear size={24} cursor="pointer" onClick={closeModal} />
-              </Stack>
-              {hasActions && <Text typo="titleMedium">{infoTitle}</Text>}
-              {hasLabels
-                ? labels.map(
-                    (field, id) =>
-                      infoData[field.id] && (
-                        <TextField
-                          key={id}
-                          label={field.titleName}
-                          name={field.id}
-                          id={field.id}
-                          placeholder={field.titleName}
-                          value={infoData[field.id]}
-                          isFullWidth={true}
-                          type="text"
-                          size="compact"
-                          readOnly={true}
-                        />
-                      )
-                  )
-                : Object.keys(infoData).map((key, id) => (
-                    <TextField
-                      key={id}
-                      label={key}
-                      name={key}
-                      id={key}
-                      placeholder={key}
-                      value={infoData[key]}
-                      isFullWidth={true}
-                      type="text"
-                      size="compact"
-                      readOnly={true}
-                    />
-                  ))}
+      <StyledModal smallScreen={smallScreen}>
+        <Stack direction="column" gap="24px">
+          <Stack direction="column" gap="16px">
+            <Stack alignItems="center" justifyContent="space-between">
+              <Text typo="headlineSmall">{title}</Text>
+              <MdClear size={24} cursor="pointer" onClick={closeModal} />
             </Stack>
-            {hasActions && (
-              <Stack direction="column" gap="16px">
-                <Text typo="titleMedium">{actionsTitle}</Text>
-                {actions.map((action) => (
-                  <Stack key={action.id} gap="10px">
-                    {typeof action.content === "function"
-                      ? action.content(infoData)
-                      : action.content}
-                  </Stack>
+            {hasActions && <Text typo="titleMedium">{infoTitle}</Text>}
+            {hasLabels
+              ? labels.map(
+                  (field, id) =>
+                    infoData[field.id] && (
+                      <TextField
+                        key={id}
+                        label={field.titleName}
+                        name={field.id}
+                        id={field.id}
+                        placeholder={field.titleName}
+                        value={infoData[field.id]}
+                        isFullWidth={true}
+                        type="text"
+                        size="compact"
+                        readOnly={true}
+                      />
+                    )
+                )
+              : Object.keys(infoData).map((key, id) => (
+                  <TextField
+                    key={id}
+                    label={key}
+                    name={key}
+                    id={key}
+                    placeholder={key}
+                    value={infoData[key]}
+                    isFullWidth={true}
+                    type="text"
+                    size="compact"
+                    readOnly={true}
+                  />
                 ))}
-              </Stack>
-            )}
           </Stack>
-        </StyledModal>
-      </Stack>
+          {hasActions && (
+            <Stack direction="column" gap="16px">
+              <Text typo="titleMedium">{actionsTitle}</Text>
+              {actions.map((action) => (
+                <Stack key={action.id} gap="10px">
+                  {typeof action.content === "function"
+                    ? action.content(infoData)
+                    : action.content}
+                </Stack>
+              ))}
+            </Stack>
+          )}
+        </Stack>
+      </StyledModal>
     </Blanket>,
     node
   );

--- a/src/components/feedback/InteractiveModal/index.jsx
+++ b/src/components/feedback/InteractiveModal/index.jsx
@@ -37,61 +37,63 @@ const InteractiveModal = (props) => {
 
   return createPortal(
     <Blanket>
-      <StyledModal smallScreen={smallScreen}>
-        <Stack direction="column" gap="24px">
-          <Stack direction="column" gap="16px">
-            <Stack alignItems="center" justifyContent="space-between">
-              <Text typo="headlineSmall">{title}</Text>
-              <MdClear size={24} cursor="pointer" onClick={closeModal} />
-            </Stack>
-            {hasActions && <Text typo="titleMedium">{infoTitle}</Text>}
-            {hasLabels
-              ? labels.map(
-                  (field, id) =>
-                    infoData[field.id] && (
-                      <TextField
-                        key={id}
-                        label={field.titleName}
-                        name={field.id}
-                        id={field.id}
-                        placeholder={field.titleName}
-                        value={infoData[field.id]}
-                        isFullWidth={true}
-                        type="text"
-                        size="compact"
-                        readOnly={true}
-                      />
-                    )
-                )
-              : Object.keys(infoData).map((key, id) => (
-                  <TextField
-                    key={id}
-                    label={key}
-                    name={key}
-                    id={key}
-                    placeholder={key}
-                    value={infoData[key]}
-                    isFullWidth={true}
-                    type="text"
-                    size="compact"
-                    readOnly={true}
-                  />
-                ))}
-          </Stack>
-          {hasActions && (
+      <Stack alignItems="center" justifyContent="center">
+        <StyledModal smallScreen={smallScreen}>
+          <Stack direction="column" gap="24px">
             <Stack direction="column" gap="16px">
-              <Text typo="titleMedium">{actionsTitle}</Text>
-              {actions.map((action) => (
-                <Stack key={action.id} gap="10px">
-                  {typeof action.content === "function"
-                    ? action.content(infoData)
-                    : action.content}
-                </Stack>
-              ))}
+              <Stack alignItems="center" justifyContent="space-between">
+                <Text typo="headlineSmall">{title}</Text>
+                <MdClear size={24} cursor="pointer" onClick={closeModal} />
+              </Stack>
+              {hasActions && <Text typo="titleMedium">{infoTitle}</Text>}
+              {hasLabels
+                ? labels.map(
+                    (field, id) =>
+                      infoData[field.id] && (
+                        <TextField
+                          key={id}
+                          label={field.titleName}
+                          name={field.id}
+                          id={field.id}
+                          placeholder={field.titleName}
+                          value={infoData[field.id]}
+                          isFullWidth={true}
+                          type="text"
+                          size="compact"
+                          readOnly={true}
+                        />
+                      )
+                  )
+                : Object.keys(infoData).map((key, id) => (
+                    <TextField
+                      key={id}
+                      label={key}
+                      name={key}
+                      id={key}
+                      placeholder={key}
+                      value={infoData[key]}
+                      isFullWidth={true}
+                      type="text"
+                      size="compact"
+                      readOnly={true}
+                    />
+                  ))}
             </Stack>
-          )}
-        </Stack>
-      </StyledModal>
+            {hasActions && (
+              <Stack direction="column" gap="16px">
+                <Text typo="titleMedium">{actionsTitle}</Text>
+                {actions.map((action) => (
+                  <Stack key={action.id} gap="10px">
+                    {typeof action.content === "function"
+                      ? action.content(infoData)
+                      : action.content}
+                  </Stack>
+                ))}
+              </Stack>
+            )}
+          </Stack>
+        </StyledModal>
+      </Stack>
     </Blanket>,
     node
   );

--- a/src/components/feedback/InteractiveModal/styles.js
+++ b/src/components/feedback/InteractiveModal/styles.js
@@ -4,8 +4,10 @@ import styled from "styled-components";
 const StyledModal = styled.div`
   background-color: ${colors.ref.palette.neutral.n10};
   min-width: ${(props) => (props.smallScreen ? "100%" : "450px")};
-  min-height: ${(props) => (props.smallScreen ? "100%" : "auto")};
+  min-height: ${(props) => (props.smallScreen ? "100vh" : "auto")};
+  height: auto;
   border-radius: ${(props) => (props.smallScreen ? "0" : "8px")};
+
   & > div {
     padding: ${(props) => (props.smallScreen ? "24px" : "32px")};
   }

--- a/src/components/utils/Blanket/index.tsx
+++ b/src/components/utils/Blanket/index.tsx
@@ -1,16 +1,9 @@
-import { Stack } from "@src/components/layouts/Stack";
 import { BlanketProps } from "./interfaces/interface.Blanket";
 import { StyledBlanket } from "./styles";
 
 const Blanket = (props: BlanketProps) => {
   const { children } = props;
-  return (
-    <StyledBlanket>
-      <Stack alignItems="center" justifyContent="center">
-        {children}
-      </Stack>
-    </StyledBlanket>
-  );
+  return <StyledBlanket>{children}</StyledBlanket>;
 };
 
 export { Blanket };

--- a/src/components/utils/Blanket/index.tsx
+++ b/src/components/utils/Blanket/index.tsx
@@ -1,9 +1,19 @@
+import { Stack } from "@src/components/layouts/Stack";
 import { BlanketProps } from "./interfaces/interface.Blanket";
 import { StyledBlanket } from "./styles";
+import { useMediaQuery } from "@src/hooks/useMediaQuery";
 
 const Blanket = (props: BlanketProps) => {
   const { children } = props;
-  return <StyledBlanket>{children}</StyledBlanket>;
+  const isSmallScreen = useMediaQuery("(max-width: 580px)");
+
+  return (
+    <StyledBlanket isSmallScreen={!isSmallScreen}>
+      <Stack alignItems="center" justifyContent="center">
+        {children}
+      </Stack>
+    </StyledBlanket>
+  );
 };
 
 export { Blanket };

--- a/src/components/utils/Blanket/index.tsx
+++ b/src/components/utils/Blanket/index.tsx
@@ -1,9 +1,16 @@
+import { Stack } from "@src/components/layouts/Stack";
 import { BlanketProps } from "./interfaces/interface.Blanket";
 import { StyledBlanket } from "./styles";
 
 const Blanket = (props: BlanketProps) => {
   const { children } = props;
-  return <StyledBlanket>{children}</StyledBlanket>;
+  return (
+    <StyledBlanket>
+      <Stack alignItems="center" justifyContent="center">
+        {children}
+      </Stack>
+    </StyledBlanket>
+  );
 };
 
 export { Blanket };

--- a/src/components/utils/Blanket/styles.ts
+++ b/src/components/utils/Blanket/styles.ts
@@ -2,18 +2,12 @@ import styled from "styled-components";
 import { colors } from "../../../shared/colors/colors";
 
 const StyledBlanket = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: absolute;
-  top: 0%;
-  bottom: 0%;
-  left: 0%;
-  right: 0%;
+  position: fixed;
+  inset: 0;
   background-color: ${colors.ref.palette.neutralAlpha.n100A};
   border: none;
   z-index: 1;
-  overflow: auto;
+  overflow-y: auto;
 `;
 
 export { StyledBlanket };

--- a/src/components/utils/Blanket/styles.ts
+++ b/src/components/utils/Blanket/styles.ts
@@ -3,8 +3,10 @@ import { colors } from "../../../shared/colors/colors";
 
 const StyledBlanket = styled.div`
   position: fixed;
-  display: grid;
-  place-items: center;
+  display: ${(props: { isSmallScreen: string }) =>
+    props.isSmallScreen ? "grid" : "block"};
+  place-items: ${(props: { isSmallScreen: string }) =>
+    props.isSmallScreen ? "center" : "initial"};
   inset: 0;
   background-color: ${colors.ref.palette.neutralAlpha.n100A};
   border: none;

--- a/src/components/utils/Blanket/styles.ts
+++ b/src/components/utils/Blanket/styles.ts
@@ -8,6 +8,8 @@ const StyledBlanket = styled.div`
   border: none;
   z-index: 1;
   overflow-y: auto;
+  display: grid;
+  place-items: center;
 `;
 
 export { StyledBlanket };

--- a/src/components/utils/Blanket/styles.ts
+++ b/src/components/utils/Blanket/styles.ts
@@ -3,13 +3,13 @@ import { colors } from "../../../shared/colors/colors";
 
 const StyledBlanket = styled.div`
   position: fixed;
+  display: grid;
+  place-items: center;
   inset: 0;
   background-color: ${colors.ref.palette.neutralAlpha.n100A};
   border: none;
   z-index: 1;
   overflow-y: auto;
-  display: grid;
-  place-items: center;
 `;
 
 export { StyledBlanket };

--- a/src/hooks/stories/Example.stories.tsx
+++ b/src/hooks/stories/Example.stories.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Switch } from "../../components/inputs/Switch";
-import { SwitchController } from "../../components/inputs/Switch/stories/SwitchController";
+
 import { useMediaQuery } from "../useMediaQuery";
 import { IExampleSwitch } from "./IExampleSwitch.interface";
+import { SwitchController } from "@src/components/inputs/Switch/stories/SwitchController";
 
 const story = {
   title: "hooks/useMediaQuery",
@@ -21,12 +22,21 @@ export const Example = (args: IExampleSwitch) => {
 
   const size = isLargeScreen ? "large" : "small";
 
-  return <SwitchController {...args} size={size} />;
+  return (
+    <SwitchController
+      label={""}
+      margin={"0px"}
+      padding={"0px"}
+      {...args}
+      size={size}
+    />
+  );
 };
 
 Example.args = {
   handleChange: () => {},
   id: "thisIsAnId",
+  label: "",
 };
 
 export default story;


### PR DESCRIPTION
The `<Blanket/>` component is currently cutting off the top of the children-component that is shown inside of it. This is because the `<Blanket/>` component is using the flex and position: absolute properties. To fix this issue, we need to remove the flex and position: absolute properties from the `<Blanket/>` component. This will allow the children-component to be displayed in the correct way.