### PR TITLE
Refactor `<Breadcrumbs />` to decouple paths from text

### DIFF
--- a/src/components/navigation/Breadcrumbs/index.tsx
+++ b/src/components/navigation/Breadcrumbs/index.tsx
@@ -1,59 +1,40 @@
-import { BreadcrumbLink } from "../BreadcrumbLink";
-import { BreadcrumbEllipsis } from "../BreadcrumbEllipsis";
-
-import { useMediaQuery } from "../../../hooks/useMediaQuery";
-
-import { StyledBreadcrumbs } from "./styles";
-import { IBreadcrumbItem } from "./interfaces/Breadcrumbs.Item.interface";
 import { IBreadcrumbsProps } from "./interfaces/Breadcrumbs.interface";
 import { Sizes, sizes } from "./types/Breadcrumb.Size.type";
 
-function getBreadcrumbItems(crumbs: string[]): IBreadcrumbItem[] {
-  const breadcrumbItems = [
-    { id: "Home", path: "/", label: "Home", isActive: false },
-    ...crumbs.map((label, index) => ({
-      path: `/${crumbs
-        .slice(0, index + 1)
-        .join("/")
-        .toLowerCase()}`,
-      label: `${capitalizeString(label)}`,
-      id: `/${crumbs.slice(0, index + 1).join("/")}`,
-      isActive: index === crumbs.length - 1,
-    })),
-  ];
+import { BreadcrumbLink } from "../BreadcrumbLink";
+import { BreadcrumbEllipsis } from "../BreadcrumbEllipsis";
+import { useMediaQuery } from "../../../hooks/useMediaQuery";
 
-  return breadcrumbItems;
-}
+import { StyledBreadcrumbs } from "./styles";
 
 function capitalizeString(string: string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
 const Breadcrumbs = (props: IBreadcrumbsProps) => {
-  const { route } = props;
+  const { crumbs } = props;
 
-  const crumbs = route.split("/").filter((crumb) => crumb !== "");
   const isDesktop = useMediaQuery("(min-width: 768px)");
   const maxCrumbs = isDesktop ? 5 : 3;
-  const breadcrumbItems = getBreadcrumbItems(crumbs);
+
   const transformedSize: Sizes = isDesktop ? sizes[0] : sizes[1];
 
-  if (breadcrumbItems.length > maxCrumbs) {
-    const routesForEllipsis = breadcrumbItems.slice(1, -1);
-    const transformedLastElement = breadcrumbItems[breadcrumbItems.length - 1];
+  if (crumbs.length > maxCrumbs) {
+    //const routesForEllipsis = crumbs.slice(1, -1);
+    const transformedLastElement = crumbs[crumbs.length - 1];
     return (
       <StyledBreadcrumbs>
         <BreadcrumbLink
-          key={breadcrumbItems[0].path}
-          path={breadcrumbItems[0].path}
-          id={breadcrumbItems[0].path}
-          label={breadcrumbItems[0].label}
-          isActive={breadcrumbItems[0].isActive}
+          key={crumbs[0].path}
+          path={crumbs[0].path}
+          id={crumbs[0].path}
+          label={crumbs[0].label}
+          isActive={crumbs[0].isActive}
         />
         <BreadcrumbEllipsis
           key={`breadcrumb-ellipsis`}
           typo={transformedSize}
-          routes={routesForEllipsis}
+          routes={crumbs}
         />
         <BreadcrumbLink
           key={transformedLastElement.path}
@@ -68,12 +49,12 @@ const Breadcrumbs = (props: IBreadcrumbsProps) => {
 
   return (
     <StyledBreadcrumbs>
-      {breadcrumbItems.map(({ path, label, isActive }) => (
+      {crumbs.map(({ path, label, isActive }) => (
         <BreadcrumbLink
           key={path}
           path={path}
           id={path}
-          label={label}
+          label={capitalizeString(label)}
           isActive={isActive}
         />
       ))}

--- a/src/components/navigation/Breadcrumbs/interfaces/Breadcrumbs.interface.ts
+++ b/src/components/navigation/Breadcrumbs/interfaces/Breadcrumbs.interface.ts
@@ -1,3 +1,4 @@
+import { IBreadcrumbItem } from "./Breadcrumbs.Item.interface";
 export interface IBreadcrumbsProps {
-  route: string;
+  crumbs: IBreadcrumbItem[];
 }

--- a/src/components/navigation/Breadcrumbs/stories/Breadcrumbs.Default.stories.tsx
+++ b/src/components/navigation/Breadcrumbs/stories/Breadcrumbs.Default.stories.tsx
@@ -1,6 +1,6 @@
 import { Breadcrumbs } from "../index";
 import { BrowserRouter } from "react-router-dom";
-import { parameters, route } from "./props";
+import { parameters, crumbs } from "./props";
 import { IBreadcrumbsProps } from "../interfaces/Breadcrumbs.interface";
 
 const story = {
@@ -20,10 +20,29 @@ const story = {
 
 export const Default = (args: IBreadcrumbsProps) => <Breadcrumbs {...args} />;
 Default.args = {
-  route: "Privileges/Users",
+  crumbs: [
+    {
+      path: "/home",
+      label: "inicio",
+      id: "/home",
+      isActive: false,
+    },
+    {
+      path: "/home/users",
+      label: "usuarios",
+      id: "/home/users",
+      isActive: false,
+    },
+    {
+      path: "/home/users/invitation",
+      label: "invitación",
+      id: "/home/users/invitation",
+      isActive: true,
+    },
+  ],
 };
 Default.argTypes = {
-  route,
+  crumbs,
 };
 
 export default story;

--- a/src/components/navigation/Breadcrumbs/stories/Breadcrumbs.Desktop.stories.tsx
+++ b/src/components/navigation/Breadcrumbs/stories/Breadcrumbs.Desktop.stories.tsx
@@ -1,6 +1,6 @@
 import { Breadcrumbs } from "../index";
 import { BrowserRouter } from "react-router-dom";
-import { parameters, route } from "./props";
+import { parameters, crumbs } from "./props";
 import { IBreadcrumbsProps } from "../interfaces/Breadcrumbs.interface";
 
 const story = {
@@ -20,10 +20,29 @@ const story = {
 
 export const Desktop = (args: IBreadcrumbsProps) => <Breadcrumbs {...args} />;
 Desktop.args = {
-  route: "Privileges/Users/Edition/Branches/City",
+  crumbs: [
+    {
+      path: "/home",
+      label: "inicio",
+      id: "/home",
+      isActive: false,
+    },
+    {
+      path: "/home/users",
+      label: "usuarios",
+      id: "/home/users",
+      isActive: false,
+    },
+    {
+      path: "/home/users/invitation",
+      label: "invitación",
+      id: "/home/users/invitation",
+      isActive: true,
+    },
+  ],
 };
 Desktop.argTypes = {
-  route,
+  crumbs,
 };
 
 export default story;

--- a/src/components/navigation/Breadcrumbs/stories/Breadcrumbs.Mobile.stories.tsx
+++ b/src/components/navigation/Breadcrumbs/stories/Breadcrumbs.Mobile.stories.tsx
@@ -1,6 +1,6 @@
 import { Breadcrumbs } from "../index";
 import { BrowserRouter } from "react-router-dom";
-import { parameters, route } from "./props";
+import { parameters, crumbs } from "./props";
 import { IBreadcrumbsProps } from "../interfaces/Breadcrumbs.interface";
 
 const story = {
@@ -20,10 +20,29 @@ const story = {
 
 export const Mobile = (args: IBreadcrumbsProps) => <Breadcrumbs {...args} />;
 Mobile.args = {
-  route: "Privileges/Users/Registration",
+  crumbs: [
+    {
+      path: "/home",
+      label: "inicio",
+      id: "/home",
+      isActive: false,
+    },
+    {
+      path: "/home/users",
+      label: "usuarios",
+      id: "/home/users",
+      isActive: false,
+    },
+    {
+      path: "/home/users/invitation",
+      label: "invitación",
+      id: "/home/users/invitation",
+      isActive: true,
+    },
+  ],
 };
 Mobile.argTypes = {
-  route,
+  crumbs,
 };
 
 export default story;

--- a/src/components/navigation/Breadcrumbs/stories/props.ts
+++ b/src/components/navigation/Breadcrumbs/stories/props.ts
@@ -7,10 +7,10 @@ const parameters = {
   },
 };
 
-const route = {
+const crumbs = {
   control: { type: "text" },
   description:
-    "The breadcrumb-component will utilize this route for display, and consequently, it can be employed to locate the source of breadcrumbLinks present within this component.",
+    "An array of objects that contain the path, label, id, and isActive properties.",
 };
 
-export { parameters, route };
+export { parameters, crumbs };


### PR DESCRIPTION
Implements a refactoring of the `<Breadcrumb />` component in order to decouple the path segments from the text displayed in the component. In addition, the ability for the application to display each breadcrumb in Spanish or other languages is enabled.

**BREAKING CHANGE:** This commit generates breaks in the code used by the component