### PR TITLE
Pass default values in stories args

### DIFF
--- a/src/components/data/Icon/index.tsx
+++ b/src/components/data/Icon/index.tsx
@@ -3,15 +3,15 @@ import { StyledIcon } from "./styles";
 
 const Icon = (props: IIconProps) => {
   const {
-    appearance = "primary",
-    cursorHover = false,
-    parentHover = false,
+    appearance,
+    cursorHover,
+    parentHover,
     children,
-    disabled = false,
-    spacing = "wide",
+    disabled,
+    spacing,
     variant,
-    shape = "rectangle",
-    size = "24px",
+    shape,
+    size,
     handleClick,
   } = props;
 

--- a/src/components/data/Icon/stories/Icon.Default.stories.tsx
+++ b/src/components/data/Icon/stories/Icon.Default.stories.tsx
@@ -26,6 +26,13 @@ export const Default = (args: IIconProps) => <Icon {...args} />;
 Default.args = {
   appearance: "primary",
   children: <MdAdb />,
+  cursorHover: false,
+  parentHover: false,
+  disabled: false,
+  spacing: "wide",
+  variant: "none",
+  shape: "rectangle",
+  size: "24px",
   handleClick: () => console.log("clicked from Default Icon-story"),
 };
 

--- a/src/components/feedback/CountdownBar/stories/CountdownBar.Default.stories.tsx
+++ b/src/components/feedback/CountdownBar/stories/CountdownBar.Default.stories.tsx
@@ -26,6 +26,10 @@ const story = {
 export const Default = (args: ICountdownBarProps) => <CountdownBar {...args} />;
 
 Default.args = {
+  size: "4px",
+  appearance: "primary",
+  duration: 3000,
+  isPaused: false,
   handleCountdown: () => console.log("countdown complete."),
 };
 Default.argTypes = {

--- a/src/components/feedback/Spinner/stories/Spinner.All.stories.tsx
+++ b/src/components/feedback/Spinner/stories/Spinner.All.stories.tsx
@@ -48,6 +48,12 @@ export const All = () => (
   </StyledFlex>
 );
 
+All.args = {
+  size: "large",
+  appearance: "blue",
+  isTransparent: false,
+};
+
 All.argTypes = {
   size,
   appearance,

--- a/src/components/feedback/Spinner/stories/Spinner.Colors.stories.tsx
+++ b/src/components/feedback/Spinner/stories/Spinner.Colors.stories.tsx
@@ -5,7 +5,7 @@ import { ISpinnerProps } from "../interfaces/Spinner.interface";
 import { appearances } from "../types/Spinner.Appearance.type";
 import { StyledFlex } from "./styles";
 
-import { parameters, size, isTransparent } from "./props";
+import { parameters, size, isTransparent, appearance } from "./props";
 
 const story = {
   title: "feedback/Spinner",
@@ -18,8 +18,14 @@ const story = {
       </div>
     ),
   ],
+  args: {
+    size: "medium",
+    appearance: "blue",
+    isTransparent: false,
+  },
   argTypes: {
     size,
+    appearance,
     isTransparent,
   },
 };

--- a/src/components/feedback/Spinner/stories/Spinner.Default.stories.tsx
+++ b/src/components/feedback/Spinner/stories/Spinner.Default.stories.tsx
@@ -15,6 +15,11 @@ const story = {
       </div>
     ),
   ],
+  args: {
+    size: "medium",
+    appearance: "blue",
+    isTransparent: false,
+  },
   argTypes: {
     size,
     appearance,

--- a/src/components/feedback/Spinner/stories/Spinner.Sizes.stories.tsx
+++ b/src/components/feedback/Spinner/stories/Spinner.Sizes.stories.tsx
@@ -18,8 +18,11 @@ const story = {
       </div>
     ),
   ],
+  args: {
+    appearance: "blue",
+    isTransparent: false,
+  },
   argTypes: {
-    size,
     appearance,
     isTransparent,
   },

--- a/src/components/feedback/Spinner/stories/Spinner.Transparency.stories.tsx
+++ b/src/components/feedback/Spinner/stories/Spinner.Transparency.stories.tsx
@@ -18,6 +18,11 @@ const story = {
       </div>
     ),
   ],
+  args: {
+    size: "medium",
+    appearance: "blue",
+    isTransparent: false,
+  },
   argTypes: {
     size,
     appearance,

--- a/src/components/inputs/Button/stories/Button.Default.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Default.stories.tsx
@@ -39,8 +39,15 @@ export const Default = (args: IButtonProps) => <Button {...args} />;
 
 Default.args = {
   children: "Button",
+  appearance: "primary",
   path: "/privilege",
   iconBefore: <MdAdd />,
+  isLoading: false,
+  isDisabled: false,
+  type: "button",
+  spacing: "wide",
+  variant: "filled",
+  isFullWidth: false,
   handleClick: () => console.log("clicked from Default-story"),
 };
 Default.argTypes = {

--- a/src/components/inputs/Button/stories/Button.Disabled.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Disabled.stories.tsx
@@ -51,6 +51,7 @@ const ButtonComponent = (props: IButtonProps) => {
 export const Disabled = (args: IButtonProps) => <ButtonComponent {...args} />;
 Disabled.args = {
   children: "Button",
+  appearance: "primary",
   isLoading: false,
   iconBefore: <MdAdd />,
   type: "button",

--- a/src/components/inputs/Label/stories/Label.Default.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.Default.stories.tsx
@@ -22,8 +22,12 @@ const Default = (args: ILabelProps) => {
   return <Label {...args}>{args.children}</Label>;
 };
 Default.args = {
-  htmlFor: "LabelText",
+  htmlFor: "id",
   children: "Label Text",
+  typo: "labelLarge",
+  isDisabled: false,
+  isFocused: false,
+  isInvalid: false,
 };
 Default.argTypes = {
   isDisabled,

--- a/src/components/inputs/Label/stories/Label.Size.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.Size.stories.tsx
@@ -51,7 +51,7 @@ const Size = ({
 };
 
 Size.args = {
-  htmlFor: "LabelText",
+  htmlFor: "id",
   children: "Text Label",
   isDisabled: false,
   isFocused: false,

--- a/src/components/inputs/Select/stories/Select.Default.stories.tsx
+++ b/src/components/inputs/Select/stories/Select.Default.stories.tsx
@@ -43,6 +43,7 @@ Default.args = {
     { id: "3", label: "Item", isDisabled: false },
   ],
   isRequired: false,
+  size: "wide",
   errorMessage: "This field can not be blank",
   isFullWidth: false,
 };

--- a/src/components/inputs/Switch/stories/Switch.Checks.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.Checks.stories.tsx
@@ -52,9 +52,9 @@ const SwitchComponent = (props: ISwitchProps) => {
 
 export const Checks = {
   args: {
-    id: "idValue",
+    id: "id",
     isDisabled: false,
-    name: "nameValue",
+    name: "name",
     checked: false,
     handleChange: () => {},
     margin: "0px",

--- a/src/components/inputs/Switch/stories/Switch.Default.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.Default.stories.tsx
@@ -30,10 +30,10 @@ const story = {
 
 export const Default = (args: ISwitchProps) => <SwitchController {...args} />;
 Default.args = {
-  id: "thisIsAnId",
+  id: "id",
   isDisabled: false,
-  name: "thisIsAName",
-  value: "as",
+  name: "name",
+  value: "switchTest1",
   checked: false,
   size: "small",
   handleChange: () => {},

--- a/src/components/inputs/Switch/stories/Switch.Disabled.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.Disabled.stories.tsx
@@ -39,9 +39,9 @@ const SwitchComponent = (args: ISwitchProps) => {
 
 export const Disabled = {
   args: {
-    id: "idStates",
+    id: "id",
     isDisabled: true,
-    name: "nameState",
+    name: "name",
     handleChange: () => {},
     margin: "0px",
     padding: "0px",

--- a/src/components/inputs/Switch/stories/Switch.Sizes.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.Sizes.stories.tsx
@@ -56,10 +56,10 @@ const SwitchComponent = (args: ISwitchProps) => {
 
 export const Sizes = {
   args: {
-    id: "idSize",
+    id: "id",
     isDisabled: false,
-    name: "nameSize",
-    value: "as",
+    name: "name",
+    value: "switchTest2",
     checked: false,
     handleChange: () => {},
     margin: "0px",

--- a/src/components/inputs/Switch/stories/Switch.WithLabel.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.WithLabel.stories.tsx
@@ -53,9 +53,9 @@ const SwitchComponent = (args: ISwitchProps) => {
 
 export const WithLabel = {
   args: {
-    id: "idValue",
+    id: "id",
     isDisabled: false,
-    name: "nameValue",
+    name: "name",
     checked: false,
     handleChange: () => {},
     label: "Label",

--- a/src/components/inputs/TextArea/stories/TextArea.Default.stories.jsx
+++ b/src/components/inputs/TextArea/stories/TextArea.Default.stories.jsx
@@ -37,6 +37,7 @@ Default.args = {
   label: "TextArea",
   name: "textarea",
   id: "textarea",
+  state: "pending",
   placeholder: "Storybook TextArea",
   isDisabled: false,
   counter: true,

--- a/src/components/inputs/TextField/stories/TextField.Disabled.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Disabled.stories.tsx
@@ -60,6 +60,7 @@ const Disabled = {
     name: "Username",
     id: "Username",
     value: "",
+    type: "text",
     placeholder: "Write your full name",
     maxLength: 10,
     minLength: 1,

--- a/src/components/inputs/TextField/stories/TextField.Required.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Required.stories.tsx
@@ -52,6 +52,7 @@ Required.args = {
   isDisabled: false,
   type: "text",
   state: "pending",
+  size: "wide",
   maxLength: 20,
   minLength: 1,
   max: 10,

--- a/src/components/inputs/TextField/stories/TextField.Search.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Search.stories.tsx
@@ -46,6 +46,7 @@ Search.args = {
   max: 10,
   min: 1,
   size: "wide",
+  type: "text",
   isFullWidth: false,
 };
 

--- a/src/components/inputs/TextField/stories/TextField.Sizes.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Sizes.stories.tsx
@@ -76,6 +76,7 @@ const Size = {
     placeholder: "Write your full name",
     value: "",
     state: "pending",
+    type: "text",
     maxLength: 10,
     minLength: 1,
     errorMessage: "Please enter only letters in this field",

--- a/src/components/inputs/TextField/stories/TextField.Valid.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Valid.stories.tsx
@@ -72,6 +72,9 @@ const Valid = {
     errorMessage: "Please enter only letters in this field",
     validMessage: "Field validation is successful",
     isRequired: true,
+    state: "pending",
+    type: "text",
+    size: "wide",
   },
   render: (args: ITextFieldProps) => <TextFieldComponent {...args} />,
 };

--- a/src/components/layouts/Stack/index.tsx
+++ b/src/components/layouts/Stack/index.tsx
@@ -17,7 +17,7 @@ const Stack = (props: IStackProps) => {
     margin,
     padding,
   } = props;
-  console.log("stack: ", width, transformedMeasure(width));
+
   return (
     <StyledFlex
       direction={direction}

--- a/src/components/layouts/Stack/stories/Stack.Default.stories.tsx
+++ b/src/components/layouts/Stack/stories/Stack.Default.stories.tsx
@@ -27,7 +27,15 @@ export const Default = (args: any) => (
 Default.args = {
   children: [...Array(6 + 1).keys()].slice(1),
   gap: "10px",
+  wrap: "wrap",
+  direction: "row",
+  justifyContent: "unset",
+  alignItems: "initial",
+  alignContent: "unset",
+  height: "100%",
   width: "100%",
+  margin: "0px",
+  padding: "0px",
 };
 
 export default story;

--- a/src/components/navigation/BreadcrumbEllipsis/stories/BreadcrumbEllipsis.Default.stories.tsx
+++ b/src/components/navigation/BreadcrumbEllipsis/stories/BreadcrumbEllipsis.Default.stories.tsx
@@ -37,6 +37,7 @@ Default.args = {
       id: "usersEdition",
     },
   ],
+  size: "large",
 };
 Default.argTypes = {
   routes,

--- a/src/components/navigation/BreadcrumbLink/stories/BreadcrumbLink.Default.stories.tsx
+++ b/src/components/navigation/BreadcrumbLink/stories/BreadcrumbLink.Default.stories.tsx
@@ -35,6 +35,8 @@ Default.args = {
   label: "Privileges",
   path: "/privileges",
   id: "privileges",
+  isActive: false,
+  typo: "large",
 };
 Default.argTypes = {
   id,

--- a/src/components/navigation/BreadcrumbMenuLink/stories/BreadcrumbMenuLink.Default.stories.tsx
+++ b/src/components/navigation/BreadcrumbMenuLink/stories/BreadcrumbMenuLink.Default.stories.tsx
@@ -26,6 +26,7 @@ Default.args = {
   label: "Privileges",
   path: "/privileges",
   id: "privileges",
+  typo: "large",
 };
 Default.argTypes = {
   id,


### PR DESCRIPTION
This PR aims to improve the usability and type inference capabilities of Storybook for our default stories by ensuring that we pass default values for each prop in these stories.

Doing so will allow Storybook to more effectively determine the type of prop, subsequently providing more relevant controls to the end-users. This change will also allow users of our library to glean meaningful information about the prop types, instead of merely seeing generic button labels like "Set boolean" for boolean props.

With this change, we're striving to not only increase the accuracy of prop type detection but also to enhance the overall user experience within our library.