### PR TITLE
Refactor `<Icon />` to use spacing tokens in `margin` & `padding`

### DIFF
--- a/src/components/data/Avatar/index.tsx
+++ b/src/components/data/Avatar/index.tsx
@@ -8,9 +8,7 @@ const Avatar = (props: IAvatarProps) => {
   const { icon = defaultIcon } = props;
 
   return (
-    <Icon appearance="primary" variant="filled" shape="circle">
-      {icon}
-    </Icon>
+    <Icon appearance="primary" variant="filled" shape="circle" icon={icon} />
   );
 };
 

--- a/src/components/data/Icon/styles.ts
+++ b/src/components/data/Icon/styles.ts
@@ -7,8 +7,8 @@ const homologationColorSurfaceTokens: any = inube.color.surface;
 
 const StyledIcon = styled.figure`
   display: inline-block;
-  padding: 0;
-  margin: 0;
+  padding: ${inube.spacing.s0};
+  margin: ${inube.spacing.s0};
 
   border-radius: ${({ shape }: any) => (shape === "circle" ? "50%" : "8px")};
   border-width: ${({ variant }: any) =>


### PR DESCRIPTION
Handling of spacing in styles in the `<Icon />` component. Instead of using fixed values for **margins** and **padding**, **spacing tokens** will now be used, allowing us to maintain consistency throughout the project and facilitating future modifications.