### PR TITLE
Remove decorators in `<Avatar />` stories

### DIFF
--- a/src/components/data/Avatar/stories/Avatar.Default.stories.tsx
+++ b/src/components/data/Avatar/stories/Avatar.Default.stories.tsx
@@ -1,26 +1,14 @@
-import { ElementType } from "react";
-
 import { Avatar } from "../index";
 
-import { parameters, icon } from "./props";
+import { parameters, props } from "./props";
 
 const story = {
   title: "data/Avatar",
   components: [Avatar],
   parameters,
-  decorators: [
-    (Story: ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
+  argTypes: props,
 };
 
 export const Default = () => <Avatar />;
-
-Default.argTypes = {
-  icon,
-};
 
 export default story;

--- a/src/components/data/Avatar/stories/props.ts
+++ b/src/components/data/Avatar/stories/props.ts
@@ -6,11 +6,13 @@ const parameters = {
   },
 };
 
-const icon = {
-  description: "icon that will be displayed inside of avatar-component",
-  table: {
-    defaultValue: { summary: "MdPersonOutline" },
+const props = {
+  icon: {
+    description: "icon that will be displayed inside of avatar-component",
+    table: {
+      defaultValue: { summary: "MdPersonOutline" },
+    },
   },
 };
 
-export { parameters, icon };
+export { parameters, props };


### PR DESCRIPTION
Component history `decorator` removed, this has no impact on library users using the component, as this is a development and display issue in **Storybook**.