### PR TITLE
Refactor `<Icon />` stories

### DIFF
--- a/src/components/data/Icon/stories/Icon.Default.stories.tsx
+++ b/src/components/data/Icon/stories/Icon.Default.stories.tsx
@@ -9,9 +9,7 @@ const story = {
   title: "data/Icon",
   component: Icon,
   decorators: [(Story: React.ElementType) => <Story />],
-  argTypes: {
-    props,
-  },
+  argTypes: props,
 };
 
 export const Default = (args: IIconProps) => <Icon {...args} />;

--- a/src/components/data/Icon/stories/Icon.Default.stories.tsx
+++ b/src/components/data/Icon/stories/Icon.Default.stories.tsx
@@ -2,23 +2,16 @@ import { MdAdb } from "react-icons/md";
 
 import { Icon } from "../index";
 
-import {
-  appearance,
-  cursorHover,
-  parentHover,
-  disabled,
-  spacing,
-  variant,
-  shape,
-  handleClick,
-  size,
-} from "./props";
 import { IIconProps } from "../interfaces/Icon.interface";
+import { props } from "./props";
 
 const story = {
   title: "data/Icon",
   component: Icon,
   decorators: [(Story: React.ElementType) => <Story />],
+  argTypes: {
+    props,
+  },
 };
 
 export const Default = (args: IIconProps) => <Icon {...args} />;
@@ -34,19 +27,6 @@ Default.args = {
   shape: "rectangle",
   size: "24px",
   handleClick: () => console.log("clicked from Default Icon-story"),
-};
-
-Default.argTypes = {
-  appearance,
-  cursorHover,
-  parentHover,
-  icon: { control: "object" },
-  disabled,
-  spacing,
-  variant,
-  shape,
-  handleClick,
-  size,
 };
 
 export default story;

--- a/src/components/data/Icon/stories/props.ts
+++ b/src/components/data/Icon/stories/props.ts
@@ -3,15 +3,15 @@ import { shapes } from "../types/Icon.Shape.type";
 import { spacings } from "../types/Icon.Spacing.type";
 import { variants } from "../types/Icon.Variant.type";
 
-const parameters = {
-  docs: {
-    description: {
-      component: "Icon component is used to display different icons.",
+const props = {
+  parameters: {
+    docs: {
+      description: {
+        component: "Icon component is used to display different icons.",
+      },
     },
   },
-};
 
-const props = {
   appearance: {
     options: Object.keys(inube.color.text),
     control: { type: "select" },
@@ -92,4 +92,4 @@ const props = {
   },
 };
 
-export { parameters, props };
+export { props };

--- a/src/components/data/Icon/stories/props.ts
+++ b/src/components/data/Icon/stories/props.ts
@@ -11,95 +11,85 @@ const parameters = {
   },
 };
 
-const appearance = {
-  options: Object.keys(inube.color.text),
-  control: { type: "select" },
-  description: "the base styling to apply to the icon",
-  table: {
-    defaultValue: { summary: "black" },
+const props = {
+  appearance: {
+    options: Object.keys(inube.color.text),
+    control: { type: "select" },
+    description: "the base styling to apply to the icon",
+    table: {
+      defaultValue: { summary: "black" },
+    },
+  },
+
+  cursorHover: {
+    options: [false, true],
+    control: { type: "boolean" },
+    description: "whether the icon changes upon cursor hover",
+    table: {
+      defaultValue: { summary: false },
+    },
+  },
+
+  parentHover: {
+    options: [false, true],
+    control: { type: "boolean" },
+    description: "whether the icon changes upon its parent hover",
+    table: {
+      defaultValue: { summary: false },
+    },
+  },
+
+  icon: {
+    control: { type: "object" },
+    description: "icon to be displayed inside the Icon component",
+  },
+
+  disabled: {
+    options: [false, true],
+    control: { type: "boolean" },
+    description: "set if the icon is disabled",
+    table: {
+      defaultValue: { summary: false },
+    },
+  },
+
+  spacing: {
+    options: spacings,
+    control: { type: "select" },
+    description: "spacing around the icon",
+    table: {
+      defaultValue: { summary: "wide" },
+    },
+  },
+
+  variant: {
+    options: variants,
+    control: { type: "select" },
+    description: "variant of the icon",
+    table: {
+      defaultValue: { summary: "filled" },
+    },
+  },
+
+  shape: {
+    options: shapes,
+    control: { type: "select" },
+    description: "shape of the icon",
+    table: {
+      defaultValue: { summary: "circle" },
+    },
+  },
+
+  handleClick: {
+    options: ["logState"],
+    control: { type: "func" },
+    description: "function to handle icon click",
+  },
+
+  size: {
+    control: { type: "text" },
+    description: "size of the icon in pixels",
   },
 };
 
-const cursorHover = {
-  options: [false, true],
-  control: { type: "boolean" },
-  description: "whether the icon changes upon cursor hover",
-  table: {
-    defaultValue: { summary: false },
-  },
-};
-
-const parentHover = {
-  options: [false, true],
-  control: { type: "boolean" },
-  description: "whether the icon changes upon its parent hover",
-  table: {
-    defaultValue: { summary: false },
-  },
-};
-
-const icon = {
-  control: { type: "object" },
-  description: "icon to be displayed inside the Icon component",
-};
-
-const disabled = {
-  options: [false, true],
-  control: { type: "boolean" },
-  description: "set if the icon is disabled",
-  table: {
-    defaultValue: { summary: false },
-  },
-};
-
-const spacing = {
-  options: spacings,
-  control: { type: "select" },
-  description: "spacing around the icon",
-  table: {
-    defaultValue: { summary: "wide" },
-  },
-};
-
-const variant = {
-  options: variants,
-  control: { type: "select" },
-  description: "variant of the icon",
-  table: {
-    defaultValue: { summary: "filled" },
-  },
-};
-
-const shape = {
-  options: shapes,
-  control: { type: "select" },
-  description: "shape of the icon",
-  table: {
-    defaultValue: { summary: "circle" },
-  },
-};
-
-const handleClick = {
-  options: ["logState"],
-  control: { type: "func" },
-  description: "function to handle icon click",
-};
-
-const size = {
-  control: { type: "text" },
-  description: "size of the icon in pixels",
-};
-
-export {
-  parameters,
-  appearance,
-  cursorHover,
-  parentHover,
-  icon,
-  disabled,
-  spacing,
-  variant,
-  shape,
-  handleClick,
-  size,
-};
+export { parameters, props };


### PR DESCRIPTION
This PR introduces several changes to the structure and organization of props in our stories/props.ts file and stories setup in Icon.stories.tsx. The purpose of these changes is to make the code more manageable and easier to update or modify in the future.

Props Refactoring
Instead of having one variable per prop in our stories/props.ts, we are transitioning to a more compact design by using just a single variable props. This variable will hold an object where each key corresponds to one prop.

Here's an example of how this should look:

javascript
Copy code
const props = {
  appearance: {},
  cursorHover: {},
}

export {props}
Icon.stories.tsx Reorganization
Moving onto the story creation, we're consolidating all stories into a single file Icon.stories.tsx. For now, we need only two stories.

Import the newly refactored props from ./props.tsx.

In addition, argTypes should now be defined at the story object level, not for each individual story. This means the Default.argTypes definition should be removed.

