### PR TITLE
Remove decorators from `<Icon />` stories

### DIFF
--- a/src/components/data/Icon/stories/Icon.Default.stories.tsx
+++ b/src/components/data/Icon/stories/Icon.Default.stories.tsx
@@ -18,7 +18,6 @@ import { IIconProps } from "../interfaces/Icon.interface";
 const story = {
   title: "data/Icon",
   component: Icon,
-  decorators: [(Story: React.ElementType) => <Story />],
 };
 
 export const Default = (args: IIconProps) => <Icon {...args} />;


### PR DESCRIPTION
This pull request proposes the removal of decorators from the `<Icon />` component stories. We've found that these decorators add complexity while providing limited additional functionality. By removing them, we aim to streamline the code and improve readability, which can facilitate maintenance and future updates.