### PR TITLE
Refactor handleClick in `<Icon />`

### DIFF
--- a/src/components/data/Icon/index.tsx
+++ b/src/components/data/Icon/index.tsx
@@ -12,7 +12,7 @@ const Icon = (props: IIconProps) => {
     variant,
     shape,
     size,
-    handleClick,
+    onClick,
   } = props;
 
   return (
@@ -25,7 +25,7 @@ const Icon = (props: IIconProps) => {
       variant={variant}
       shape={shape}
       size={size}
-      onClick={handleClick}
+      onClick={onClick}
     >
       {icon}
     </StyledIcon>

--- a/src/components/data/Icon/interfaces/Icon.interface.ts
+++ b/src/components/data/Icon/interfaces/Icon.interface.ts
@@ -15,5 +15,5 @@ export interface IIconProps {
   shape?: Shape;
   size?: string;
   theme?: typeof inube;
-  handleClick?: () => void;
+  onClick?: () => void;
 }

--- a/src/components/data/Icon/stories/Icon.Default.stories.tsx
+++ b/src/components/data/Icon/stories/Icon.Default.stories.tsx
@@ -25,7 +25,6 @@ Default.args = {
   variant: "none",
   shape: "rectangle",
   size: "24px",
-  handleClick: () => console.log("clicked from Default Icon-story"),
 };
 
 const theme = {

--- a/src/components/data/Icon/stories/props.ts
+++ b/src/components/data/Icon/stories/props.ts
@@ -80,9 +80,8 @@ const props = {
     },
   },
 
-  handleClick: {
-    options: ["logState"],
-    control: { type: "func" },
+  onClick: {
+    control: { action: "clicked" },
     description: "function to handle icon click",
   },
 


### PR DESCRIPTION
This PR covers the change of the handleClick prop to onClick in the concerned component. The steps followed to perform this refactor include:

- Modification of the component interface to accommodate the new `onClick` prop.
- Re-naming of the `handleClick` prop to `onClick` throughout the component.
- In Default.args, the `handleClick` arg has been removed and is no longer passed.
- The `handleClick` prop has been renamed to `onClick` in props.ts.
- An action {action: "clicked"} has been added for `onClick` in props.ts.

This change streamlines the naming convention across our components, making it easier for developers to understand and use them.