### PR TITLE
Move the props.ts file to `/Icon`

### DIFF
--- a/src/components/data/Icon/props.ts
+++ b/src/components/data/Icon/props.ts
@@ -1,7 +1,7 @@
 import { inube } from "@src/shared/tokens";
-import { shapes } from "../types/Icon.Shape.type";
-import { spacings } from "../types/Icon.Spacing.type";
-import { variants } from "../types/Icon.Variant.type";
+import { shapes } from "./types/Icon.Shape.type";
+import { spacings } from "./types/Icon.Spacing.type";
+import { variants } from "./types/Icon.Variant.type";
 
 const props = {
   parameters: {

--- a/src/components/data/Icon/stories/Icon.Default.stories.tsx
+++ b/src/components/data/Icon/stories/Icon.Default.stories.tsx
@@ -3,7 +3,7 @@ import { MdAdb } from "react-icons/md";
 import { Icon } from "../index";
 
 import { IIconProps } from "../interfaces/Icon.interface";
-import { props } from "./props";
+import { props } from "../props";
 import { presente } from "@src/shared/themes/presente";
 import { ThemeProvider } from "styled-components";
 


### PR DESCRIPTION
This PR aims to alter the file's location. Instead of nesting the file within the `/stories` directory, we've opted to move it up to the `/icon` directory. This improves the file organization and allows for easier access to this particular file. 