### PR TITLE
Remove all decorations applied to story margins

### DIFF
--- a/src/components/data/Table/stories/Pagination.stories.tsx
+++ b/src/components/data/Table/stories/Pagination.stories.tsx
@@ -8,13 +8,6 @@ const story = {
   title: "data/Table/Pagination",
   component: [Pagination],
   argTypes: props,
-  decorators: [
-    (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 const Default = (args: ITableProps) => <PaginationController {...args} />;

--- a/src/components/feedback/CountdownBar/stories/CountdownBar.stories.tsx
+++ b/src/components/feedback/CountdownBar/stories/CountdownBar.stories.tsx
@@ -6,13 +6,6 @@ const story = {
   title: "feedback/CountdownBar",
   components: [CountdownBar],
   argTypes: props,
-  decorators: [
-    (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 export const Default = (args: ICountdownBarProps) => <CountdownBar {...args} />;

--- a/src/components/feedback/InteractiveModal/stories/InteractiveModal.WithActions.stories.jsx
+++ b/src/components/feedback/InteractiveModal/stories/InteractiveModal.WithActions.stories.jsx
@@ -15,13 +15,6 @@ const story = {
   title: "feedback/InteractiveModal",
   components: [InteractiveModal],
   argTypes: props,
-  decorators: [
-    (Story) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 const data = {

--- a/src/components/feedback/InteractiveModal/stories/InteractiveModal.WithLabels.stories.jsx
+++ b/src/components/feedback/InteractiveModal/stories/InteractiveModal.WithLabels.stories.jsx
@@ -9,13 +9,6 @@ const story = {
   title: "feedback/InteractiveModal",
   components: [InteractiveModal],
   argTypes: props,
-  decorators: [
-    (Story) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 const data = {

--- a/src/components/feedback/InteractiveModal/stories/InteractiveModal.stories.jsx
+++ b/src/components/feedback/InteractiveModal/stories/InteractiveModal.stories.jsx
@@ -8,13 +8,6 @@ const story = {
   title: "feedback/InteractiveModal",
   components: [InteractiveModal],
   argTypes: props,
-  decorators: [
-    (Story) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 const data = {

--- a/src/components/feedback/SkeletonIcon/stories/SkeletonIcon.stories.tsx
+++ b/src/components/feedback/SkeletonIcon/stories/SkeletonIcon.stories.tsx
@@ -6,13 +6,6 @@ const story = {
   title: "feedback/SkeletonIcon",
   components: [SkeletonIcon],
   argTypes: props,
-  decorators: [
-    (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 export const Default = (args: ISkeletonIconProps) => <SkeletonIcon {...args} />;

--- a/src/components/feedback/SkeletonLine/stories/SkeletonLine.stories.tsx
+++ b/src/components/feedback/SkeletonLine/stories/SkeletonLine.stories.tsx
@@ -5,13 +5,6 @@ const story = {
   title: "feedback/SkeletonLine",
   components: [SkeletonLine],
   argTypes: props,
-  decorators: [
-    (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
 };
 const Default = (args: ISkeletonLineProps) => <SkeletonLine {...args} />;
 Default.args = {

--- a/src/components/feedback/Spinner/stories/Spinner.All.stories.tsx
+++ b/src/components/feedback/Spinner/stories/Spinner.All.stories.tsx
@@ -1,4 +1,3 @@
-import { ElementType } from "react";
 import { Spinner } from "..";
 import { appearances, props, sizes } from "../props";
 
@@ -8,13 +7,6 @@ const story = {
   title: "feedback/Spinner",
   component: Spinner,
   argTypes: props,
-  decorators: [
-    (Story: ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 export const All = () => (

--- a/src/components/feedback/Spinner/stories/Spinner.Colors.stories.tsx
+++ b/src/components/feedback/Spinner/stories/Spinner.Colors.stories.tsx
@@ -1,5 +1,3 @@
-import { ElementType } from "react";
-
 import { Spinner, ISpinnerProps } from "..";
 import { StyledFlex } from "./styles";
 
@@ -9,13 +7,6 @@ const story = {
   title: "feedback/Spinner",
   component: Spinner,
   argTypes: props,
-  decorators: [
-    (Story: ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
   args: {
     size: "medium",
     appearance: "blue",

--- a/src/components/feedback/Spinner/stories/Spinner.Sizes.stories.tsx
+++ b/src/components/feedback/Spinner/stories/Spinner.Sizes.stories.tsx
@@ -1,5 +1,3 @@
-import { ElementType } from "react";
-
 import { Spinner, ISpinnerProps } from "..";
 import { StyledFlexBetween } from "./styles";
 
@@ -8,13 +6,6 @@ import { props, sizes } from "../props";
 const story = {
   title: "feedback/Spinner",
   component: Spinner,
-  decorators: [
-    (Story: ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
   args: {
     appearance: "blue",
     isTransparent: false,

--- a/src/components/feedback/Spinner/stories/Spinner.Transparency.stories.tsx
+++ b/src/components/feedback/Spinner/stories/Spinner.Transparency.stories.tsx
@@ -1,5 +1,3 @@
-import { ElementType } from "react";
-
 import { Spinner, ISpinnerProps } from "..";
 
 import { StyledFlex } from "./styles";
@@ -9,13 +7,6 @@ import { props } from "../props";
 const story = {
   title: "feedback/Spinner",
   component: Spinner,
-  decorators: [
-    (Story: ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
   args: {
     size: "medium",
     appearance: "blue",

--- a/src/components/feedback/Spinner/stories/Spinner.stories.tsx
+++ b/src/components/feedback/Spinner/stories/Spinner.stories.tsx
@@ -1,4 +1,3 @@
-import { ElementType } from "react";
 import { Spinner, ISpinnerProps } from "..";
 
 import { props } from "../props";
@@ -6,14 +5,6 @@ import { props } from "../props";
 const story = {
   title: "feedback/Spinner",
   component: Spinner,
-
-  decorators: [
-    (Story: ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
   args: {
     size: "medium",
     appearance: "blue",

--- a/src/components/inputs/Button/stories/Button.Appearances.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Appearances.stories.tsx
@@ -14,9 +14,7 @@ const story = {
   decorators: [
     (Story: React.ElementType) => (
       <BrowserRouter>
-        <div style={{ margin: "3em" }}>
-          <Story />
-        </div>
+        <Story />
       </BrowserRouter>
     ),
   ],

--- a/src/components/inputs/Button/stories/Button.Disabled.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Disabled.stories.tsx
@@ -13,9 +13,7 @@ const story = {
   decorators: [
     (Story: React.ElementType) => (
       <BrowserRouter>
-        <div style={{ margin: "3em" }}>
-          <Story />
-        </div>
+        <Story />
       </BrowserRouter>
     ),
   ],

--- a/src/components/inputs/Button/stories/Button.FullWidth.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.FullWidth.stories.tsx
@@ -13,9 +13,7 @@ const story = {
   decorators: [
     (Story: React.ElementType) => (
       <BrowserRouter>
-        <div style={{ margin: "3em" }}>
-          <Story />
-        </div>
+        <Story />
       </BrowserRouter>
     ),
   ],

--- a/src/components/inputs/Button/stories/Button.Icons.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Icons.stories.tsx
@@ -13,9 +13,7 @@ const story = {
   decorators: [
     (Story: React.ElementType) => (
       <BrowserRouter>
-        <div style={{ margin: "3em" }}>
-          <Story />
-        </div>
+        <Story />
       </BrowserRouter>
     ),
   ],

--- a/src/components/inputs/Button/stories/Button.Loading.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Loading.stories.tsx
@@ -12,9 +12,7 @@ const story = {
   decorators: [
     (Story: React.ElementType) => (
       <BrowserRouter>
-        <div style={{ margin: "3em" }}>
-          <Story />
-        </div>
+        <Story />
       </BrowserRouter>
     ),
   ],

--- a/src/components/inputs/Button/stories/Button.Spacing.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Spacing.stories.tsx
@@ -13,9 +13,7 @@ const story = {
   decorators: [
     (Story: React.ElementType) => (
       <BrowserRouter>
-        <div style={{ margin: "3em" }}>
-          <Story />
-        </div>
+        <Story />
       </BrowserRouter>
     ),
   ],

--- a/src/components/inputs/Button/stories/Button.Variants.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Variants.stories.tsx
@@ -13,9 +13,7 @@ const story = {
   decorators: [
     (Story: React.ElementType) => (
       <BrowserRouter>
-        <div style={{ margin: "3em" }}>
-          <Story />
-        </div>
+        <Story />
       </BrowserRouter>
     ),
   ],

--- a/src/components/inputs/Button/stories/Button.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.stories.tsx
@@ -12,9 +12,7 @@ const story = {
   decorators: [
     (Story: React.ElementType) => (
       <BrowserRouter>
-        <div style={{ margin: "3em" }}>
-          <Story />
-        </div>
+        <Story />
       </BrowserRouter>
     ),
   ],

--- a/src/components/inputs/Switch/stories/Switch.Checks.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.Checks.stories.tsx
@@ -7,13 +7,6 @@ import { Stack } from "../../../layouts/Stack";
 const story = {
   title: "inputs/Switch",
   components: [Switch],
-  decorators: [
-    (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
   argTypes: props,
 };
 

--- a/src/components/inputs/Switch/stories/Switch.Disabled.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.Disabled.stories.tsx
@@ -7,13 +7,6 @@ import { Stack } from "../../../layouts/Stack";
 const story = {
   title: "inputs/Switch",
   components: [Switch],
-  decorators: [
-    (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
   argTypes: props,
 };
 const SwitchComponent = (args: ISwitchProps) => {

--- a/src/components/inputs/Switch/stories/Switch.Sizes.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.Sizes.stories.tsx
@@ -7,13 +7,6 @@ import { Stack } from "../../../layouts/Stack";
 const story = {
   title: "inputs/Switch",
   components: [Switch],
-  decorators: [
-    (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
   argTypes: props,
 };
 

--- a/src/components/inputs/Switch/stories/Switch.WithLabel.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.WithLabel.stories.tsx
@@ -8,13 +8,6 @@ import { Stack } from "../../../layouts/Stack";
 const story = {
   title: "inputs/Switch",
   components: [Switch],
-  decorators: [
-    (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
   argTypes: props,
 };
 

--- a/src/components/inputs/Switch/stories/Switch.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.stories.tsx
@@ -7,13 +7,6 @@ const story = {
   title: "inputs/Switch",
   components: [Switch],
   argTypes: props,
-  decorators: [
-    (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 export const Default = (args: ISwitchProps) => <SwitchController {...args} />;

--- a/src/components/layouts/Stack/stories/Stack.stories.tsx
+++ b/src/components/layouts/Stack/stories/Stack.stories.tsx
@@ -1,4 +1,3 @@
-import { ElementType } from "react";
 import { Stack } from "..";
 import { props } from "../props";
 import { Squares } from "./Squares";
@@ -6,13 +5,6 @@ import { Squares } from "./Squares";
 const story = {
   title: "layout/Stack",
   components: [Stack],
-  decorators: [
-    (Story: ElementType) => (
-      <div style={{ margin: "3em", width: "430px" }}>
-        <Story />
-      </div>
-    ),
-  ],
   argTypes: props,
 };
 

--- a/src/components/navigation/BreadcrumbEllipsis/stories/BreadcrumbEllipsis.stories.tsx
+++ b/src/components/navigation/BreadcrumbEllipsis/stories/BreadcrumbEllipsis.stories.tsx
@@ -10,11 +10,9 @@ const story = {
   argTypes: props,
   decorators: [
     (Story: React.ElementType) => (
-      <div style={{ margin: "2em 2em 7em 2em" }}>
-        <BrowserRouter>
-          <Story />
-        </BrowserRouter>
-      </div>
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
     ),
   ],
 };

--- a/src/components/navigation/BreadcrumbLink/stories/BreadcrumbLink.stories.tsx
+++ b/src/components/navigation/BreadcrumbLink/stories/BreadcrumbLink.stories.tsx
@@ -10,11 +10,9 @@ const story = {
   argTypes: props,
   decorators: [
     (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <BrowserRouter>
-          <Story />
-        </BrowserRouter>
-      </div>
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
     ),
   ],
 };

--- a/src/components/navigation/BreadcrumbMenu/stories/BreadcrumbMenu.stories.tsx
+++ b/src/components/navigation/BreadcrumbMenu/stories/BreadcrumbMenu.stories.tsx
@@ -8,11 +8,9 @@ const story = {
   argTypes: props,
   decorators: [
     (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <BrowserRouter>
-          <Story />
-        </BrowserRouter>
-      </div>
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
     ),
   ],
 };

--- a/src/components/navigation/BreadcrumbMenuLink/stories/BreadcrumbMenuLink.stories.tsx
+++ b/src/components/navigation/BreadcrumbMenuLink/stories/BreadcrumbMenuLink.stories.tsx
@@ -9,11 +9,9 @@ const story = {
   argTypes: props,
   decorators: [
     (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <BrowserRouter>
-          <Story />
-        </BrowserRouter>
-      </div>
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
     ),
   ],
 };

--- a/src/components/navigation/Breadcrumbs/stories/Breadcrumbs.Desktop.stories.tsx
+++ b/src/components/navigation/Breadcrumbs/stories/Breadcrumbs.Desktop.stories.tsx
@@ -8,11 +8,9 @@ const story = {
   argTypes: props,
   decorators: [
     (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <BrowserRouter>
-          <Story />
-        </BrowserRouter>
-      </div>
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
     ),
   ],
 };

--- a/src/components/navigation/Breadcrumbs/stories/Breadcrumbs.Mobile.stories.tsx
+++ b/src/components/navigation/Breadcrumbs/stories/Breadcrumbs.Mobile.stories.tsx
@@ -8,11 +8,9 @@ const story = {
   argTypes: props,
   decorators: [
     (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <BrowserRouter>
-          <Story />
-        </BrowserRouter>
-      </div>
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
     ),
   ],
 };

--- a/src/components/navigation/Breadcrumbs/stories/Breadcrumbs.stories.tsx
+++ b/src/components/navigation/Breadcrumbs/stories/Breadcrumbs.stories.tsx
@@ -8,11 +8,9 @@ const story = {
   argTypes: props,
   decorators: [
     (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <BrowserRouter>
-          <Story />
-        </BrowserRouter>
-      </div>
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
     ),
   ],
 };

--- a/src/components/navigation/FullscreenNav/stories/FullscreenNav.WithoutSections.stories.tsx
+++ b/src/components/navigation/FullscreenNav/stories/FullscreenNav.WithoutSections.stories.tsx
@@ -19,11 +19,9 @@ const story = {
   argTypes: props,
   decorators: [
     (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <BrowserRouter>
-          <Story />
-        </BrowserRouter>
-      </div>
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
     ),
   ],
 };

--- a/src/components/navigation/FullscreenNav/stories/FullscreenNav.stories.tsx
+++ b/src/components/navigation/FullscreenNav/stories/FullscreenNav.stories.tsx
@@ -19,11 +19,9 @@ const story = {
   argTypes: props,
   decorators: [
     (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <BrowserRouter>
-          <Story />
-        </BrowserRouter>
-      </div>
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
     ),
   ],
 };

--- a/src/components/navigation/Header/stories/Header.stories.jsx
+++ b/src/components/navigation/Header/stories/Header.stories.jsx
@@ -21,11 +21,9 @@ const story = {
   argTypes: props,
   decorators: [
     (Story) => (
-      <div>
-        <BrowserRouter>
-          <Story />
-        </BrowserRouter>
-      </div>
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
     ),
   ],
 };

--- a/src/components/navigation/NavLink/stories/NavLink.stories.tsx
+++ b/src/components/navigation/NavLink/stories/NavLink.stories.tsx
@@ -12,11 +12,9 @@ const story = {
   argTypes: props,
   decorators: [
     (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <BrowserRouter>
-          <Story />
-        </BrowserRouter>
-      </div>
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
     ),
   ],
 };

--- a/src/components/navigation/Tab/stories/Tab.stories.tsx
+++ b/src/components/navigation/Tab/stories/Tab.stories.tsx
@@ -1,4 +1,3 @@
-import { ElementType } from "react";
 import { Tab, ITabProps } from "../index";
 import { TabController } from "./TabController";
 
@@ -8,13 +7,6 @@ const story = {
   title: "navigation/Tab",
   components: [Tab],
   argTypes: props,
-  decorators: [
-    (Story: ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 export const Default = (args: ITabProps) => <TabController {...args} />;

--- a/src/components/navigation/Tabs/stories/Tabs.Responsive.stories.tsx
+++ b/src/components/navigation/Tabs/stories/Tabs.Responsive.stories.tsx
@@ -7,13 +7,6 @@ const story = {
   title: "navigation/Tabs",
   components: [Tabs],
   argTypes: props,
-  decorators: [
-    (Story: React.ElementType) => (
-      <div>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 export const Responsive = (args: ITabsProps) => (

--- a/src/components/navigation/Tabs/stories/Tabs.stories.tsx
+++ b/src/components/navigation/Tabs/stories/Tabs.stories.tsx
@@ -7,13 +7,6 @@ const story = {
   title: "navigation/Tabs",
   components: [Tabs],
   argTypes: props,
-  decorators: [
-    (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 export const Default = (args: ITabsProps) => <TabsController {...args} />;

--- a/src/hooks/stories/Example.stories.tsx
+++ b/src/hooks/stories/Example.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Switch } from "../../components/inputs/Switch";
 
 import { useMediaQuery } from "../useMediaQuery";
@@ -10,13 +9,6 @@ const story = {
   title: "hooks/useMediaQuery",
   components: [Switch],
   argTypes: props,
-  decorators: [
-    (Story: React.ElementType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 export const Example = (args: IExampleSwitch) => {

--- a/src/hooks/stories/ExampleMediaQueries.stories.tsx
+++ b/src/hooks/stories/ExampleMediaQueries.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useMediaQueries } from "../useMediaQueries";
 import { Text } from "../../components/data/Text";
 import { IArgs } from "./ExampleMediaQueries.interface";
@@ -8,13 +7,6 @@ const story = {
   title: "hooks/useMediaQueries",
   components: [useMediaQueries],
   argTypes: props,
-  decorators: [
-    (Story: React.ComponentType) => (
-      <div style={{ margin: "3em" }}>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 export const ExampleMediaQueries = (args: IArgs) => {


### PR DESCRIPTION
In this PR, the handling of decorators that apply a 3em margin to stories has been optimized. The changes are broken down into two main parts:

- Deletion of Single-Purpose Decorators: Any decorator found to have the sole purpose of applying a 3em margin to a story has been deleted. This ensures a cleaner codebase without redundant features.
- Refactoring of Multi-Purpose Decorators: In cases where a decorator was found to be responsible for applying a 3em margin along with other functionalities, the decorator has been refactored. Specifically, the part that applies the 3em margin has been removed while keeping the other functionalities intact.

These changes aim to simplify the usage of decorators in our stories and adhere to the principle of keeping our code as lean and purpose-driven as possible.