### PR TITLE
Create aliases for main folders in vite.config.ts

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,15 +22,15 @@
       "@src/*": ["./src/*"],
       "@components/*": ["./src/components/*"],
       "@styles/*": ["./src/styles/*"],
-      "@data/*": ["./src/components/data"],
-      "@feedback/*": ["./src/components/feedback"],
-      "@inputs/*": ["./src/components/inputs"],
-      "@layouts/*": ["./src/components/layouts"],
-      "@navigation/*": ["./src/components/navigation"],
-      "@utils/*": ["./src/components/utils"],
-      "@hooks/*": ["./src/hooks"],
-      "@shared/*": ["./src/shared"],
-      "@utilities/*": ["./src/utilities"]
+      "@data/*": ["./src/components/data/*"],
+      "@feedback/*": ["./src/components/feedback/*"],
+      "@inputs/*": ["./src/components/inputs/*"],
+      "@layouts/*": ["./src/components/layouts/*"],
+      "@navigation/*": ["./src/components/navigation/*"],
+      "@utils/*": ["./src/components/utils/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@shared/*": ["./src/shared/*"],
+      "@utilities/*": ["./src/utilities/*"]
     }
   },
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,10 +20,17 @@
     "baseUrl": ".",
     "paths": {
       "@src/*": ["./src/*"],
-      "@mocks/*": ["./src/mocks/*"],
       "@components/*": ["./src/components/*"],
-      "@pages/*": ["./src/pages/*"],
-      "@styles/*": ["./src/styles/*"]
+      "@styles/*": ["./src/styles/*"],
+      "@data/*": ["./src/components/data"],
+      "@feedback/*": ["./src/components/feedback"],
+      "@inputs/*": ["./src/components/inputs"],
+      "@layouts/*": ["./src/components/layouts"],
+      "@navigation/*": ["./src/components/navigation"],
+      "@utils/*": ["./src/components/utils"],
+      "@hooks/*": ["./src/hooks"],
+      "@shared/*": ["./src/shared"],
+      "@utilities/*": ["./src/utilities"]
     }
   },
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,22 @@
 import { resolve } from "path";
-
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import vitesconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@data": resolve(__dirname, "src/data"),
+      "@feedback": resolve(__dirname, "src/feedback"),
+      "@inputs": resolve(__dirname, "src/inputs"),
+      "@layouts": resolve(__dirname, "src/layouts"),
+      "@navigation": resolve(__dirname, "src/navigation"),
+      "@utils": resolve(__dirname, "src/utils"),
+      "@hooks": resolve(__dirname, "src/hooks"),
+      "@shared": resolve(__dirname, "src/shared"),
+      "@utilities": resolve(__dirname, "src/utilities"),
+    },
+  },
   build: {
     lib: {
       entry: resolve(__dirname, "src/index.ts"),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,12 +6,12 @@ import vitesconfigPaths from "vite-tsconfig-paths";
 export default defineConfig({
   resolve: {
     alias: {
-      "@data": resolve(__dirname, "src/data"),
-      "@feedback": resolve(__dirname, "src/feedback"),
-      "@inputs": resolve(__dirname, "src/inputs"),
-      "@layouts": resolve(__dirname, "src/layouts"),
-      "@navigation": resolve(__dirname, "src/navigation"),
-      "@utils": resolve(__dirname, "src/utils"),
+      "@data": resolve(__dirname, "src/components/data"),
+      "@feedback": resolve(__dirname, "src/components/feedback"),
+      "@inputs": resolve(__dirname, "src/components/inputs"),
+      "@layouts": resolve(__dirname, "src/components/layouts"),
+      "@navigation": resolve(__dirname, "src/components/navigation"),
+      "@utils": resolve(__dirname, "src/components/utils"),
       "@hooks": resolve(__dirname, "src/hooks"),
       "@shared": resolve(__dirname, "src/shared"),
       "@utilities": resolve(__dirname, "src/utilities"),


### PR DESCRIPTION
In an effort to streamline our codebase and improve maintainability, this pull request introduces support for aliases, eliminating the need for complex relative paths.

Previously, we had to use cumbersome paths like:

`import { Component } from '../../../../data/Component';`
With this PR, we can now simplify the import to:

`import { Component } from '@data/Component';`
Here are the aliases that have been created:

```
@data
@feedback
@inputs
@layouts
@navigation
@utils
@hooks
@shared
@utilities
```
These changes make the code more readable and easier to maintain, allowing developers to understand and make changes more efficiently.