### PR TITLE
replace all imports for `@feedback`

### DIFF
--- a/src/components/data/Table/DisplayEntry/index.tsx
+++ b/src/components/data/Table/DisplayEntry/index.tsx
@@ -1,4 +1,4 @@
-import { InteractiveModal } from "../../../feedback/InteractiveModal";
+import { InteractiveModal } from "@feedback/InteractiveModal";
 import { useState } from "react";
 import { MdOpenInNew } from "react-icons/md";
 import { IAction } from "../interface";

--- a/src/components/inputs/Button/index.tsx
+++ b/src/components/inputs/Button/index.tsx
@@ -1,5 +1,5 @@
 import { StyledButton, StyledSpan, StyledIcon, StyledLink } from "./styles";
-import { Spinner } from "../../feedback/Spinner";
+import { Spinner } from "@feedback/Spinner";
 import { colors } from "../../../shared/colors/colors";
 import {
   Appearance,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,11 @@ export { Table } from "./components/data/Table";
 export { Icon } from "./components/data/Icon";
 
 // feedback
-export { CountdownBar } from "./components/feedback/CountdownBar";
-export { InteractiveModal } from "./components/feedback/InteractiveModal";
-export { SkeletonIcon } from "./components/feedback/SkeletonIcon";
-export { SkeletonLine } from "./components/feedback/SkeletonLine";
-export { Spinner } from "./components/feedback/Spinner";
+export { CountdownBar } from "@feedback/CountdownBar";
+export { InteractiveModal } from "@feedback/InteractiveModal";
+export { SkeletonIcon } from "@feedback/SkeletonIcon";
+export { SkeletonLine } from "@feedback/SkeletonLine";
+export { Spinner } from "@feedback/Spinner";
 
 //  hooks
 export { useMediaQueries } from "./hooks/useMediaQueries";


### PR DESCRIPTION
In this pull request, we've addressed the need to streamline our codebase by updating the way components are imported from the `/feedback` directory.

Changes:

- Searched throughout the project for all instances where components were imported from `/feedback`.
- Refactored the imports to now use `@feedback/`, aligning with our new import structure.
- Ensured that the refactored imports are consistent and adhere to our coding standards.

These changes are expected to improve maintainability and align the project with our new directory structure. A thorough review of all affected files has been conducted to ensure that there are no breaks in functionality.