### PR TITLE
replace all imports for `@layouts`

### DIFF
--- a/src/components/data/Table/Pagination/index.tsx
+++ b/src/components/data/Table/Pagination/index.tsx
@@ -6,7 +6,7 @@ import {
 } from "react-icons/md";
 
 import { Text } from "../../Text/index";
-import { Stack } from "../../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 import { StyledButton } from "./styles";
 
 export interface IPaginationProps {

--- a/src/components/data/Table/index.tsx
+++ b/src/components/data/Table/index.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 
 import { Pagination } from "./Pagination";
 import { IAction, IBreakpoint, TableUI } from "./interface";
-import { Stack } from "../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 import { ITitle } from "./interface";
 import { IEntry } from "./DisplayEntry";
 

--- a/src/components/data/User/index.tsx
+++ b/src/components/data/User/index.tsx
@@ -1,6 +1,6 @@
 import { Avatar } from "../Avatar";
 import { Text } from "../Text";
-import { Stack } from "../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 import { spacing } from "@src/shared/tokens/spacing/spacing";
 import { Size } from "./props";
 

--- a/src/components/feedback/InteractiveModal/index.jsx
+++ b/src/components/feedback/InteractiveModal/index.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Blanket } from "../../utils/Blanket";
-import { Stack } from "../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 import { Text } from "../../data/Text";
 import { TextField } from "../../inputs/TextField";
 import { useMediaQuery } from "../../../hooks/useMediaQuery";

--- a/src/components/inputs/Label/stories/Label.Size.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.Size.stories.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
 
 import { Label } from "../";
-import { Stack } from "../../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 
 import { TypographyLabel, props, typos } from "../props";
 

--- a/src/components/inputs/Label/stories/Label.State.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.State.stories.tsx
@@ -1,5 +1,5 @@
 import { Label, ILabelProps } from "..";
-import { Stack } from "../../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 
 import { props } from "../props";
 

--- a/src/components/inputs/Switch/index.tsx
+++ b/src/components/inputs/Switch/index.tsx
@@ -1,6 +1,6 @@
 import { MdDone, MdClose } from "react-icons/md";
 
-import { Stack } from "../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 import { Label } from "../Label";
 
 import { StyledContainer, StyledInput, StyledSpan, StyledIcon } from "./styles";

--- a/src/components/inputs/Switch/stories/Switch.Checks.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.Checks.stories.tsx
@@ -3,7 +3,7 @@ import { SwitchController } from "./SwitchController";
 
 import { props } from "../props";
 
-import { Stack } from "../../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 const story = {
   title: "inputs/Switch",
   components: [Switch],

--- a/src/components/inputs/Switch/stories/Switch.Disabled.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.Disabled.stories.tsx
@@ -2,7 +2,7 @@ import { Switch, ISwitchProps } from "..";
 import { SwitchController } from "./SwitchController";
 import { props } from "../props";
 
-import { Stack } from "../../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 
 const story = {
   title: "inputs/Switch",

--- a/src/components/inputs/Switch/stories/Switch.Sizes.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.Sizes.stories.tsx
@@ -2,7 +2,7 @@ import { Switch, ISwitchProps } from "..";
 import { SwitchController } from "./SwitchController";
 import { props, sizes } from "../props";
 
-import { Stack } from "../../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 
 const story = {
   title: "inputs/Switch",

--- a/src/components/inputs/Switch/stories/Switch.WithLabel.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.WithLabel.stories.tsx
@@ -3,7 +3,7 @@ import { Switch, ISwitchProps } from "..";
 import { SwitchController } from "./SwitchController";
 import { props } from "../props";
 
-import { Stack } from "../../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 
 const story = {
   title: "inputs/Switch",

--- a/src/components/inputs/TextField/stories/TextField.Disabled.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Disabled.stories.tsx
@@ -1,7 +1,7 @@
 import { TextField, ITextFieldProps } from "..";
 import { TextFieldController } from "./TextfieldController";
 
-import { Stack } from "../../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 
 import { props, sizes } from "../props";
 

--- a/src/components/inputs/TextField/stories/TextField.Required.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Required.stories.tsx
@@ -1,7 +1,7 @@
 import { TextField, ITextFieldProps } from "..";
 import { TextFieldController } from "./TextfieldController";
 
-import { Stack } from "../../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 
 import { props } from "../props";
 

--- a/src/components/inputs/TextField/stories/TextField.Sizes.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Sizes.stories.tsx
@@ -1,6 +1,6 @@
 import { TextField, ITextFieldProps } from "..";
 import { TextFieldController } from "./TextfieldController";
-import { Stack } from "../../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 
 import { props, sizes } from "../props";
 

--- a/src/components/inputs/TextField/stories/TextField.Valid.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Valid.stories.tsx
@@ -1,6 +1,6 @@
 import { TextField, ITextFieldProps } from "..";
 import { TextFieldController } from "./TextfieldController";
-import { Stack } from "../../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 import { props, sizes } from "../props";
 
 const story = {

--- a/src/components/navigation/BreadcrumbMenu/index.tsx
+++ b/src/components/navigation/BreadcrumbMenu/index.tsx
@@ -1,4 +1,4 @@
-import { Stack } from "../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 import { BreadcrumbMenuLink } from "../BreadcrumbMenuLink";
 import { StyledBreadcrumbMenu } from "./styles";
 

--- a/src/components/navigation/BreadcrumbMenuLink/index.tsx
+++ b/src/components/navigation/BreadcrumbMenuLink/index.tsx
@@ -1,4 +1,4 @@
-import { Stack } from "../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 import { Text } from "../../data/Text";
 
 import { StyledContainerLink, StyledBreadcrumbMenuLink } from "./styles";

--- a/src/components/navigation/FullscreenNav/index.tsx
+++ b/src/components/navigation/FullscreenNav/index.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { createPortal } from "react-dom";
 import { MdMenu, MdClose, MdLogout } from "react-icons/md";
 
-import { Stack } from "../../layouts/Stack/index";
+import { Stack } from "@layouts/Stack/index";
 import { Text } from "../../data/Text";
 import { NavLink } from "../NavLink/index";
 

--- a/src/components/navigation/Header/index.jsx
+++ b/src/components/navigation/Header/index.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import { FullscreenNav } from "../FullscreenNav";
 import { User } from "../../data/User";
-import { Stack } from "../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 import { useMediaQueries } from "../../../hooks/useMediaQueries";
 import { StyledHeader } from "./styles";
 

--- a/src/components/navigation/Nav/index.tsx
+++ b/src/components/navigation/Nav/index.tsx
@@ -2,7 +2,7 @@ import { useLocation } from "react-router-dom";
 import { MdLogout } from "react-icons/md";
 
 import { NavLink } from "../NavLink";
-import { Stack } from "../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 import { Text } from "../../data/Text";
 
 import { StyledNav, StyledFooter, SeparatorLine } from "./styles";

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -3,7 +3,7 @@ import { MdKeyboardArrowDown } from "react-icons/md";
 
 import { Types, types } from "./props";
 import { Tab } from "../Tab";
-import { Stack } from "../../layouts/Stack";
+import { Stack } from "@layouts/Stack";
 import { DropDownMenu } from "../../inputs/DropDownMenu";
 import { StyledTabs, StyledIconWrapper } from "./styles";
 

--- a/src/components/utils/Blanket/index.tsx
+++ b/src/components/utils/Blanket/index.tsx
@@ -1,4 +1,4 @@
-import { Stack } from "@src/components/layouts/Stack";
+import { Stack } from "@layouts/Stack";
 import { StyledBlanket } from "./styles";
 import { useMediaQuery } from "@src/hooks/useMediaQuery";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export { TextArea } from "./components/inputs/TextArea";
 export { TextField } from "./components/inputs/TextField";
 
 // layouts
-export { Stack } from "./components/layouts/Stack";
+export { Stack } from "@layouts/Stack";
 
 // navigation
 export { Breadcrumbs } from "./components/navigation/Breadcrumbs";


### PR DESCRIPTION
This pull request addresses the need to streamline the way we import components within our project. It involves identifying all instances where components are being imported directly from the `/layout` directory and refactoring these imports to use the more convenient and readable `@layout/` alias.

This refactor is expected to enhance readability and maintainability by making the codebase more consistent and easier to navigate. This change is not expected to affect any functionality as it solely involves refactoring of import statements.