### PR TITLE
`Aliases` replace all imports for `@navigation`

### DIFF
--- a/src/components/navigation/BreadcrumbEllipsis/index.tsx
+++ b/src/components/navigation/BreadcrumbEllipsis/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 
-import { BreadcrumbMenu } from "../../navigation/BreadcrumbMenu";
+import { BreadcrumbMenu } from "@navigation/BreadcrumbMenu";
 import { Text } from "@data/Text";
 
 import {

--- a/src/components/navigation/BreadcrumbMenu/index.tsx
+++ b/src/components/navigation/BreadcrumbMenu/index.tsx
@@ -1,5 +1,5 @@
 import { Stack } from "@layouts/Stack";
-import { BreadcrumbMenuLink } from "../BreadcrumbMenuLink";
+import { BreadcrumbMenuLink } from "@navigation/BreadcrumbMenuLink";
 import { StyledBreadcrumbMenu } from "./styles";
 
 export interface IBreadcrumbRoute {

--- a/src/components/navigation/Breadcrumbs/index.tsx
+++ b/src/components/navigation/Breadcrumbs/index.tsx
@@ -1,7 +1,7 @@
-import { useMediaQuery } from "../../../hooks/useMediaQuery";
+import { useMediaQuery } from "@hooks/useMediaQuery";
 
-import { BreadcrumbLink } from "../BreadcrumbLink";
-import { BreadcrumbEllipsis } from "../BreadcrumbEllipsis";
+import { BreadcrumbLink } from "@navigation/BreadcrumbLink";
+import { BreadcrumbEllipsis } from "@navigation/BreadcrumbEllipsis";
 
 import { StyledBreadcrumbs } from "./styles";
 import { Sizes } from "./props";

--- a/src/components/navigation/FullscreenNav/index.tsx
+++ b/src/components/navigation/FullscreenNav/index.tsx
@@ -4,7 +4,7 @@ import { MdMenu, MdClose, MdLogout } from "react-icons/md";
 
 import { Stack } from "@layouts/Stack/index";
 import { Text } from "@data/Text";
-import { NavLink } from "../NavLink/index";
+import { NavLink } from "@navigation/NavLink";
 
 import {
   StyledContDropMenu,

--- a/src/components/navigation/Header/index.jsx
+++ b/src/components/navigation/Header/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { User } from "@data/User";
 import { useMediaQueries } from "@hooks/useMediaQueries";
 import { Stack } from "@layouts/Stack";
-import { FullscreenNav } from "../FullscreenNav";
+import { FullscreenNav } from "@navigation/FullscreenNav";
 import { StyledHeader } from "./styles";
 
 const SMALL_SCREEN = "(min-width: 320px)";

--- a/src/components/navigation/Nav/index.tsx
+++ b/src/components/navigation/Nav/index.tsx
@@ -1,7 +1,7 @@
 import { useLocation } from "react-router-dom";
 import { MdLogout } from "react-icons/md";
 
-import { NavLink } from "../NavLink";
+import { NavLink } from "@navigation/NavLink";
 import { Stack } from "@layouts/Stack";
 import { Text } from "@data/Text";
 

--- a/src/components/navigation/Nav/props.ts
+++ b/src/components/navigation/Nav/props.ts
@@ -1,13 +1,14 @@
-const props = {
-  parameters: {
-    layout: "fullscreen",
-    docs: {
-      description: {
-        component:
-          "A versatile side navigation component, which allows you to nest links",
-      },
+const parameters = {
+  layout: "fullscreen",
+  docs: {
+    description: {
+      component:
+        "A versatile side navigation component, which allows you to nest links",
     },
   },
+};
+
+const props = {
   navigation: {
     description:
       "The primary object that will organize and store the requisite paths for the correct operation of the Nav component is forthcoming and is required",
@@ -18,4 +19,4 @@ const props = {
   },
 };
 
-export { props };
+export { props, parameters };

--- a/src/components/navigation/Nav/stories/Nav.stories.tsx
+++ b/src/components/navigation/Nav/stories/Nav.stories.tsx
@@ -11,11 +11,12 @@ import {
 
 import { Nav, INavProps } from "..";
 
-import { props } from "../props";
+import { props, parameters } from "../props";
 
 const story = {
   title: "navigation/Nav",
   components: [Nav],
+  parameters,
   argTypes: props,
   decorators: [
     (Story: React.ElementType) => (

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { MdKeyboardArrowDown } from "react-icons/md";
 
 import { Types, types } from "./props";
-import { Tab } from "../Tab";
+import { Tab } from "@navigation/Tab";
 import { Stack } from "@layouts/Stack";
 import { DropDownMenu } from "@inputs/DropDownMenu";
 import { StyledTabs, StyledIconWrapper } from "./styles";

--- a/src/components/navigation/Tabs/props.ts
+++ b/src/components/navigation/Tabs/props.ts
@@ -1,15 +1,15 @@
 export const types = ["select", "tabs"] as const;
 export type Types = typeof types[number];
 
-const props = {
-  parameters: {
-    docs: {
-      description: {
-        component:
-          "Use to alternate among related views within the same context",
-      },
+const parameters = {
+  docs: {
+    description: {
+      component: "Use to alternate among related views within the same context",
     },
   },
+};
+
+const props = {
   tabs: {
     control: { type: "func" },
     description:
@@ -43,4 +43,4 @@ const props = {
   },
 };
 
-export { props };
+export { props, parameters };

--- a/src/components/navigation/Tabs/stories/Tabs.Responsive.stories.tsx
+++ b/src/components/navigation/Tabs/stories/Tabs.Responsive.stories.tsx
@@ -1,11 +1,12 @@
 import { Tabs, ITabsProps } from "..";
 import { TabsResponsiveController } from "./TabsResponsiveController";
 
-import { props } from "../props";
+import { props, parameters } from "../props";
 
 const story = {
   title: "navigation/Tabs",
   components: [Tabs],
+  parameters,
   argTypes: props,
 };
 

--- a/src/components/navigation/Tabs/stories/Tabs.stories.tsx
+++ b/src/components/navigation/Tabs/stories/Tabs.stories.tsx
@@ -1,11 +1,12 @@
 import { Tabs, ITabsProps } from "..";
 import { TabsController } from "./TabsController";
 
-import { props } from "../props";
+import { props, parameters } from "../props";
 
 const story = {
   title: "navigation/Tabs",
   components: [Tabs],
+  parameters,
   argTypes: props,
 };
 

--- a/src/components/utils/Blanket/index.tsx
+++ b/src/components/utils/Blanket/index.tsx
@@ -1,4 +1,4 @@
-import { useMediaQuery } from "@src/hooks/useMediaQuery";
+import { useMediaQuery } from "@hooks/useMediaQuery";
 import { Stack } from "@layouts/Stack";
 import { StyledBlanket } from "./styles";
 

--- a/src/components/utils/Blanket/index.tsx
+++ b/src/components/utils/Blanket/index.tsx
@@ -1,6 +1,6 @@
+import { useMediaQuery } from "@src/hooks/useMediaQuery";
 import { Stack } from "@layouts/Stack";
 import { StyledBlanket } from "./styles";
-import { useMediaQuery } from "@src/hooks/useMediaQuery";
 
 export interface BlanketProps {
   children?: React.ReactNode;

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,10 +28,10 @@ export { TextField } from "@inputs/TextField";
 export { Stack } from "@layouts/Stack";
 
 // navigation
-export { Breadcrumbs } from "./components/navigation/Breadcrumbs";
-export { Header } from "./components/navigation/Header";
-export { Nav } from "./components/navigation/Nav";
-export { Tabs } from "./components/navigation/Tabs";
+export { Breadcrumbs } from "@navigation/Breadcrumbs";
+export { Header } from "@navigation/Header";
+export { Nav } from "@navigation/Nav";
+export { Tabs } from "@navigation/Tabs";
 
 // utils
 export { Blanket } from "./components/utils/Blanket";


### PR DESCRIPTION
Refactoring the **imports** of **navigation** module components to use the corresponding **alias**. This aims to improve the readability and organisation of the code, by adopting a more coherent and clear import structure.