### PR TITLE
replace all imports for `@utils`

### DIFF
--- a/src/components/feedback/InteractiveModal/index.jsx
+++ b/src/components/feedback/InteractiveModal/index.jsx
@@ -2,11 +2,11 @@ import React from "react";
 import { createPortal } from "react-dom";
 import { MdClear } from "react-icons/md";
 import PropTypes from "prop-types";
-import { Blanket } from "../../utils/Blanket";
+import { Blanket } from "@utils/Blanket";
 import { Stack } from "@layouts/Stack";
 import { Text } from "@data/Text";
 import { TextField } from "@inputs/TextField";
-import { useMediaQuery } from "../../../hooks/useMediaQuery";
+import { useMediaQuery } from "@hooks/useMediaQuery";
 import { StyledModal } from "./styles";
 
 const InteractiveModal = (props) => {

--- a/src/components/utils/Blanket/index.tsx
+++ b/src/components/utils/Blanket/index.tsx
@@ -1,6 +1,6 @@
 import { Stack } from "@layouts/Stack";
 import { StyledBlanket } from "./styles";
-import { useMediaQuery } from "@src/hooks/useMediaQuery";
+import { useMediaQuery } from "@hooks/useMediaQuery";
 
 export interface BlanketProps {
   children?: React.ReactNode;

--- a/src/hooks/stories/Example.stories.tsx
+++ b/src/hooks/stories/Example.stories.tsx
@@ -1,6 +1,6 @@
 import { Switch } from "@inputs/Switch";
 
-import { useMediaQuery } from "../useMediaQuery";
+import { useMediaQuery } from "@hooks/useMediaQuery";
 import { IExampleSwitch } from "./IExampleSwitch.interface";
 import { SwitchController } from "@inputs/Switch/stories/SwitchController";
 import { props } from "@inputs/Switch/props";

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export { Nav } from "./components/navigation/Nav";
 export { Tabs } from "./components/navigation/Tabs";
 
 // utils
-export { Blanket } from "./components/utils/Blanket";
+export { Blanket } from "@utils/Blanket";
 
 //tokens
 export { inube } from "./shared/tokens/index";


### PR DESCRIPTION
This PR addresses the need to standardize the import paths across our project. All instances where components were imported from `/utils` have been refactored to use the more consistent `@utils/` alias.