### PR TITLE
replace all imports for `@shared`

### DIFF
--- a/src/components/data/Avatar/Avatar.stories.tsx
+++ b/src/components/data/Avatar/Avatar.stories.tsx
@@ -1,6 +1,6 @@
 import { ThemeProvider } from "styled-components";
 
-import { presente } from "@src/shared/themes/presente";
+import { presente } from "@shared/themes/presente";
 import { Avatar, IAvatarProps } from ".";
 
 import { props, parameters } from "./props";

--- a/src/components/data/Icon/Icon.stories.tsx
+++ b/src/components/data/Icon/Icon.stories.tsx
@@ -4,7 +4,7 @@ import { MdAdb } from "react-icons/md";
 import { Icon, IIconProps } from ".";
 
 import { props, parameters } from "./props";
-import { presente } from "@src/shared/themes/presente";
+import { presente } from "@shared/themes/presente";
 
 const story = {
   title: "data/Icon",

--- a/src/components/data/Icon/props.ts
+++ b/src/components/data/Icon/props.ts
@@ -1,4 +1,4 @@
-import { inube } from "@src/shared/tokens";
+import { inube } from "@shared/tokens";
 
 export const shapes = ["circle", "rectangle"] as const;
 export type Shape = typeof shapes[number];

--- a/src/components/data/Icon/styles.ts
+++ b/src/components/data/Icon/styles.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { inube } from "../../../shared/tokens";
+import { inube } from "@shared/tokens";
 import { IIconProps } from ".";
 
 const filledAppearancesWithGrayIcon = ["gray", "light"];

--- a/src/components/data/Table/Pagination/styles.ts
+++ b/src/components/data/Table/Pagination/styles.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { colors } from "../../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 
 const StyledButton = styled.button`
   cursor: pointer;

--- a/src/components/data/Table/stories/styles.ts
+++ b/src/components/data/Table/stories/styles.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { colors } from "../../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 
 const StyledContainerActions = styled.div`
   > svg {

--- a/src/components/data/Table/styles.ts
+++ b/src/components/data/Table/styles.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 
 const StyledTable = styled.table`
   box-sizing: border-box;

--- a/src/components/data/Text/props.ts
+++ b/src/components/data/Text/props.ts
@@ -1,4 +1,4 @@
-import { inube } from "@src/shared/tokens";
+import { inube } from "@shared/tokens";
 
 export const textAlignOptions = ["start", "center", "end", "justify"];
 export type AlignOptions = typeof textAlignOptions[number];

--- a/src/components/data/Text/styles.ts
+++ b/src/components/data/Text/styles.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { inube } from "@src/shared/tokens";
+import { inube } from "@shared/tokens";
 import { ITextProps } from ".";
 
 const StyledText = styled.p`

--- a/src/components/data/User/index.tsx
+++ b/src/components/data/User/index.tsx
@@ -1,7 +1,7 @@
 import { Avatar } from "@data/Avatar";
 import { Text } from "@data/Text";
 import { Stack } from "@layouts/Stack";
-import { spacing } from "@src/shared/tokens/spacing/spacing";
+import { spacing } from "@shared/tokens/spacing/spacing";
 import { Size } from "./props";
 
 export interface IUserProps {

--- a/src/components/data/User/stories/User.stories.tsx
+++ b/src/components/data/User/stories/User.stories.tsx
@@ -2,7 +2,7 @@ import { ThemeProvider } from "styled-components";
 import { User, IUserProps } from "..";
 
 import { props } from "../props";
-import { presente } from "@src/shared/themes/presente";
+import { presente } from "@shared/themes/presente";
 
 const story = {
   title: "data/User",

--- a/src/components/feedback/CountdownBar/index.tsx
+++ b/src/components/feedback/CountdownBar/index.tsx
@@ -1,6 +1,6 @@
 import { AnimationEvent } from "react";
 
-import { inube } from "@src/shared/tokens";
+import { inube } from "@shared/tokens";
 import { StyledCountdownBar } from "./styles";
 import { Appearance } from "./props";
 

--- a/src/components/feedback/CountdownBar/props.ts
+++ b/src/components/feedback/CountdownBar/props.ts
@@ -1,4 +1,4 @@
-import { inube } from "@src/shared/tokens";
+import { inube } from "@shared/tokens";
 
 export type Appearance = keyof typeof inube.color.surface;
 

--- a/src/components/feedback/InteractiveModal/styles.js
+++ b/src/components/feedback/InteractiveModal/styles.js
@@ -1,4 +1,4 @@
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 import styled from "styled-components";
 
 const StyledModal = styled.div`

--- a/src/components/feedback/SkeletonIcon/styles.ts
+++ b/src/components/feedback/SkeletonIcon/styles.ts
@@ -1,6 +1,6 @@
 import styled, { keyframes } from "styled-components";
 
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 import { ISkeletonIconProps } from "./index";
 
 const shimmer = keyframes`

--- a/src/components/feedback/SkeletonLine/styles.ts
+++ b/src/components/feedback/SkeletonLine/styles.ts
@@ -1,6 +1,6 @@
 import styled, { keyframes } from "styled-components";
 
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 import { ISkeletonLineProps } from "./index";
 
 const shimmer = keyframes`

--- a/src/components/feedback/Spinner/stories/styles.ts
+++ b/src/components/feedback/Spinner/stories/styles.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { colors } from "../../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 
 const StyledFlex = styled.div`
   display: flex;

--- a/src/components/feedback/Spinner/styles.ts
+++ b/src/components/feedback/Spinner/styles.ts
@@ -1,7 +1,7 @@
 import styled, { keyframes } from "styled-components";
 import { ISpinnerProps } from "./index";
 
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 
 const colorHomologation: any = {
   blue: colors.ref.palette.blue.b400,

--- a/src/components/inputs/Button/index.tsx
+++ b/src/components/inputs/Button/index.tsx
@@ -1,6 +1,6 @@
 import { StyledButton, StyledSpan, StyledIcon, StyledLink } from "./styles";
 import { Spinner } from "@feedback/Spinner";
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 import {
   Appearance,
   Type,

--- a/src/components/inputs/Button/stories/stories.styles.ts
+++ b/src/components/inputs/Button/stories/stories.styles.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { colors } from "../../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 
 const StyledFlex = styled.div`
   display: flex;

--- a/src/components/inputs/Button/styles.ts
+++ b/src/components/inputs/Button/styles.ts
@@ -1,8 +1,8 @@
 import { Link } from "react-router-dom";
 import styled, { css } from "styled-components";
 
-import { colors } from "../../../shared/colors/colors";
-import { typography } from "../../../shared/typography/typography";
+import { colors } from "@shared/colors/colors";
+import { typography } from "@shared/typography/typography";
 import { IButtonProps } from ".";
 import { Appearance, Variant } from "./props";
 

--- a/src/components/inputs/DropDownItem/styles.js
+++ b/src/components/inputs/DropDownItem/styles.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
-import { colors } from "../../../shared/colors/colors";
-import { typography } from "../../../shared/typography/typography";
+import { colors } from "@shared/colors/colors";
+import { typography } from "@shared/typography/typography";
 
 const getColor = (isDisabled, isSelected) => {
   if (isDisabled) {

--- a/src/components/inputs/DropDownMenu/styled.js
+++ b/src/components/inputs/DropDownMenu/styled.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 
 const StyledDropDownMenu = styled.ul`
   display: flex;

--- a/src/components/inputs/Label/styles.ts
+++ b/src/components/inputs/Label/styles.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components";
-import { typography } from "../../../shared/typography/typography";
-import { colors } from "../../../shared/colors/colors";
+import { typography } from "@shared/typography/typography";
+import { colors } from "@shared/colors/colors";
 
 import { ILabelProps } from "./index";
 

--- a/src/components/inputs/Select/styles.ts
+++ b/src/components/inputs/Select/styles.ts
@@ -1,8 +1,8 @@
 import styled from "styled-components";
 
 import { ISelectInterfaceProps } from "./interface";
-import { colors } from "../../../shared/colors/colors";
-import { typography } from "../../../shared/typography/typography";
+import { colors } from "@shared/colors/colors";
+import { typography } from "@shared/typography/typography";
 
 const sizeOptions = {
   compact: {

--- a/src/components/inputs/Switch/index.tsx
+++ b/src/components/inputs/Switch/index.tsx
@@ -1,10 +1,10 @@
 import { MdDone, MdClose } from "react-icons/md";
 
 import { Stack } from "@layouts/Stack";
-import { Label } from "../Label";
+import { Label } from "@inputs/Label";
 
 import { StyledContainer, StyledInput, StyledSpan, StyledIcon } from "./styles";
-import { transformedMeasure } from "../../../utilities/transformedMeasure";
+import { transformedMeasure } from "@utilities/transformedMeasure";
 import { Size, sizes } from "./props";
 
 export interface ISwitchProps {

--- a/src/components/inputs/Switch/styles.ts
+++ b/src/components/inputs/Switch/styles.ts
@@ -1,7 +1,7 @@
 import { ISwitchProps } from "./index";
 import styled, { css } from "styled-components";
 
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 
 const sizes: any = {
   large: {

--- a/src/components/inputs/TextArea/styles.js
+++ b/src/components/inputs/TextArea/styles.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
-import { colors } from "../../../shared/colors/colors";
-import { typography } from "../../../shared/typography/typography";
+import { colors } from "@shared/colors/colors";
+import { typography } from "@shared/typography/typography";
 
 const getGrid = (label, counter) => {
   if (label && counter) {

--- a/src/components/inputs/TextField/styles.ts
+++ b/src/components/inputs/TextField/styles.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { ITextFieldProps } from ".";
-import { colors } from "../../../shared/colors/colors";
-import { typography } from "../../../shared/typography/typography";
+import { colors } from "@shared/colors/colors";
+import { typography } from "@shared/typography/typography";
 
 const sizeOptions = {
   compact: {

--- a/src/components/layouts/Stack/index.tsx
+++ b/src/components/layouts/Stack/index.tsx
@@ -1,4 +1,4 @@
-import { transformedMeasure } from "@src/utilities/transformedMeasure";
+import { transformedMeasure } from "@utilities/transformedMeasure";
 
 import { StyledFlex } from "./styles";
 import {

--- a/src/components/layouts/Stack/stories/stories.styles.ts
+++ b/src/components/layouts/Stack/stories/stories.styles.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { inube } from "@src/shared/tokens";
+import { inube } from "@shared/tokens";
 
 const StyledSquare = styled.div`
   display: flex;

--- a/src/components/navigation/BreadcrumbEllipsis/styles.ts
+++ b/src/components/navigation/BreadcrumbEllipsis/styles.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 
 const StyledContainerEllipsis = styled.li`
   display: inline-block;

--- a/src/components/navigation/BreadcrumbLink/styles.ts
+++ b/src/components/navigation/BreadcrumbLink/styles.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 import { Link } from "react-router-dom";
 import { IBreadcrumbLinkProps } from "./index";
 

--- a/src/components/navigation/BreadcrumbMenu/styles.ts
+++ b/src/components/navigation/BreadcrumbMenu/styles.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 
 const StyledBreadcrumbMenu = styled.div`
   position: absolute;

--- a/src/components/navigation/BreadcrumbMenuLink/styles.ts
+++ b/src/components/navigation/BreadcrumbMenuLink/styles.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 import { Link } from "react-router-dom";
 
 const StyledContainerLink = styled.li`

--- a/src/components/navigation/Breadcrumbs/index.tsx
+++ b/src/components/navigation/Breadcrumbs/index.tsx
@@ -1,4 +1,4 @@
-import { useMediaQuery } from "../../../hooks/useMediaQuery";
+import { useMediaQuery } from "@hooks/useMediaQuery";
 
 import { BreadcrumbLink } from "../BreadcrumbLink";
 import { BreadcrumbEllipsis } from "../BreadcrumbEllipsis";

--- a/src/components/navigation/FullscreenNav/styles.ts
+++ b/src/components/navigation/FullscreenNav/styles.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 
 const StyledContDropMenu = styled.div`
   position: absolute;

--- a/src/components/navigation/Header/styles.js
+++ b/src/components/navigation/Header/styles.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 
 const StyledHeader = styled.div`
   display: flex;

--- a/src/components/navigation/Nav/styles.ts
+++ b/src/components/navigation/Nav/styles.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 
 const StyledNav = styled.div`
   box-sizing: border-box;

--- a/src/components/navigation/NavLink/styles.ts
+++ b/src/components/navigation/NavLink/styles.ts
@@ -2,8 +2,8 @@ import { INavLinkProps } from ".";
 import styled, { css } from "styled-components";
 import { Link } from "react-router-dom";
 
-import { colors } from "../../../shared/colors/colors";
-import { typography } from "../../../shared/typography/typography";
+import { colors } from "@shared/colors/colors";
+import { typography } from "@shared/typography/typography";
 
 const getGrid = (props: INavLinkProps) => {
   const { icon } = props;

--- a/src/components/navigation/Tab/styles.ts
+++ b/src/components/navigation/Tab/styles.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 import { ITabProps } from ".";
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 
 const StyledTab = styled.li`
   width: fit-content;

--- a/src/components/navigation/Tabs/styles.ts
+++ b/src/components/navigation/Tabs/styles.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 import { ITabsProps } from ".";
 
 const StyledTabs = styled.div`

--- a/src/components/utils/Blanket/index.tsx
+++ b/src/components/utils/Blanket/index.tsx
@@ -1,6 +1,6 @@
 import { Stack } from "@layouts/Stack";
 import { StyledBlanket } from "./styles";
-import { useMediaQuery } from "@src/hooks/useMediaQuery";
+import { useMediaQuery } from "@hooks/useMediaQuery";
 
 export interface BlanketProps {
   children?: React.ReactNode;

--- a/src/components/utils/Blanket/styles.ts
+++ b/src/components/utils/Blanket/styles.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { colors } from "../../../shared/colors/colors";
+import { colors } from "@shared/colors/colors";
 
 const StyledBlanket = styled.div`
   position: fixed;

--- a/src/hooks/stories/Example.stories.tsx
+++ b/src/hooks/stories/Example.stories.tsx
@@ -1,6 +1,6 @@
 import { Switch } from "@inputs/Switch";
 
-import { useMediaQuery } from "../useMediaQuery";
+import { useMediaQuery } from "@hooks/useMediaQuery";
 import { IExampleSwitch } from "./IExampleSwitch.interface";
 import { SwitchController } from "@inputs/Switch/stories/SwitchController";
 import { props } from "@inputs/Switch/props";

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export { Nav } from "./components/navigation/Nav";
 export { Tabs } from "./components/navigation/Tabs";
 
 // utils
-export { Blanket } from "./components/utils/Blanket";
+export { Blanket } from "@utils/Blanket";
 
 //tokens
-export { inube } from "./shared/tokens/index";
+export { inube } from "@shared/tokens/index";

--- a/src/shared/colors/stories/reference/index.jsx
+++ b/src/shared/colors/stories/reference/index.jsx
@@ -9,7 +9,7 @@ import {
   StyledSpanColorName,
 } from "./styles";
 
-import { colors } from "../../colors";
+import { colors } from "@shared/colors/colors";
 
 const CardColor = (props) => {
   const { colorGroupWrap, colorName } = props;

--- a/src/shared/colors/stories/reference/styles.js
+++ b/src/shared/colors/stories/reference/styles.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { colors } from "../../colors";
+import { colors } from "@shared/colors/colors";
 
 const StyledGlobalFlex = styled.div`
   display: flex;

--- a/src/shared/colors/stories/system/index.jsx
+++ b/src/shared/colors/stories/system/index.jsx
@@ -6,7 +6,7 @@ import {
   StyledColor,
   StyledSpan,
 } from "./styles";
-import { colors } from "../../colors";
+import { colors } from "@shared/colors/colors";
 
 function getRefTokenFromHex(value, obj = colors.ref) {
   for (const [key, val] of Object.entries(obj)) {

--- a/src/shared/colors/stories/system/styles.js
+++ b/src/shared/colors/stories/system/styles.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { colors } from "../../colors";
+import { colors } from "@shared/colors/colors";
 
 const StyledTitleCard = styled.div`
   display: flex;

--- a/src/utilities/transformedMeasure.js
+++ b/src/utilities/transformedMeasure.js
@@ -1,4 +1,4 @@
-import { validateBoxModelMeasure } from "../utilities/validateBoxModelMeasure";
+import { validateBoxModelMeasure } from "@utilities/validateBoxModelMeasure";
 
 const transformedMeasure = (valueBoxModel, defaultValue) => {
   if (!valueBoxModel) {


### PR DESCRIPTION
This PR addresses the need to unify the import structure throughout our project. It targets all instances where components are imported from the `/shared` directory and updates them to use the new `@shared/` path.