### PR TITLE
`<Text />`: Refactor type definitions

### DIFF
--- a/src/components/data/Text/index.tsx
+++ b/src/components/data/Text/index.tsx
@@ -5,8 +5,8 @@ import { transformedMeasure } from "../../../utilities/transformedMeasure";
 import {
   AlignOptions,
   HtmlElements,
-  TyposOptions,
-  SizesOptions,
+  TypeOptions,
+  SizeOptions,
   Appearance,
 } from "./props";
 import { StyledText } from "./styles";
@@ -19,8 +19,8 @@ export interface ITextProps extends ComponentPropsWithRef<"p"> {
   as?: HtmlElements;
   appearance: Appearance;
   isDisabled?: boolean;
-  type: TyposOptions;
-  size: SizesOptions;
+  type: TypeOptions;
+  size: SizeOptions;
   cursorHover?: boolean;
   parentHover?: boolean;
   ellipsis?: boolean;

--- a/src/components/data/Text/props.ts
+++ b/src/components/data/Text/props.ts
@@ -21,9 +21,9 @@ export const htmlElements = [
 export type HtmlElements = typeof htmlElements[number];
 
 export const sizes = ["large", "medium", "small"] as const;
-export type SizesOptions = typeof sizes[number];
+export type SizeOptions = typeof sizes[number]; // Renamed to SizeOptions
 
-export type TyposOptions = keyof typeof inube.typography;
+export type TypeOptions = keyof typeof inube.typography; // Renamed to TypeOptions
 
 const typesOptions = Object.keys(inube.typography);
 


### PR DESCRIPTION
In this pull request, we have made the following changes:

- **Updated Type Property:** The type property within the interface was previously using **TyposOptions**. This has been refactored to now utilize the **TypeOptions** type.

- **Renamed SizesOptions:** All instances of **SizesOptions** have been replaced with **SizeOptions** to align with naming conventions and improve readability.

These changes ensure better alignment with our coding standards and enhance code maintainability. Please review and let me know if any additional adjustments are needed.