### PR TITLE
`<Text />`: refactor styles to not nest rules inside functions

### DIFF
--- a/src/components/data/Text/styles.ts
+++ b/src/components/data/Text/styles.ts
@@ -22,27 +22,25 @@ const StyledText = styled.p`
       ? inube.color.text[appearance].regular
       : inube.color.text[appearance].disabled};
 
-  ${({ ellipsis }: ITextProps) =>
-    ellipsis &&
-    `
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  `};
+  white-space: ${({ ellipsis }: ITextProps) => ellipsis && "nowrap"};
+  overflow: ${({ ellipsis }: ITextProps) => ellipsis && "hidden"};
+  text-overflow: ${({ ellipsis }: ITextProps) => ellipsis && "ellipsis"};
 
-  ${({ cursorHover, appearance, disabled }: ITextProps) =>
-    cursorHover &&
-    `
-    cursor: pointer;
-    &:hover {
-      color: ${!disabled && appearance && inube.color.text[appearance].hover};
-    }
-  `};
+  cursor: ${({ cursorHover, parentHover }: ITextProps) =>
+    (cursorHover || parentHover) && "pointer"};
+  &:hover {
+    color: ${({ cursorHover, appearance, disabled }: ITextProps) =>
+      cursorHover &&
+      !disabled &&
+      appearance &&
+      inube.color.text[appearance].hover};
+  }
 
-  ${({ parentHover, appearance, disabled }: ITextProps) =>
+  color: ${({ parentHover, appearance, disabled }: ITextProps) =>
     parentHover &&
-    `cursor: pointer; color: ${
-      !disabled && appearance && inube.color.text[appearance].hover
-    };`}
+    !disabled &&
+    appearance &&
+    inube.color.text[appearance].hover};
 `;
+
 export { StyledText };


### PR DESCRIPTION
We are introducing a slight modification to our code structure within the styles.ts files. The aim is to improve readability and maintain a consistent approach in defining CSS properties.

**Old Approach:**
If a CSS property required a function to determine its value, the entire CSS rule set was wrapped inside the function.

**For example:**
```
  ${({ ellipsis }: ITextProps) =>
    ellipsis &&
    `
    white-space: nowrap;
    overflow: hidden;
    text-overflow: ellipsis;
  `};
```
**New Standard:**
Instead, we'll define each CSS property individually, and if it requires a function to resolve its value, then that specific property will contain the function.

**Modified example:**
```
white-space: ${({ellipsis}) => ellipsis && "nowrap"}
overflow: ${({ellipsis}) => ellipsis && "hidden"}
text-overflow: ${({ellipsis}) => ellipsis && "ellipsis"}
```
By adopting this standard, we avoid cases where functions reverse the dependency and define multiple CSS properties in their return statements. This PR addresses these instances in the styles.ts file, ensuring a cleaner and more predictable code structure.

I recommend reviewing the changes to ensure that the refactoring aligns with our intended pattern and that there are no unintentional side effects.