### PR TITLE
`<Text />`: remove the StyledContainer of the Default story

### DIFF
--- a/src/components/data/Text/Text.stories.tsx
+++ b/src/components/data/Text/Text.stories.tsx
@@ -1,7 +1,5 @@
-import { Text, ITextProps } from "..";
-
-import { StyledContainer } from "./styles";
-import { props, parameters } from "../props";
+import { Text, ITextProps } from ".";
+import { props, parameters } from "./props";
 
 const story = {
   title: "data/Text",
@@ -11,11 +9,7 @@ const story = {
 };
 
 const Default = (args: ITextProps) => {
-  return (
-    <StyledContainer>
-      <Text {...args}>{args.children}</Text>
-    </StyledContainer>
-  );
+  return <Text {...args}>{args.children}</Text>;
 };
 
 Default.args = {

--- a/src/components/data/Text/stories/styles.ts
+++ b/src/components/data/Text/stories/styles.ts
@@ -1,8 +1,0 @@
-import styled from "styled-components";
-
-const StyledContainer = styled.section`
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(50%, 1fr));
-`;
-
-export { StyledContainer };


### PR DESCRIPTION
This pull request addresses the `<Text />` component used in the Default story. We have removed the `StyledContainer` wrapper to streamline the component's presentation and eliminate unnecessary styling layers. This change ensures better clarity and performance for the Default story.