### PR TITLE
Create the `fonts.js` file in Presente theme `/typography` folder

### DIFF
--- a/src/shared/themes/presente/typography/blocks/font.ts
+++ b/src/shared/themes/presente/typography/blocks/font.ts
@@ -1,0 +1,20 @@
+const fonts = [
+  {
+    family: "Roboto",
+    url: "https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu4mxK.woff2",
+    options: {
+      weight: "400",
+      style: "normal",
+    },
+  },
+  {
+    family: "Roboto",
+    url: "https://fonts.gstatic.com/s/roboto/v30/KFOlCnqEu92Fr1MmEU9fBBc4.woff2",
+    options: {
+      weight: "500",
+      style: "normal",
+    },
+  },
+];
+
+export { fonts };

--- a/src/shared/themes/presente/typography/typography.ts
+++ b/src/shared/themes/presente/typography/typography.ts
@@ -3,6 +3,7 @@ import { display } from "./blocks/display";
 import { headline } from "./blocks/headline";
 import { label } from "./blocks/label";
 import { title } from "./blocks/title";
+import { fonts } from "./blocks/font";
 
 const typography = {
   display,
@@ -10,6 +11,7 @@ const typography = {
   title,
   label,
   body,
+  fonts,
 };
 
 export { typography };


### PR DESCRIPTION
This PR introduces a new `fonts.js` file to the `/typography` folder within the Presente theme. This file centralizes our font definitions and ensures a consistent typography experience throughout the theme. 