### PR TITLE
Rename Prop `isPaused` to `paused` in `<CountdownBar />`

### DIFF
--- a/src/components/feedback/CountdownBar/CountdownBar.stories.tsx
+++ b/src/components/feedback/CountdownBar/CountdownBar.stories.tsx
@@ -14,7 +14,7 @@ Default.args = {
   size: "4px",
   appearance: "primary",
   duration: 3000,
-  isPaused: false,
+  paused: false,
   handleCountdown: () => console.log("countdown complete."),
 };
 

--- a/src/components/feedback/CountdownBar/index.tsx
+++ b/src/components/feedback/CountdownBar/index.tsx
@@ -6,7 +6,7 @@ export interface ICountdownBarProps extends Themed {
   size?: string;
   appearance?: Appearance;
   duration?: number;
-  isPaused?: boolean;
+  paused?: boolean;
   handleCountdown?: (e: AnimationEvent<HTMLDivElement>) => void;
 }
 
@@ -20,7 +20,7 @@ const CountdownBar = ({
   size = defaultSize,
   appearance = "primary",
   duration = 3000,
-  isPaused = false,
+  paused = false,
   handleCountdown,
 }: ICountdownBarProps) => {
   const transformedSize = isValidCssPixelMeasure(size) ? size : defaultSize;
@@ -31,7 +31,7 @@ const CountdownBar = ({
       appearance={appearance}
       size={transformedSize}
       duration={duration}
-      isPaused={isPaused}
+      paused={paused}
       onAnimationEnd={handleCountdown}
     />
   );

--- a/src/components/feedback/CountdownBar/props.ts
+++ b/src/components/feedback/CountdownBar/props.ts
@@ -28,7 +28,7 @@ const props = {
       defaultValue: { summary: 1000 },
     },
   },
-  isPaused: {
+  paused: {
     control: { type: "boolean" },
     description: "pause or start the animation",
     table: {

--- a/src/components/feedback/CountdownBar/styles.ts
+++ b/src/components/feedback/CountdownBar/styles.ts
@@ -26,7 +26,7 @@ const StyledCountdownBar = styled.div`
   }};
   animation-fill-mode: forwards;
   animation-play-state: ${(props: ICountdownBarProps) =>
-    props.isPaused ? "paused" : "running"};
+    props.paused ? "paused" : "running"};
 `;
 
 export { StyledCountdownBar };


### PR DESCRIPTION
This PR modifies the `<CountdownBar />` component by renaming the `isPaused` prop to a more concise paused. This change streamlines our prop naming conventions and enhances readability.