### PR TITLE
Remove `isValidCSSPixelMeasure` Function from `<CountdownBar />`

### DIFF
--- a/src/components/feedback/CountdownBar/index.tsx
+++ b/src/components/feedback/CountdownBar/index.tsx
@@ -10,26 +10,18 @@ export interface ICountdownBarProps extends Themed {
   handleCountdown?: (e: AnimationEvent<HTMLDivElement>) => void;
 }
 
-const defaultSize = "4px";
-
-const isValidCssPixelMeasure = (size: string): boolean => {
-  return /^[0-9]+px$/.test(size);
-};
-
 const CountdownBar = ({
-  size = defaultSize,
+  size = "4px",
   appearance = "primary",
   duration = 3000,
   isPaused = false,
   handleCountdown,
 }: ICountdownBarProps) => {
-  const transformedSize = isValidCssPixelMeasure(size) ? size : defaultSize;
-
   return (
     <StyledCountdownBar
       id="progress-bar"
       appearance={appearance}
-      size={transformedSize}
+      size={size}
       duration={duration}
       isPaused={isPaused}
       onAnimationEnd={handleCountdown}


### PR DESCRIPTION
In this PR, the `isValidCSSPixelMeasure` function has been deleted from the `<CountdownBar />` component. This function was identified as redundant or no longer needed in our current implementation. Kindly review the changes to ensure that the component's behavior remains unaffected and consistent with our expectations.

