### PR TITLE
Rename Prop `handleCountdown` to `onCountdown` in `<CountdownBar />`

### DIFF
--- a/src/components/feedback/CountdownBar/CountdownBar.stories.tsx
+++ b/src/components/feedback/CountdownBar/CountdownBar.stories.tsx
@@ -15,7 +15,7 @@ Default.args = {
   appearance: "primary",
   duration: 3000,
   isPaused: false,
-  handleCountdown: () => console.log("countdown complete."),
+  onCountdown: () => console.log("countdown complete."),
 };
 
 export default story;

--- a/src/components/feedback/CountdownBar/index.tsx
+++ b/src/components/feedback/CountdownBar/index.tsx
@@ -7,7 +7,7 @@ export interface ICountdownBarProps extends Themed {
   appearance?: Appearance;
   duration?: number;
   isPaused?: boolean;
-  handleCountdown?: (e: AnimationEvent<HTMLDivElement>) => void;
+  onCountdown?: (e: AnimationEvent<HTMLDivElement>) => void;
 }
 
 const defaultSize = "4px";
@@ -21,7 +21,7 @@ const CountdownBar = ({
   appearance = "primary",
   duration = 3000,
   isPaused = false,
-  handleCountdown,
+  onCountdown,
 }: ICountdownBarProps) => {
   const transformedSize = isValidCssPixelMeasure(size) ? size : defaultSize;
 
@@ -32,7 +32,7 @@ const CountdownBar = ({
       size={transformedSize}
       duration={duration}
       isPaused={isPaused}
-      onAnimationEnd={handleCountdown}
+      onAnimationEnd={onCountdown}
     />
   );
 };

--- a/src/components/feedback/CountdownBar/props.ts
+++ b/src/components/feedback/CountdownBar/props.ts
@@ -35,7 +35,7 @@ const props = {
       defaultValue: { summary: false },
     },
   },
-  handleCountdown: {
+  onCountdown: {
     description: "function to be executed when the progress bar reaches zero",
   },
 };


### PR DESCRIPTION
This PR focuses on renaming the `handleCountdown` prop in the `<CountdownBar />` component to `onCountdown`, which aligns better with conventional naming patterns for event handlers. 