### PR TITLE
Remove the defaultSize variable and assing the default in `<User />`

### DIFF
--- a/src/components/data/User/User.stories.tsx
+++ b/src/components/data/User/User.stories.tsx
@@ -1,12 +1,13 @@
 import { ThemeProvider } from "styled-components";
 import { User, IUserProps } from ".";
 
-import { props } from "./props";
+import { props, parameters } from "./props";
 import { presente } from "@shared/themes/presente";
 
 const story = {
   title: "data/User",
   components: [User],
+  parameters,
   argTypes: props,
 };
 

--- a/src/components/data/User/index.tsx
+++ b/src/components/data/User/index.tsx
@@ -10,10 +10,8 @@ export interface IUserProps {
   size: Size;
 }
 
-const defaultSize = "large";
-
 const User = (props: IUserProps) => {
-  const { userName, client, size = defaultSize } = props;
+  const { userName, client, size = "large" } = props;
 
   return (
     <Stack justifyContent="flex-start" alignItems="center" gap={spacing.s200}>

--- a/src/components/data/User/props.ts
+++ b/src/components/data/User/props.ts
@@ -1,6 +1,15 @@
 export const sizes = ["small", "large"] as const;
 export type Size = typeof sizes[number];
 
+const parameters = {
+  docs: {
+    description: {
+      component:
+        "Component that allows the user to identify himself and locate himself next to the business unit",
+    },
+  },
+};
+
 const props = {
   userName: {
     description: "shall be the displayed username",
@@ -25,4 +34,4 @@ const props = {
   },
 };
 
-export { props };
+export { props, parameters };


### PR DESCRIPTION
Instead of using the `"defaultSize"` variable, remove this variable and assign the default value directly in the `<User /> `component. This ensures that the default size is handled directly in the component instead of relying on an external variable. By doing so, you will simplify the code and make the default settings clearer and easier to understand.