### PR TITLE
Not use a variable to store default values in `<SkeletonLine />`

### DIFF
--- a/src/components/feedback/SkeletonLine/index.tsx
+++ b/src/components/feedback/SkeletonLine/index.tsx
@@ -8,12 +8,7 @@ export interface ISkeletonLineProps {
 const SkeletonLine = (props: ISkeletonLineProps) => {
   const { width = "100%", isAnimated = false } = props;
 
-  const transformedIsAnimated =
-    typeof isAnimated === "boolean" ? isAnimated : false;
-
-  return (
-    <StyledSkeletonLine width={width} isAnimated={transformedIsAnimated} />
-  );
+  return <StyledSkeletonLine width={width} isAnimated={isAnimated} />;
 };
 
 export { SkeletonLine };

--- a/src/components/feedback/SkeletonLine/props.ts
+++ b/src/components/feedback/SkeletonLine/props.ts
@@ -1,12 +1,12 @@
-const props = {
-  parameters: {
-    docs: {
-      description: {
-        component:
-          "Skeleton line is used to provide a low fidelity representation of content before it appears on the page, and improves load times perceived by users.",
-      },
+const parameters = {
+  docs: {
+    description: {
+      component:
+        "Skeleton line is used to provide a low fidelity representation of content before it appears on the page, and improves load times perceived by users.",
     },
   },
+};
+const props = {
   width: {
     description: "indicates the width that the component should take",
     table: {
@@ -21,4 +21,4 @@ const props = {
   },
 };
 
-export { props };
+export { props, parameters };

--- a/src/components/feedback/SkeletonLine/stories/SkeletonLine.stories.tsx
+++ b/src/components/feedback/SkeletonLine/stories/SkeletonLine.stories.tsx
@@ -1,9 +1,10 @@
 import { SkeletonLine, ISkeletonLineProps } from "..";
-import { props } from "../props";
+import { props, parameters } from "../props";
 
 const story = {
   title: "feedback/SkeletonLine",
   components: [SkeletonLine],
+  parameters,
   argTypes: props,
 };
 const Default = (args: ISkeletonLineProps) => <SkeletonLine {...args} />;


### PR DESCRIPTION
avoids the creation of variables that hold the default value of the **component** to check the value of the property. This is because by using **TypeScript**, which allows us to perform typing, we can ensure that the component will be given the correct value.