### PR TITLE
`<SkeletonLine />`: rename `isAnimated` prop for just `animated`

### DIFF
--- a/src/components/feedback/SkeletonLine/index.tsx
+++ b/src/components/feedback/SkeletonLine/index.tsx
@@ -2,18 +2,13 @@ import { StyledSkeletonLine } from "./styles";
 
 export interface ISkeletonLineProps {
   width?: string;
-  isAnimated?: boolean;
+  animated?: boolean;
 }
 
 const SkeletonLine = (props: ISkeletonLineProps) => {
-  const { width = "100%", isAnimated = false } = props;
+  const { width = "100%", animated = false } = props;
 
-  const transformedIsAnimated =
-    typeof isAnimated === "boolean" ? isAnimated : false;
-
-  return (
-    <StyledSkeletonLine width={width} isAnimated={transformedIsAnimated} />
-  );
+  return <StyledSkeletonLine width={width} animated={animated} />;
 };
 
 export { SkeletonLine };

--- a/src/components/feedback/SkeletonLine/props.ts
+++ b/src/components/feedback/SkeletonLine/props.ts
@@ -13,7 +13,7 @@ const props = {
       defaultValue: { summary: "100px" },
     },
   },
-  isAnimated: {
+  animated: {
     description: "enable loading effect animation",
     table: {
       defaultValue: { summary: false },

--- a/src/components/feedback/SkeletonLine/stories/SkeletonLine.stories.tsx
+++ b/src/components/feedback/SkeletonLine/stories/SkeletonLine.stories.tsx
@@ -9,7 +9,7 @@ const story = {
 const Default = (args: ISkeletonLineProps) => <SkeletonLine {...args} />;
 Default.args = {
   width: "100%",
-  isAnimated: false,
+  animated: false,
 };
 
 export default story;

--- a/src/components/feedback/SkeletonLine/styles.ts
+++ b/src/components/feedback/SkeletonLine/styles.ts
@@ -33,8 +33,8 @@ const StyledSkeletonLine = styled.div`
       ${colors.ref.palette.neutralAlpha.n20A} 50%,
       ${colors.ref.palette.neutralAlpha.n0A} 80%
     );
-    animation: ${({ isAnimated }: ISkeletonLineProps) => isAnimated && shimmer}
-      2s linear infinite;
+    animation: ${({ animated }: ISkeletonLineProps) => animated && shimmer} 2s
+      linear infinite;
   }
 `;
 


### PR DESCRIPTION
This PR makes a modification to the `<SkeletonLine />` component by renaming the `isAnimated` prop to the more succinct `animated`. This change is part of an effort to streamline our prop naming conventions and enhance code readability.