### PR TITLE
Rename props `isTransparent` to `transparent` in `<Spinner />`

### DIFF
--- a/src/components/feedback/Spinner/Spinner.stories.tsx
+++ b/src/components/feedback/Spinner/Spinner.stories.tsx
@@ -8,7 +8,7 @@ const story = {
   args: {
     size: "medium",
     appearance: "blue",
-    isTransparent: false,
+    transparent: false,
   },
   argTypes: props,
 };

--- a/src/components/feedback/Spinner/index.tsx
+++ b/src/components/feedback/Spinner/index.tsx
@@ -29,7 +29,7 @@ const Spinner = (props: ISpinnerProps) => {
     <StyledSpinner
       appearance={transformedAppearance}
       size={transformedSize}
-      isTransparent={transformedIsTransparent}
+      transparent={transformedIsTransparent}
     />
   );
 };

--- a/src/components/feedback/Spinner/index.tsx
+++ b/src/components/feedback/Spinner/index.tsx
@@ -4,7 +4,7 @@ import { StyledSpinner } from "./styles";
 export interface ISpinnerProps {
   size: Size;
   appearance: Appearance;
-  isTransparent: boolean;
+  transparent: boolean;
 }
 
 const defaultAppearance = "blue";
@@ -15,7 +15,7 @@ const Spinner = (props: ISpinnerProps) => {
   const {
     size = defaultSize,
     appearance = defaultAppearance,
-    isTransparent = defaultTransparent,
+    transparent = defaultTransparent,
   } = props;
 
   const transformedSize = sizes.includes(size) ? size : defaultSize;
@@ -23,7 +23,7 @@ const Spinner = (props: ISpinnerProps) => {
     ? appearance
     : defaultAppearance;
   const transformedIsTransparent =
-    typeof isTransparent === "boolean" ? isTransparent : defaultTransparent;
+    typeof transparent === "boolean" ? transparent : defaultTransparent;
 
   return (
     <StyledSpinner

--- a/src/components/feedback/Spinner/props.ts
+++ b/src/components/feedback/Spinner/props.ts
@@ -38,7 +38,7 @@ const props = {
       defaultValue: { summary: "blue" },
     },
   },
-  isTransparent: {
+  transparent: {
     options: [true, false],
     control: { type: "boolean" },
     description:

--- a/src/components/feedback/Spinner/styles.ts
+++ b/src/components/feedback/Spinner/styles.ts
@@ -42,7 +42,7 @@ const StyledSpinner = styled.div`
   animation: 0.8s linear infinite ${spinner};
   border: solid 4px
     ${(props: ISpinnerProps) =>
-      props.isTransparent === true
+      props.transparent === true
         ? colors.ref.palette.neutralAlpha.n0A
         : colors.ref.palette.neutral.n30};
   border-bottom-color: ${(props: ISpinnerProps) =>

--- a/src/components/inputs/Button/index.tsx
+++ b/src/components/inputs/Button/index.tsx
@@ -170,7 +170,7 @@ const Button = (props: IButtonProps) => {
             transformedVariant,
             transformedAppearance
           )}
-          isTransparent={transformedTransparentSpinner}
+          transparent={transformedTransparentSpinner}
           size={defaultSpinnerSize}
         />
       ) : (


### PR DESCRIPTION
The `isTransparent` property is **renamed** to `transparent` in the `<Spinner />` component. This change makes the code easier to read and conforms to the design system standards.

**BREAKING CHANGE**

This name change may cause the component to not behave as expected in the places where it is used. It is important to validate and adjust the code so that the component works correctly with the new property name.