### PR TITLE
Create the `useFonts` hook

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,9 +1,0 @@
-export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
-  controls: {
-    matchers: {
-      color: /(background|color)$/i,
-      date: /Date$/,
-    },
-  },
-};

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { useFonts } from "../src/hooks/useFonts";
+import { presente } from "../src/shared/themes/presente";
+
+/** @type { import('@storybook/react').Preview } */
+const preview: import("@storybook/react").Preview = {
+  parameters: {
+    actions: { argTypesRegex: "^on[A-Z].*" },
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/,
+      },
+    },
+  },
+  decorators: [
+    (Story) => {
+      const theme = {
+        ...presente,
+      };
+      useFonts(theme.typography.fonts);
+      return <Story />;
+    },
+  ],
+};
+
+export default preview;

--- a/src/hooks/useFonts.ts
+++ b/src/hooks/useFonts.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from "react";
+
+interface IFonts {
+  family: string;
+  url: string;
+  options: IOptions;
+}
+
+interface IOptions {
+  weight: string;
+  style: string;
+}
+
+export type fontsList = Array<IFonts>;
+
+function useFonts(fonts: fontsList) {
+  const [fontFaces] = useState(
+    fonts.map((font) => {
+      return new FontFace(font.family, `url(${font.url})`, font.options);
+    })
+  );
+
+  async function loadFontFace(fontFace: FontFace) {
+    const loadedFont = await fontFace.load();
+    document.fonts.add(loadedFont);
+  }
+
+  useEffect(() => {
+    fontFaces.forEach((fontFace, index: number) => {
+      loadFontFace(fontFace);
+      if (index === 1) {
+        document.body.style.fontFamily = fontFace.family;
+      }
+    });
+  }, [fontFaces]);
+}
+
+export { useFonts };


### PR DESCRIPTION
This PR presents the creation of a new custom hook, `useFonts`. This hook aims to centralize and streamline font-related logic, facilitating better typography management throughout the application. 