### PR TITLE
Rename props `isFocused` to `focused` in <Label />

### DIFF
--- a/src/components/inputs/Label/index.tsx
+++ b/src/components/inputs/Label/index.tsx
@@ -3,7 +3,7 @@ import { StyledLabel } from "./styles";
 
 export interface ILabelProps {
   isDisabled?: boolean;
-  isFocused?: boolean;
+  focused?: boolean;
   htmlFor: string;
   isInvalid?: boolean;
   typo?: TypographyLabel;
@@ -19,7 +19,7 @@ const defaultTypo = "labelLarge";
 const Label = (props: ILabelProps) => {
   const {
     isDisabled = defaultIsDisabled,
-    isFocused = defaultIsFocused,
+    focused = defaultIsFocused,
     htmlFor,
     isInvalid = defaultIsInvalid,
     typo = "labelLarge",
@@ -30,7 +30,7 @@ const Label = (props: ILabelProps) => {
     typeof isDisabled === "boolean" ? isDisabled : defaultIsDisabled;
 
   const transformedIsFocused =
-    typeof isFocused === "boolean" ? isFocused : defaultIsFocused;
+    typeof focused === "boolean" ? focused : defaultIsFocused;
 
   const transformedIsInvalid =
     typeof isInvalid === "boolean" ? isInvalid : defaultIsInvalid;
@@ -40,7 +40,7 @@ const Label = (props: ILabelProps) => {
   return (
     <StyledLabel
       isDisabled={transformedIsDisabled}
-      isFocused={transformedIsFocused}
+      focused={transformedIsFocused}
       htmlFor={htmlFor}
       isInvalid={transformedIsInvalid}
       typo={transformedTypo}

--- a/src/components/inputs/Label/props.ts
+++ b/src/components/inputs/Label/props.ts
@@ -16,7 +16,7 @@ const props = {
       defaultValue: { summary: false },
     },
   },
-  isFocused: {
+  focused: {
     description: "indicates wheter the text is in its focused state",
     table: {
       defaultValue: { summary: false },

--- a/src/components/inputs/Label/stories/Label.IsFocused.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.IsFocused.stories.tsx
@@ -17,7 +17,7 @@ const IsFocused = ({
   return (
     <Label
       isDisabled={isDisabled}
-      isFocused={true}
+      focused={true}
       isInvalid={isInvalid}
       htmlFor={htmlFor}
       typo={typo}

--- a/src/components/inputs/Label/stories/Label.Size.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.Size.stories.tsx
@@ -14,7 +14,7 @@ const story = {
 interface LabelArgs {
   isDisabled: boolean;
   htmlFor: string;
-  isFocused: boolean;
+  focused: boolean;
   isInvalid: boolean;
   typo: TypographyLabel;
   children: ReactNode;
@@ -22,7 +22,7 @@ interface LabelArgs {
 
 const Size = ({
   isDisabled,
-  isFocused,
+  focused,
   htmlFor,
   isInvalid,
   children,
@@ -36,7 +36,7 @@ const Size = ({
       {typos.map((typo) => (
         <Label
           isDisabled={isDisabled}
-          isFocused={isFocused}
+          focused={focused}
           htmlFor={htmlFor}
           typo={typo}
           isInvalid={isInvalid}

--- a/src/components/inputs/Label/stories/Label.Size.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.Size.stories.tsx
@@ -53,7 +53,7 @@ Size.args = {
   htmlFor: "id",
   children: "Text Label",
   isDisabled: false,
-  isFocused: false,
+  focused: false,
   isInvalid: false,
 };
 

--- a/src/components/inputs/Label/stories/Label.State.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.State.stories.tsx
@@ -11,7 +11,7 @@ const story = {
 
 const States = ({
   isDisabled,
-  isFocused,
+  focused,
   children,
   typo,
   htmlFor,
@@ -21,7 +21,7 @@ const States = ({
       {[false, true].map((isInvalid) => (
         <Label
           isDisabled={isDisabled}
-          isFocused={isFocused}
+          focused={focused}
           isInvalid={isInvalid}
           htmlFor={htmlFor}
           typo={typo}
@@ -36,7 +36,7 @@ const States = ({
 
 States.args = {
   isDisabled: false,
-  isFocused: false,
+  focused: false,
   htmlFor: "id",
   typo: "labelLarge",
   children: "Label Text",

--- a/src/components/inputs/Label/stories/Label.isDisabled.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.isDisabled.stories.tsx
@@ -7,16 +7,11 @@ const story = {
   argTypes: props,
 };
 
-const IsDisabled = ({
-  isFocused,
-  htmlFor,
-  isInvalid,
-  children,
-}: ILabelProps) => {
+const IsDisabled = ({ focused, htmlFor, isInvalid, children }: ILabelProps) => {
   return (
     <Label
       isDisabled={true}
-      isFocused={isFocused}
+      focused={focused}
       htmlFor={htmlFor}
       isInvalid={isInvalid}
     >

--- a/src/components/inputs/Label/stories/Label.isDisabled.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.isDisabled.stories.tsx
@@ -21,7 +21,7 @@ const IsDisabled = ({ focused, htmlFor, isInvalid, children }: ILabelProps) => {
 };
 IsDisabled.args = {
   children: "Label Text",
-  isFocused: false,
+  focused: false,
   htmlFor: "id",
   isInvalid: false,
 };

--- a/src/components/inputs/Label/stories/Label.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.stories.tsx
@@ -16,7 +16,7 @@ Default.args = {
   children: "Label Text",
   typo: "labelLarge",
   isDisabled: false,
-  isFocused: false,
+  focused: false,
   isInvalid: false,
 };
 

--- a/src/components/inputs/Label/styles.ts
+++ b/src/components/inputs/Label/styles.ts
@@ -5,7 +5,7 @@ import { colors } from "@shared/colors/colors";
 import { ILabelProps } from "./index";
 
 const getColor = (props: ILabelProps): string => {
-  const { isDisabled, isFocused, isInvalid } = props;
+  const { isDisabled, focused, isInvalid } = props;
   let color = colors.sys.text.dark;
 
   if (isDisabled) {
@@ -18,7 +18,7 @@ const getColor = (props: ILabelProps): string => {
     return color;
   }
 
-  if (isFocused) {
+  if (focused) {
     color = colors.sys.text.primary;
     return color;
   }

--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -138,7 +138,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
           <Label
             htmlFor={id}
             isDisabled={isDisabled}
-            isFocused={isFocused}
+            focused={isFocused}
             isInvalid={transformedIsInvalid}
             typo={getTypo(size!)}
           >

--- a/src/components/inputs/TextArea/interface.jsx
+++ b/src/components/inputs/TextArea/interface.jsx
@@ -127,7 +127,7 @@ const TextAreaUI = (props) => {
           <Label
             htmlFor={id}
             isDisabled={isDisabled}
-            isFocused={isFocused}
+            focused={isFocused}
             isInvalid={transformedIsInvalid}
           >
             {label}

--- a/src/components/inputs/TextField/interface.tsx
+++ b/src/components/inputs/TextField/interface.tsx
@@ -111,7 +111,7 @@ const TextFieldUI = (props: ITextFieldProps) => {
           <Label
             htmlFor={id}
             isDisabled={isDisabled}
-            isFocused={isFocused}
+            focused={isFocused}
             isInvalid={transformedIsInvalid}
             typo={getTypo(size!)}
           >


### PR DESCRIPTION
The `isFocused` property is renamed to `focused` in the <Label />component. This change makes the code easier to read and conforms to the design system standards.

**BREAKING CHANGE**
This name change may cause the component to not behave as expected in the places where it is used. It is important to validate and **adjust the code so that the component** works correctly with the new property name.