### PR TITLE
`<Spinner />:` sizes object in styles let typescript define the type by itself

### DIFF
--- a/src/components/feedback/Spinner/styles.ts
+++ b/src/components/feedback/Spinner/styles.ts
@@ -2,7 +2,7 @@ import styled, { keyframes } from "styled-components";
 import { inube } from "@src/shared/tokens";
 import { ISpinnerProps } from ".";
 
-const sizes: any = {
+const sizes = {
   large: {
     width: "40px",
     height: "40px",


### PR DESCRIPTION
This PR makes a change to the `<Spinner />` component's styling approach. For the sizes object in styles, rather than explicitly defining the type, we are allowing TypeScript to automatically infer it. This adjustment simplifies the code and takes advantage of TypeScript's type inference capabilities.