### PR TITLE
`<Label />:` delete `onClick` prop from interface

### DIFF
--- a/src/components/inputs/Label/index.tsx
+++ b/src/components/inputs/Label/index.tsx
@@ -8,7 +8,6 @@ export interface ILabelProps {
   isInvalid?: boolean;
   typo?: TypographyLabel;
   children?: React.ReactNode;
-  onClick?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 const defaultIsDisabled = false;

--- a/src/components/inputs/Switch/index.tsx
+++ b/src/components/inputs/Switch/index.tsx
@@ -73,7 +73,7 @@ const Switch = (props: ISwitchProps) => {
         </StyledSpan>
       </StyledContainer>
       {label && (
-        <Label htmlFor={id} isDisabled={isDisabled} onClick={handleChange}>
+        <Label htmlFor={id} isDisabled={isDisabled}>
           {label}
         </Label>
       )}


### PR DESCRIPTION
This PR entails the removal of the `onClick` prop from the `<Label />` component's interface. This decision was made after identifying that the prop is either redundant or not required in the current component's use cases. 