### PR TITLE
`<Label />:` refactor typo prop and typography styles to use new token structure

### DIFF
--- a/src/components/inputs/Label/index.tsx
+++ b/src/components/inputs/Label/index.tsx
@@ -1,7 +1,7 @@
-import { TypographyLabel, typos } from "./props";
+import { Themed, TypographyLabel, typos } from "./props";
 import { StyledLabel } from "./styles";
 
-export interface ILabelProps {
+export interface ILabelProps extends Themed {
   isDisabled?: boolean;
   isFocused?: boolean;
   htmlFor: string;
@@ -22,7 +22,7 @@ const Label = (props: ILabelProps) => {
     isFocused = defaultIsFocused,
     htmlFor,
     isInvalid = defaultIsInvalid,
-    typo = "labelLarge",
+    typo = "large",
     children,
   } = props;
 

--- a/src/components/inputs/Label/props.ts
+++ b/src/components/inputs/Label/props.ts
@@ -1,5 +1,8 @@
-export const typos = ["labelLarge", "labelMedium", "labelSmall"] as const;
+import { inube } from "@shared/tokens";
+
+export const typos = ["large", "medium", "small"] as const;
 export type TypographyLabel = typeof typos[number];
+export type Themed = { theme?: typeof inube };
 
 const props = {
   parameters: {

--- a/src/components/inputs/Label/stories/Label.IsFocused.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.IsFocused.stories.tsx
@@ -31,7 +31,7 @@ IsFocused.args = {
   isDisabled: false,
   htmlFor: "id",
   isInvalid: false,
-  typo: "labelLarge",
+  typo: "large",
 };
 
 export default story;

--- a/src/components/inputs/Label/stories/Label.State.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.State.stories.tsx
@@ -38,7 +38,7 @@ States.args = {
   isDisabled: false,
   isFocused: false,
   htmlFor: "id",
-  typo: "labelLarge",
+  typo: "large",
   children: "Label Text",
 };
 

--- a/src/components/inputs/Label/stories/Label.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.stories.tsx
@@ -14,7 +14,7 @@ const Default = (args: ILabelProps) => {
 Default.args = {
   htmlFor: "id",
   children: "Label Text",
-  typo: "labelLarge",
+  typo: "large",
   isDisabled: false,
   isFocused: false,
   isInvalid: false,

--- a/src/components/inputs/Label/styles.ts
+++ b/src/components/inputs/Label/styles.ts
@@ -1,25 +1,28 @@
 import styled from "styled-components";
-import { typography } from "@shared/typography/typography";
-import { colors } from "@shared/colors/colors";
 
 import { ILabelProps } from "./index";
+import { inube } from "@shared/tokens";
 
 const getColor = (props: ILabelProps): string => {
-  const { isDisabled, isFocused, isInvalid } = props;
-  let color = colors.sys.text.dark;
+  const { theme, isDisabled, isFocused, isInvalid } = props;
+  let color =
+    theme?.color?.text?.dark?.regular || inube.color.text.dark.regular;
 
   if (isDisabled) {
-    color = colors.sys.text.disabled;
+    color =
+      theme?.color?.text?.dark?.disabled || inube.color.text.dark.disabled;
     return color;
   }
 
   if (isInvalid) {
-    color = colors.sys.text.error;
+    color =
+      theme?.color?.text?.error?.regular || inube.color.text.error.regular;
     return color;
   }
 
   if (isFocused) {
-    color = colors.sys.text.primary;
+    color =
+      theme?.color?.text?.primary?.hover || inube.color.text.primary.hover;
     return color;
   }
 
@@ -27,15 +30,27 @@ const getColor = (props: ILabelProps): string => {
 };
 
 const StyledLabel = styled.label`
-  font-family: ${typography.sys.typescale.labelLarge.font};
-  font-size: ${({ typo }: ILabelProps) =>
-    typo && typography.sys.typescale[typo].size};
-  font-weight: ${({ typo }: ILabelProps) =>
-    typo && typography.sys.typescale[typo].weight};
-  letter-spacing: ${({ typo }: ILabelProps) =>
-    typo && typography.sys.typescale[typo].tracking};
-  line-height: ${({ typo }: ILabelProps) =>
-    typo && typography.sys.typescale[typo].lineHeight};
+  font-family: ${({ theme }: any) => {
+    return (
+      theme?.typography?.label?.large?.font || inube.typography.label.large.font
+    );
+  }};
+  font-size: ${({ typo, theme }: ILabelProps) =>
+    typo &&
+    (theme?.typography?.label?.[typo]?.size ||
+      inube.typography.label[typo].size)};
+  font-weight: ${({ typo, theme }: ILabelProps) =>
+    typo &&
+    (theme?.typography?.label?.[typo]?.weight ||
+      inube.typography.label[typo].weight)};
+  letter-spacing: ${({ typo, theme }: ILabelProps) =>
+    typo &&
+    (theme?.typography?.label?.[typo]?.tracking ||
+      inube.typography.label[typo].tracking)};
+  line-height: ${({ typo, theme }: ILabelProps) =>
+    typo &&
+    (theme?.typography?.label?.[typo]?.lineHeight ||
+      inube.typography.label[typo].lineHeight)};
   color: ${(props: ILabelProps) => getColor(props)};
 `;
 

--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -36,9 +36,9 @@ export interface ISelectInterfaceProps extends ISelectProps {
 
 const getTypo = (size: Size) => {
   if (size === "compact") {
-    return "labelMedium";
+    return "medium";
   }
-  return "labelLarge";
+  return "large";
 };
 
 const Invalid = (props: ISelectStateProps) => {

--- a/src/components/inputs/TextField/interface.tsx
+++ b/src/components/inputs/TextField/interface.tsx
@@ -25,9 +25,9 @@ export interface IMessageProps {
 
 const getTypo = (size: Size) => {
   if (size === "compact") {
-    return "labelMedium";
+    return "medium";
   }
-  return "labelLarge";
+  return "large";
 };
 
 const Invalid = (props: IMessageProps) => {


### PR DESCRIPTION
This PR revisits the typography styles and the typo prop of the `<Label />` component, ensuring they align with our new token structure. These modifications bring the component's typography in conformity with the updated visual guidelines, ensuring design and theming consistency throughout the application. 

