### PR TITLE
Rename `typo` Prop to `size` in `<Label />`

### DIFF
--- a/src/components/inputs/Label/index.tsx
+++ b/src/components/inputs/Label/index.tsx
@@ -1,4 +1,4 @@
-import { Themed, TypographyLabel } from "./props";
+import { Size, Themed } from "./props";
 import { StyledLabel } from "./styles";
 
 export interface ILabelProps extends Themed {
@@ -6,7 +6,7 @@ export interface ILabelProps extends Themed {
   focused?: boolean;
   htmlFor: string;
   invalid?: boolean;
-  typo?: TypographyLabel;
+  size?: Size;
   children?: React.ReactNode;
 }
 
@@ -16,7 +16,7 @@ const Label = (props: ILabelProps) => {
     focused = false,
     htmlFor,
     invalid = false,
-    typo = "large",
+    size = "large",
     children,
   } = props;
 
@@ -26,7 +26,7 @@ const Label = (props: ILabelProps) => {
       focused={focused}
       htmlFor={htmlFor}
       invalid={invalid}
-      typo={typo}
+      size={size}
     >
       {children}
     </StyledLabel>

--- a/src/components/inputs/Label/props.ts
+++ b/src/components/inputs/Label/props.ts
@@ -1,7 +1,7 @@
 import { inube } from "@shared/tokens";
 
-export const typos = ["large", "medium", "small"] as const;
-export type TypographyLabel = typeof typos[number];
+export const sizes = ["large", "medium", "small"] as const;
+export type Size = typeof sizes[number];
 export type Themed = { theme?: typeof inube };
 
 const parameters = {
@@ -37,8 +37,8 @@ const props = {
       defaultValue: { summary: false },
     },
   },
-  typo: {
-    options: typos,
+  size: {
+    options: sizes,
     control: { type: "select" },
     description: "indicates the font size used in the component",
   },

--- a/src/components/inputs/Label/stories/Label.Size.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.Size.stories.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from "react";
 import { Label } from "../";
 import { Stack } from "@layouts/Stack";
 
-import { TypographyLabel, props, typos, parameters } from "../props";
+import { Size, sizes, props, parameters } from "../props";
 
 const story = {
   title: "inputs/Label",
@@ -17,25 +17,31 @@ interface LabelArgs {
   htmlFor: string;
   focused: boolean;
   invalid: boolean;
-  typo: TypographyLabel;
+  size: Size;
   children: ReactNode;
 }
 
-const Size = ({ disabled, focused, htmlFor, invalid, children }: LabelArgs) => {
+const Sizes = ({
+  disabled,
+  focused,
+  htmlFor,
+  invalid,
+  children,
+}: LabelArgs) => {
   return (
     <Stack
       direction="row"
       justifyContent="space-around"
       alignItems="flex-start"
     >
-      {typos.map((typo) => (
+      {sizes.map((size) => (
         <Label
           disabled={disabled}
           focused={focused}
           htmlFor={htmlFor}
-          typo={typo}
+          size={size}
           invalid={invalid}
-          key={typo}
+          key={size}
         >
           {children}
         </Label>
@@ -44,7 +50,7 @@ const Size = ({ disabled, focused, htmlFor, invalid, children }: LabelArgs) => {
   );
 };
 
-Size.args = {
+Sizes.args = {
   htmlFor: "id",
   children: "Text Label",
   disabled: false,
@@ -53,4 +59,4 @@ Size.args = {
 };
 
 export default story;
-export { Size };
+export { Sizes };

--- a/src/components/inputs/Label/stories/Label.State.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.State.stories.tsx
@@ -14,7 +14,7 @@ const States = ({
   disabled,
   focused,
   children,
-  typo,
+  size,
   htmlFor,
 }: ILabelProps) => {
   return (
@@ -25,7 +25,7 @@ const States = ({
           focused={focused}
           invalid={invalid}
           htmlFor={htmlFor}
-          typo={typo}
+          size={size}
           key={invalid.toString()}
         >
           {children}
@@ -39,7 +39,7 @@ States.args = {
   disabled: false,
   focused: false,
   htmlFor: "id",
-  typo: "large",
+  size: "large",
   children: "Label Text",
 };
 

--- a/src/components/inputs/Label/stories/Label.focused.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.focused.stories.tsx
@@ -12,7 +12,7 @@ const Focused = ({
   children,
   invalid,
   htmlFor,
-  typo,
+  size,
   disabled,
 }: ILabelProps) => {
   return (
@@ -21,7 +21,7 @@ const Focused = ({
       focused={true}
       invalid={invalid}
       htmlFor={htmlFor}
-      typo={typo}
+      size={size}
     >
       {children}
     </Label>
@@ -32,7 +32,7 @@ Focused.args = {
   disabled: false,
   htmlFor: "id",
   invalid: false,
-  typo: "large",
+  size: "large",
 };
 
 export default story;

--- a/src/components/inputs/Label/stories/Label.stories.tsx
+++ b/src/components/inputs/Label/stories/Label.stories.tsx
@@ -15,7 +15,7 @@ const Default = (args: ILabelProps) => {
 Default.args = {
   htmlFor: "id",
   children: "Label Text",
-  typo: "large",
+  size: "large",
   disabled: false,
   focused: false,
   invalid: false,

--- a/src/components/inputs/Label/styles.ts
+++ b/src/components/inputs/Label/styles.ts
@@ -36,22 +36,22 @@ const StyledLabel = styled.label`
       theme?.typography?.label?.large?.font || inube.typography.label.large.font
     );
   }};
-  font-size: ${({ typo, theme }: ILabelProps) =>
-    typo &&
-    (theme?.typography?.label?.[typo]?.size ||
-      inube.typography.label[typo].size)};
-  font-weight: ${({ typo, theme }: ILabelProps) =>
-    typo &&
-    (theme?.typography?.label?.[typo]?.weight ||
-      inube.typography.label[typo].weight)};
-  letter-spacing: ${({ typo, theme }: ILabelProps) =>
-    typo &&
-    (theme?.typography?.label?.[typo]?.tracking ||
-      inube.typography.label[typo].tracking)};
-  line-height: ${({ typo, theme }: ILabelProps) =>
-    typo &&
-    (theme?.typography?.label?.[typo]?.lineHeight ||
-      inube.typography.label[typo].lineHeight)};
+  font-size: ${({ size, theme }: ILabelProps) =>
+    size &&
+    (theme?.typography?.label?.[size]?.size ||
+      inube.typography.label[size].size)};
+  font-weight: ${({ size, theme }: ILabelProps) =>
+    size &&
+    (theme?.typography?.label?.[size]?.weight ||
+      inube.typography.label[size].weight)};
+  letter-spacing: ${({ size, theme }: ILabelProps) =>
+    size &&
+    (theme?.typography?.label?.[size]?.tracking ||
+      inube.typography.label[size].tracking)};
+  line-height: ${({ size, theme }: ILabelProps) =>
+    size &&
+    (theme?.typography?.label?.[size]?.lineHeight ||
+      inube.typography.label[size].lineHeight)};
   color: ${(props: ILabelProps) => getColor(props)};
 `;
 

--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -140,7 +140,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
             disabled={isDisabled}
             focused={isFocused}
             invalid={transformedInvalid}
-            typo={getTypo(size!)}
+            size={getTypo(size!)}
           >
             {label}
           </Label>

--- a/src/components/inputs/TextField/interface.tsx
+++ b/src/components/inputs/TextField/interface.tsx
@@ -113,7 +113,7 @@ const TextFieldUI = (props: ITextFieldProps) => {
             disabled={isDisabled}
             focused={isFocused}
             invalid={transformedInvalid}
-            typo={getTypo(size!)}
+            size={getTypo(size!)}
           >
             {label}
           </Label>


### PR DESCRIPTION
This PR implements a name change for the `<Label />` component's prop. Specifically, the `typo` prop has been renamed to `size`, bringing more clarity and simplicity to its purpose. This modification aligns with our intention to make prop naming more intuitive and straightforward. 