### PR TITLE
`<Switch />:` rename `isDisabled` prop for just `disabled`

### DIFF
--- a/src/components/inputs/Switch/index.tsx
+++ b/src/components/inputs/Switch/index.tsx
@@ -7,7 +7,6 @@ import { StyledContainer, StyledInput, StyledSpan, StyledIcon } from "./styles";
 import { Size } from "./props";
 
 export interface ISwitchProps {
-  isDisabled?: boolean;
   id: string;
   name?: string;
   value?: string;
@@ -22,7 +21,7 @@ export interface ISwitchProps {
 
 const Switch = (props: ISwitchProps) => {
   const {
-    isDisabled = false,
+    disabled = false,
     id,
     name,
     value,
@@ -54,10 +53,10 @@ const Switch = (props: ISwitchProps) => {
           value={value}
           checked={checked}
           onChange={handleChange}
-          disabled={isDisabled}
+          disabled={disabled}
           name={name}
         />
-        <StyledSpan size={size} isDisabled={isDisabled}>
+        <StyledSpan size={size} disabled={disabled}>
           {checked ? (
             <StyledIcon checked={checked} size={size}>
               <MdDone id="mdIcon" />
@@ -70,7 +69,7 @@ const Switch = (props: ISwitchProps) => {
         </StyledSpan>
       </StyledContainer>
       {label && (
-        <Label htmlFor={id} disabled={isDisabled}>
+        <Label htmlFor={id} disabled={disabled}>
           {label}
         </Label>
       )}

--- a/src/components/inputs/Switch/props.ts
+++ b/src/components/inputs/Switch/props.ts
@@ -17,7 +17,7 @@ const props = {
     description:
       "this element can have a label on it, so this id allows us to connect the label with the switch",
   },
-  isDisabled: {
+  disabled: {
     options: [true, false],
     control: { type: "boolean" },
     description:

--- a/src/components/inputs/Switch/stories/Switch.Checks.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.Checks.stories.tsx
@@ -29,7 +29,7 @@ const SwitchComponent = (props: ISwitchProps) => {
 export const Checks = {
   args: {
     id: "id",
-    isDisabled: false,
+    disabled: false,
     name: "name",
     checked: false,
     handleChange: () => {},

--- a/src/components/inputs/Switch/stories/Switch.Disabled.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.Disabled.stories.tsx
@@ -26,7 +26,7 @@ const SwitchComponent = (args: ISwitchProps) => {
 export const Disabled = {
   args: {
     id: "id",
-    isDisabled: true,
+    disabled: true,
     name: "name",
     handleChange: () => {},
     margin: "0px",

--- a/src/components/inputs/Switch/stories/Switch.Sizes.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.Sizes.stories.tsx
@@ -30,7 +30,7 @@ const SwitchComponent = (args: ISwitchProps) => {
 export const Sizes = {
   args: {
     id: "id",
-    isDisabled: false,
+    disabled: false,
     name: "name",
     value: "switchTest2",
     checked: false,

--- a/src/components/inputs/Switch/stories/Switch.WithLabel.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.WithLabel.stories.tsx
@@ -30,7 +30,7 @@ const SwitchComponent = (args: ISwitchProps) => {
 export const WithLabel = {
   args: {
     id: "id",
-    isDisabled: false,
+    disabled: false,
     name: "name",
     checked: false,
     handleChange: () => {},

--- a/src/components/inputs/Switch/stories/Switch.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.stories.tsx
@@ -13,7 +13,7 @@ const story = {
 export const Default = (args: ISwitchProps) => <SwitchController {...args} />;
 Default.args = {
   id: "id",
-  isDisabled: false,
+  disabled: false,
   name: "name",
   value: "switchTest1",
   checked: false,

--- a/src/components/inputs/Switch/styles.ts
+++ b/src/components/inputs/Switch/styles.ts
@@ -23,15 +23,15 @@ const StyledSpan = styled.span`
   transition: 0.1s;
   border-radius: 30px;
   cursor: ${(props: ISwitchProps) =>
-    props.isDisabled ? "not-allowed" : "pointer"};
+    props.disabled ? "not-allowed" : "pointer"};
   background: ${(props: ISwitchProps) =>
-    props.isDisabled
+    props.disabled
       ? colors.ref.palette.neutral.n40
       : colors.ref.palette.neutral.n200};
 
   &:hover {
     background-color: ${(props: ISwitchProps) =>
-      props.isDisabled
+      props.disabled
         ? colors.ref.palette.neutral.n40
         : colors.ref.palette.neutral.n70};
   }

--- a/src/hooks/stories/Example.stories.tsx
+++ b/src/hooks/stories/Example.stories.tsx
@@ -29,7 +29,7 @@ export const Example = (args: IExampleSwitch) => {
 
 Example.args = {
   id: "id",
-  isDisabled: false,
+  disabled: false,
   name: "name",
   value: "switchTest4",
   checked: false,


### PR DESCRIPTION
This PR makes a modification to the `<Switch />` component by renaming the `isDisabled` prop to the more succinct `disabled`. This change is part of our continuous effort to streamline prop naming conventions and enhance code readability. 