### PR TITLE
`<Switch />:` rename `handleChange` prop to `onChange`

### DIFF
--- a/src/components/inputs/Switch/index.tsx
+++ b/src/components/inputs/Switch/index.tsx
@@ -13,7 +13,7 @@ export interface ISwitchProps {
   value?: string;
   size?: Size;
   checked?: boolean;
-  handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   label: string;
   margin: string;
   padding: string;
@@ -28,7 +28,7 @@ const Switch = (props: ISwitchProps) => {
     value,
     size = "small",
     checked = false,
-    handleChange,
+    onChange,
     label,
     margin = "0px",
     padding = "0px",
@@ -53,7 +53,7 @@ const Switch = (props: ISwitchProps) => {
           size={size}
           value={value}
           checked={checked}
-          onChange={handleChange}
+          onChange={onChange}
           disabled={isDisabled}
           name={name}
         />

--- a/src/components/inputs/Switch/props.ts
+++ b/src/components/inputs/Switch/props.ts
@@ -45,7 +45,7 @@ const props = {
     control: { type: "select" },
     description: "value to be submitted in a form",
   },
-  handleChange: {
+  onChange: {
     options: ["logState"],
     control: { type: "func" },
     description:

--- a/src/components/inputs/Switch/stories/Switch.Checks.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.Checks.stories.tsx
@@ -32,7 +32,7 @@ export const Checks = {
     isDisabled: false,
     name: "name",
     checked: false,
-    handleChange: () => {},
+    onChange: () => {},
     margin: "0px",
     padding: "0px",
   },

--- a/src/components/inputs/Switch/stories/Switch.Disabled.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.Disabled.stories.tsx
@@ -28,7 +28,7 @@ export const Disabled = {
     id: "id",
     isDisabled: true,
     name: "name",
-    handleChange: () => {},
+    onChange: () => {},
     margin: "0px",
     padding: "0px",
   },

--- a/src/components/inputs/Switch/stories/Switch.Sizes.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.Sizes.stories.tsx
@@ -34,7 +34,7 @@ export const Sizes = {
     name: "name",
     value: "switchTest2",
     checked: false,
-    handleChange: () => {},
+    onChange: () => {},
     margin: "0px",
     padding: "0px",
   },

--- a/src/components/inputs/Switch/stories/Switch.WithLabel.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.WithLabel.stories.tsx
@@ -33,7 +33,7 @@ export const WithLabel = {
     isDisabled: false,
     name: "name",
     checked: false,
-    handleChange: () => {},
+    onChange: () => {},
     label: "Label",
     margin: "0px",
     padding: "0px",

--- a/src/components/inputs/Switch/stories/Switch.stories.tsx
+++ b/src/components/inputs/Switch/stories/Switch.stories.tsx
@@ -18,7 +18,7 @@ Default.args = {
   value: "switchTest1",
   checked: false,
   size: "small",
-  handleChange: () => {},
+  onChange: () => {},
   margin: "0px",
   padding: "0px",
 };

--- a/src/components/inputs/Switch/stories/SwitchController.tsx
+++ b/src/components/inputs/Switch/stories/SwitchController.tsx
@@ -5,13 +5,11 @@ const SwitchController = (props: ISwitchProps) => {
   const { checked = false } = props;
   const [switchChecked, setSwitchChecked] = useState(checked);
 
-  const handleChenge = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSwitchChecked(e.target.checked);
   };
 
-  return (
-    <Switch {...props} checked={switchChecked} handleChange={handleChenge} />
-  );
+  return <Switch {...props} checked={switchChecked} onChange={onChange} />;
 };
 
 export { SwitchController };

--- a/src/hooks/stories/Example.stories.tsx
+++ b/src/hooks/stories/Example.stories.tsx
@@ -34,7 +34,7 @@ Example.args = {
   value: "switchTest4",
   checked: false,
   size: "small",
-  handleChange: () => {},
+  onChange: () => {},
   margin: "0px",
   padding: "0px",
 };

--- a/src/hooks/stories/IExampleSwitch.interface.ts
+++ b/src/hooks/stories/IExampleSwitch.interface.ts
@@ -1,5 +1,5 @@
 export interface IExampleSwitch {
-  handleChange: () => void;
+  onChange: () => void;
   id: string;
   size?: string;
 }


### PR DESCRIPTION
This PR pertains to a naming modification in the `<Switch />` component. Specifically, the `handleChange` prop has been renamed to `onChange` to adhere to more conventional naming patterns and improve clarity. This change aligns the component with widely accepted naming standards, fostering better consistency across our components. Please scrutinize this update and ensure that all instances or references to this prop throughout the project have been adjusted as necessary.