### PR TITLE
`<Blanket />:` refactor styles to use new color tokens

### DIFF
--- a/src/components/utils/Blanket/index.tsx
+++ b/src/components/utils/Blanket/index.tsx
@@ -1,12 +1,14 @@
 import { useMediaQuery } from "@hooks/useMediaQuery";
 import { Stack } from "@layouts/Stack";
 import { StyledBlanket } from "./styles";
+import { inube } from "@shared/tokens";
 
-export interface BlanketProps {
+export type Themed = { theme?: typeof inube };
+export interface IBlanketProps extends Themed {
   children?: React.ReactNode;
 }
 
-const Blanket = (props: BlanketProps) => {
+const Blanket = (props: IBlanketProps) => {
   const { children } = props;
   const isSmallScreen = useMediaQuery("(max-width: 580px)");
 

--- a/src/components/utils/Blanket/stories/Blanket.stories.tsx
+++ b/src/components/utils/Blanket/stories/Blanket.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Blanket, BlanketProps } from "..";
+import { Blanket, IBlanketProps } from "..";
 
 import { Button } from "@inputs/Button/index";
 
@@ -24,7 +24,7 @@ const story = {
   },
 };
 
-const Default = (args: BlanketProps) => {
+const Default = (args: IBlanketProps) => {
   const [showBlanket, setShowBlanket] = useState(false);
 
   const handleShowBlanket = () => {

--- a/src/components/utils/Blanket/styles.ts
+++ b/src/components/utils/Blanket/styles.ts
@@ -1,5 +1,6 @@
 import styled from "styled-components";
-import { colors } from "@shared/colors/colors";
+import { inube } from "@shared/tokens";
+import { IBlanketProps } from ".";
 
 const StyledBlanket = styled.div`
   position: fixed;
@@ -7,7 +8,9 @@ const StyledBlanket = styled.div`
   place-items: ${(props: { isSmallScreen: string }) =>
     props.isSmallScreen ? "center" : "initial"};
   inset: 0;
-  background-color: ${colors.ref.palette.neutralAlpha.n100A};
+  background-color: ${({ theme }: IBlanketProps) =>
+    theme?.color?.surface?.blanket?.regular ||
+    inube.color.surface.blanket.regular};
   border: none;
   z-index: 1;
   overflow-y: auto;


### PR DESCRIPTION
In this PR, the styles of the `<Blanket />` component have been revamped to align with our updated color tokens. By integrating these tokens, we ensure that the component's visual appearance remains consistent with our unified design language and guidelines. We kindly request a review of the revised styles, ensuring that the component's design representation adheres to our established standards.