### PR TITLE
`<Textfield />:` rename `isDisabled` prop to just `disabled`

### DIFF
--- a/src/components/inputs/TextField/index.tsx
+++ b/src/components/inputs/TextField/index.tsx
@@ -8,7 +8,7 @@ export interface ITextFieldProps {
   name: string;
   id: string;
   placeholder: string;
-  isDisabled?: boolean;
+  disabled?: boolean;
   type?: InputType;
   value?: string | number;
   handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -30,7 +30,7 @@ export interface ITextFieldProps {
   isFocused?: boolean;
 }
 
-const defaultIsDisabled = false;
+const defaultdisabled = false;
 const defaultType: InputType = "text";
 const defaultIsRequired = false;
 const defaultState: State = "pending";
@@ -42,7 +42,7 @@ const TextField = (props: ITextFieldProps) => {
     name,
     id,
     placeholder,
-    isDisabled = false,
+    disabled = false,
     type = "text",
     value,
     handleChange,
@@ -81,8 +81,8 @@ const TextField = (props: ITextFieldProps) => {
     }
   };
 
-  const transformedIsDisabled =
-    typeof isDisabled === "boolean" ? isDisabled : defaultIsDisabled;
+  const transformeddisabled =
+    typeof disabled === "boolean" ? disabled : defaultdisabled;
 
   const transformedState = states.includes(state) ? state : defaultState;
 
@@ -102,7 +102,7 @@ const TextField = (props: ITextFieldProps) => {
       name={name}
       id={id}
       placeholder={placeholder}
-      isDisabled={transformedIsDisabled}
+      disabled={transformeddisabled}
       type={transformedTypes}
       value={value}
       handleChange={handleChange}

--- a/src/components/inputs/TextField/interface.tsx
+++ b/src/components/inputs/TextField/interface.tsx
@@ -18,7 +18,7 @@ import { Size, State } from "./props";
 
 export interface IMessageProps {
   state?: State;
-  isDisabled?: boolean;
+  disabled?: boolean;
   errorMessage?: string;
   validMessage?: string;
 }
@@ -31,18 +31,18 @@ const getTypo = (size: Size) => {
 };
 
 const Invalid = (props: IMessageProps) => {
-  const { isDisabled, state, errorMessage } = props;
+  const { disabled, state, errorMessage } = props;
   const transformedErrorMessage = errorMessage && `(${errorMessage})`;
 
   return (
-    <StyledErrorMessageContainer isDisabled={isDisabled} state={state}>
+    <StyledErrorMessageContainer disabled={disabled} state={state}>
       <MdOutlineError />
       <Text
         type="body"
         size="small"
         margin="8px 0px 0px 4px"
         appearance="error"
-        disabled={isDisabled}
+        disabled={disabled}
       >
         {transformedErrorMessage}
       </Text>
@@ -51,17 +51,17 @@ const Invalid = (props: IMessageProps) => {
 };
 
 const Success = (props: IMessageProps) => {
-  const { isDisabled, state, validMessage } = props;
+  const { disabled, state, validMessage } = props;
 
   return (
-    <StyledValidMessageContainer isDisabled={isDisabled} state={state}>
+    <StyledValidMessageContainer disabled={disabled} state={state}>
       <MdCheckCircle />
       <Text
         type="body"
         size="small"
         margin="8px 0px 0px 4px"
         appearance="success"
-        disabled={isDisabled}
+        disabled={disabled}
       >
         {validMessage}
       </Text>
@@ -75,7 +75,7 @@ const TextFieldUI = (props: ITextFieldProps) => {
     name,
     id,
     placeholder,
-    isDisabled,
+    disabled,
     type,
     value,
     handleChange,
@@ -100,17 +100,17 @@ const TextFieldUI = (props: ITextFieldProps) => {
   const transformedInvalid = state === "invalid" ? true : false;
 
   return (
-    <StyledContainer isFullWidth={isFullWidth} isDisabled={isDisabled}>
+    <StyledContainer isFullWidth={isFullWidth} disabled={disabled}>
       <StyledContainerLabel
         alignItems="center"
         wrap="wrap"
         size={size}
-        isDisabled={isDisabled}
+        disabled={disabled}
       >
         {label && (
           <Label
             htmlFor={id}
-            disabled={isDisabled}
+            disabled={disabled}
             focused={isFocused}
             invalid={transformedInvalid}
             size={getTypo(size!)}
@@ -119,7 +119,7 @@ const TextFieldUI = (props: ITextFieldProps) => {
           </Label>
         )}
 
-        {isRequired && !isDisabled && (
+        {isRequired && !disabled && (
           <Text type="body" size="small" appearance="dark">
             (Required)
           </Text>
@@ -127,14 +127,14 @@ const TextFieldUI = (props: ITextFieldProps) => {
       </StyledContainerLabel>
 
       <StyledInputContainer
-        isDisabled={isDisabled}
+        disabled={disabled}
         isFocused={isFocused}
         state={state}
         iconBefore={iconBefore}
         iconAfter={iconAfter}
       >
         {iconBefore && (
-          <StyledIcon isDisabled={isDisabled} iconBefore={iconBefore}>
+          <StyledIcon disabled={disabled} iconBefore={iconBefore}>
             {iconBefore}
           </StyledIcon>
         )}
@@ -144,7 +144,7 @@ const TextFieldUI = (props: ITextFieldProps) => {
           name={name}
           id={id}
           placeholder={placeholder}
-          isDisabled={isDisabled}
+          disabled={disabled}
           type={type}
           value={value}
           iconBefore={iconBefore}
@@ -165,7 +165,7 @@ const TextFieldUI = (props: ITextFieldProps) => {
         />
 
         {iconAfter && (
-          <StyledIcon iconAfter={iconAfter} isDisabled={isDisabled}>
+          <StyledIcon iconAfter={iconAfter} disabled={disabled}>
             {iconAfter}
           </StyledIcon>
         )}
@@ -173,14 +173,14 @@ const TextFieldUI = (props: ITextFieldProps) => {
 
       {state === "invalid" && (
         <Invalid
-          isDisabled={isDisabled}
+          disabled={disabled}
           state={state}
           errorMessage={errorMessage}
         />
       )}
       {state === "valid" && (
         <Success
-          isDisabled={isDisabled}
+          disabled={disabled}
           state={state}
           validMessage={validMessage}
         />

--- a/src/components/inputs/TextField/props.ts
+++ b/src/components/inputs/TextField/props.ts
@@ -36,7 +36,7 @@ const props = {
   placeholder: {
     description: "text to display in the text field whenever it is empty",
   },
-  isDisabled: {
+  disabled: {
     description:
       "sets the field as to appear disabled, users will not be able to interact with the text field",
     table: {

--- a/src/components/inputs/TextField/stories/TextField.Disabled.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Disabled.stories.tsx
@@ -16,7 +16,7 @@ const TextFieldComponent = (args: ITextFieldProps) => {
     <Stack justifyContent="space-evenly">
       {sizes.map((size) => (
         <div key={size}>
-          <TextFieldController {...args} size={size} isDisabled={true} />
+          <TextFieldController {...args} size={size} disabled={true} />
         </div>
       ))}
     </Stack>

--- a/src/components/inputs/TextField/stories/TextField.Invalid.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Invalid.stories.tsx
@@ -18,7 +18,7 @@ Invalid.args = {
   id: "Username",
   value: "L-GARZON",
   placeholder: "Username..",
-  isDisabled: false,
+  disabled: false,
   type: "text",
   maxLength: 20,
   minLength: 1,

--- a/src/components/inputs/TextField/stories/TextField.Number.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Number.stories.tsx
@@ -17,7 +17,7 @@ Number.args = {
   placeholder: "Value",
   type: "number",
   state: "pending",
-  isDisabled: false,
+  disabled: false,
   max: 10,
   min: 0,
   isRequired: false,

--- a/src/components/inputs/TextField/stories/TextField.Required.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Required.stories.tsx
@@ -28,7 +28,7 @@ Required.args = {
   name: "Username",
   id: "Username",
   placeholder: "Write your full name",
-  isDisabled: false,
+  disabled: false,
   type: "text",
   state: "pending",
   size: "wide",

--- a/src/components/inputs/TextField/stories/TextField.Search.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Search.stories.tsx
@@ -18,7 +18,7 @@ Search.args = {
   name: "searchField",
   id: "searchField",
   placeholder: "Search...",
-  isDisabled: false,
+  disabled: false,
   iconAfter: <MdSearch />,
   isRequired: false,
   errorMessage: "",

--- a/src/components/inputs/TextField/stories/TextField.Sizes.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Sizes.stories.tsx
@@ -25,7 +25,7 @@ const Size = {
     label: "Username",
     name: "Username",
     id: "Username",
-    isDisabled: false,
+    disabled: false,
     placeholder: "Write your full name",
     value: "",
     state: "pending",

--- a/src/components/inputs/TextField/stories/TextField.Valid.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Valid.stories.tsx
@@ -26,7 +26,7 @@ const Valid = {
     id: "Username",
     placeholder: "Write your full name",
     value: "LGARZON",
-    isDisabled: false,
+    disabled: false,
     errorMessage: "Please enter only letters in this field",
     validMessage: "Field validation is successful",
     isRequired: true,

--- a/src/components/inputs/TextField/styles.ts
+++ b/src/components/inputs/TextField/styles.ts
@@ -30,8 +30,8 @@ const getGrid = (props: ITextFieldProps) => {
 };
 
 const getColors = (props: ITextFieldProps) => {
-  const { isDisabled, state, isFocused } = props;
-  if (isDisabled) {
+  const { disabled, state, isFocused } = props;
+  if (disabled) {
     return colors.ref.palette.neutral.n70;
   }
 
@@ -45,9 +45,9 @@ const getColors = (props: ITextFieldProps) => {
   return colors.ref.palette.neutral.n40;
 };
 
-const getIsDisabled = (props: ITextFieldProps) => {
-  const { isDisabled, state } = props;
-  if (isDisabled) {
+const getdisabled = (props: ITextFieldProps) => {
+  const { disabled, state } = props;
+  if (disabled) {
     return colors.ref.palette.neutral.n70;
   }
 
@@ -79,7 +79,7 @@ const getPadding = (props: ITextFieldProps) => {
 };
 
 const StyledContainer = styled.div`
-  cursor: ${({ isDisabled }: ITextFieldProps) => isDisabled && "not-allowed"};
+  cursor: ${({ disabled }: ITextFieldProps) => disabled && "not-allowed"};
   width: ${({ isFullWidth }: ITextFieldProps) =>
     isFullWidth ? "100%" : "fit-content"};
 `;
@@ -89,7 +89,7 @@ const StyledContainerLabel = styled.div`
   align-items: center;
   margin-bottom: 4px;
   padding-left: 16px;
-  pointer-events: ${({ isDisabled }: ITextFieldProps) => isDisabled && "none"};
+  pointer-events: ${({ disabled }: ITextFieldProps) => disabled && "none"};
 
   & label {
     margin-right: 5px;
@@ -105,8 +105,8 @@ const StyledInputContainer = styled.div`
   background: ${colors.ref.palette.neutral.n10};
   grid-template-columns: ${(props: ITextFieldProps) => getGrid(props)};
   border: 1px solid ${(props: ITextFieldProps) => getColors(props)};
-  ${({ isDisabled }: ITextFieldProps) =>
-    isDisabled && "pointer-events: none; opacity: 0.5;"}
+  ${({ disabled }: ITextFieldProps) =>
+    disabled && "pointer-events: none; opacity: 0.5;"}
 `;
 
 const StyledInput = styled.input`
@@ -117,8 +117,8 @@ const StyledInput = styled.input`
   font-weight: ${typography.sys.typescale.bodyLarge.weight};
   line-height: ${typography.sys.typescale.bodyLarge.lineHeight};
   letter-spacing: ${typography.sys.typescale.bodyLarge.tracking};
-  color: ${({ isDisabled }: ITextFieldProps) =>
-    isDisabled ? colors.ref.palette.neutral.n70 : colors.sys.text.dark};
+  color: ${({ disabled }: ITextFieldProps) =>
+    disabled ? colors.ref.palette.neutral.n70 : colors.sys.text.dark};
   background: ${colors.ref.palette.neutral.n10};
   ${(props: ITextFieldProps) => getPadding(props)}
   width: ${({ isFullWidth }: ITextFieldProps) =>
@@ -156,8 +156,8 @@ const StyledIcon = styled.div`
   padding-right: ${({ iconAfter }: ITextFieldProps) => iconAfter && "10px"};
   height: 24px;
   width: 24px;
-  color: ${({ isDisabled }: ITextFieldProps) =>
-    isDisabled && colors.ref.palette.neutral.n70};
+  color: ${({ disabled }: ITextFieldProps) =>
+    disabled && colors.ref.palette.neutral.n70};
 `;
 
 const StyledErrorMessageContainer = styled.div`
@@ -165,7 +165,7 @@ const StyledErrorMessageContainer = styled.div`
   align-items: center;
   margin-left: 12px;
   pointer-events: none;
-  color: ${(props: ITextFieldProps) => getIsDisabled(props)};
+  color: ${(props: ITextFieldProps) => getdisabled(props)};
 
   & svg {
     width: 14px;
@@ -176,7 +176,7 @@ const StyledErrorMessageContainer = styled.div`
 `;
 
 const StyledValidMessageContainer = styled(StyledErrorMessageContainer)`
-  color: ${(props: ITextFieldProps) => getIsDisabled(props)}; ;
+  color: ${(props: ITextFieldProps) => getdisabled(props)}; ;
 `;
 
 export {


### PR DESCRIPTION
This PR enacts a change in naming for the `<Textfield />` component. Specifically, the `isDisabled` prop has been streamlined to `disabled` to foster clarity and align with common naming conventions. This renaming is part of our continuous endeavor to make prop names more intuitive across our component library. Please evaluate this alteration and ensure that every usage or reference to this prop within the codebase has been appropriately updated.