### PR TITLE
`<Textfield />:` rename `isFullWidth` prop to just `fullwidth`

### DIFF
--- a/src/components/data/Text/Text.stories.tsx
+++ b/src/components/data/Text/Text.stories.tsx
@@ -2,7 +2,7 @@ import { ThemeProvider } from "styled-components";
 import { Text, ITextProps } from ".";
 
 import { props, parameters } from "./props";
-import { presente } from "@src/shared/themes/presente";
+import { presente } from "@shared/themes/presente";
 
 const story = {
   title: "data/Text",

--- a/src/components/feedback/InteractiveModal/index.jsx
+++ b/src/components/feedback/InteractiveModal/index.jsx
@@ -61,7 +61,7 @@ const InteractiveModal = (props) => {
                         id={field.id}
                         placeholder={field.titleName}
                         value={infoData[field.id]}
-                        isFullWidth={true}
+                        fullwidth={true}
                         type="text"
                         size="compact"
                         readOnly={true}
@@ -76,7 +76,7 @@ const InteractiveModal = (props) => {
                     id={key}
                     placeholder={key}
                     value={infoData[key]}
-                    isFullWidth={true}
+                    fullwidth={true}
                     type="text"
                     size="compact"
                     readOnly={true}

--- a/src/components/inputs/TextField/index.tsx
+++ b/src/components/inputs/TextField/index.tsx
@@ -23,7 +23,7 @@ export interface ITextFieldProps {
   errorMessage?: string;
   validMessage?: string;
   size?: Size;
-  isFullWidth?: boolean;
+  fullwidth?: boolean;
   handleFocus?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleBlur?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   readOnly?: boolean;
@@ -34,7 +34,7 @@ const defaultIsDisabled = false;
 const defaultType: InputType = "text";
 const defaultIsRequired = false;
 const defaultState: State = "pending";
-const defaultIsFullWidth = false;
+const defaultfullwidth = false;
 
 const TextField = (props: ITextFieldProps) => {
   const {
@@ -57,7 +57,7 @@ const TextField = (props: ITextFieldProps) => {
     errorMessage,
     validMessage,
     size = "wide",
-    isFullWidth = false,
+    fullwidth = false,
     handleFocus,
     handleBlur,
     readOnly,
@@ -91,8 +91,8 @@ const TextField = (props: ITextFieldProps) => {
   const transformedIsRequired =
     typeof isRequired === "boolean" ? isRequired : defaultIsRequired;
 
-  const transformedIsFullWidth =
-    typeof isFullWidth === "boolean" ? isFullWidth : defaultIsFullWidth;
+  const transformedfullwidth =
+    typeof fullwidth === "boolean" ? fullwidth : defaultfullwidth;
 
   const transformedReadOnly = typeof readOnly === "boolean" ? readOnly : false;
 
@@ -117,7 +117,7 @@ const TextField = (props: ITextFieldProps) => {
       state={transformedState}
       errorMessage={errorMessage}
       validMessage={validMessage}
-      isFullWidth={transformedIsFullWidth}
+      fullwidth={transformedfullwidth}
       isFocused={isFocused}
       handleFocus={interceptFocus}
       handleBlur={interceptBlur}

--- a/src/components/inputs/TextField/interface.tsx
+++ b/src/components/inputs/TextField/interface.tsx
@@ -90,7 +90,7 @@ const TextFieldUI = (props: ITextFieldProps) => {
     errorMessage,
     validMessage,
     size,
-    isFullWidth,
+    fullwidth,
     isFocused,
     handleFocus,
     handleBlur,
@@ -100,7 +100,7 @@ const TextFieldUI = (props: ITextFieldProps) => {
   const transformedInvalid = state === "invalid" ? true : false;
 
   return (
-    <StyledContainer isFullWidth={isFullWidth} isDisabled={isDisabled}>
+    <StyledContainer fullwidth={fullwidth} isDisabled={isDisabled}>
       <StyledContainerLabel
         alignItems="center"
         wrap="wrap"
@@ -156,7 +156,7 @@ const TextFieldUI = (props: ITextFieldProps) => {
           isRequired={isRequired}
           size={size}
           state={state}
-          isFullWidth={isFullWidth}
+          fullwidth={fullwidth}
           isFocused={isFocused}
           onChange={handleChange}
           onFocus={handleFocus}

--- a/src/components/inputs/TextField/props.ts
+++ b/src/components/inputs/TextField/props.ts
@@ -107,7 +107,7 @@ const props = {
     control: { type: "select" },
     description: "defines the size of the component",
   },
-  isFullWidth: {
+  fullwidth: {
     description: "option to fit field width to its parent width",
     table: {
       defaultValue: { summary: false },

--- a/src/components/inputs/TextField/stories/TextField.Invalid.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Invalid.stories.tsx
@@ -26,7 +26,7 @@ Invalid.args = {
   errorMessage: "Please enter only letters in this field",
   validMessage: "The field has been successfully validated",
   size: "wide",
-  isFullWidth: false,
+  fullwidth: false,
 };
 
 export default story;

--- a/src/components/inputs/TextField/stories/TextField.Number.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Number.stories.tsx
@@ -22,7 +22,7 @@ Number.args = {
   min: 0,
   isRequired: false,
   size: "wide",
-  isFullWidth: false,
+  fullwidth: false,
 };
 
 export default story;

--- a/src/components/inputs/TextField/stories/TextField.Required.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Required.stories.tsx
@@ -36,7 +36,7 @@ Required.args = {
   minLength: 1,
   max: 10,
   min: 1,
-  isFullWidth: false,
+  fullwidth: false,
   errorMessage: "This field can not be blank",
   validMessage: "Field validation is successful",
 };

--- a/src/components/inputs/TextField/stories/TextField.Search.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Search.stories.tsx
@@ -28,7 +28,7 @@ Search.args = {
   min: 1,
   size: "wide",
   type: "text",
-  isFullWidth: false,
+  fullwidth: false,
 };
 
 export default story;

--- a/src/components/inputs/TextField/stories/TextField.Sizes.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Sizes.stories.tsx
@@ -34,7 +34,7 @@ const Size = {
     minLength: 1,
     errorMessage: "Please enter only letters in this field",
     validMessage: "The field has been successfully validated",
-    isFullWidth: false,
+    fullwidth: false,
     isRequired: false,
     readOnly: false,
   },

--- a/src/components/inputs/TextField/styles.ts
+++ b/src/components/inputs/TextField/styles.ts
@@ -80,8 +80,8 @@ const getPadding = (props: ITextFieldProps) => {
 
 const StyledContainer = styled.div`
   cursor: ${({ isDisabled }: ITextFieldProps) => isDisabled && "not-allowed"};
-  width: ${({ isFullWidth }: ITextFieldProps) =>
-    isFullWidth ? "100%" : "fit-content"};
+  width: ${({ fullwidth }: ITextFieldProps) =>
+    fullwidth ? "100%" : "fit-content"};
 `;
 
 const StyledContainerLabel = styled.div`
@@ -121,8 +121,8 @@ const StyledInput = styled.input`
     isDisabled ? colors.ref.palette.neutral.n70 : colors.sys.text.dark};
   background: ${colors.ref.palette.neutral.n10};
   ${(props: ITextFieldProps) => getPadding(props)}
-  width: ${({ isFullWidth }: ITextFieldProps) =>
-    isFullWidth ? "calc(100% - 32px)" : "252px"};
+  width: ${({ fullwidth }: ITextFieldProps) =>
+    fullwidth ? "calc(100% - 32px)" : "252px"};
   ${({ size }: ITextFieldProps) => size && sizeOptions[size]};
   border: none;
 


### PR DESCRIPTION
This PR carries out a naming adjustment for the `<Textfield />` component. The `isFullWidth` prop has been rebranded as `fullwidth`, resulting in a clearer and more concise prop name. This renaming aligns with our intention to simplify prop names and improve their readability throughout our components. We request a thorough review of this change and ask to ensure that all occurrences or references to this prop within the project are modified accordingly.