### PR TITLE
`<Textfield />:` rename `isRequired` prop to just `required`

### DIFF
--- a/src/components/inputs/TextField/index.tsx
+++ b/src/components/inputs/TextField/index.tsx
@@ -18,7 +18,7 @@ export interface ITextFieldProps {
   minLength?: number;
   max?: number;
   min?: number;
-  isRequired: boolean;
+  required: boolean;
   state?: State;
   errorMessage?: string;
   validMessage?: string;
@@ -32,7 +32,7 @@ export interface ITextFieldProps {
 
 const defaultIsDisabled = false;
 const defaultType: InputType = "text";
-const defaultIsRequired = false;
+const defaultRequired = false;
 const defaultState: State = "pending";
 const defaultIsFullWidth = false;
 
@@ -52,7 +52,7 @@ const TextField = (props: ITextFieldProps) => {
     minLength,
     max,
     min,
-    isRequired = false,
+    required = false,
     state = "pending",
     errorMessage,
     validMessage,
@@ -88,8 +88,8 @@ const TextField = (props: ITextFieldProps) => {
 
   const transformedTypes = inputTypes.includes(type) ? type : defaultType;
 
-  const transformedIsRequired =
-    typeof isRequired === "boolean" ? isRequired : defaultIsRequired;
+  const transformedRequired =
+    typeof required === "boolean" ? required : defaultRequired;
 
   const transformedIsFullWidth =
     typeof isFullWidth === "boolean" ? isFullWidth : defaultIsFullWidth;
@@ -112,7 +112,7 @@ const TextField = (props: ITextFieldProps) => {
       minLength={minLength}
       max={max}
       min={min}
-      isRequired={transformedIsRequired}
+      required={transformedRequired}
       size={size}
       state={transformedState}
       errorMessage={errorMessage}

--- a/src/components/inputs/TextField/interface.tsx
+++ b/src/components/inputs/TextField/interface.tsx
@@ -85,7 +85,7 @@ const TextFieldUI = (props: ITextFieldProps) => {
     minLength,
     max,
     min,
-    isRequired,
+    required,
     state,
     errorMessage,
     validMessage,
@@ -119,7 +119,7 @@ const TextFieldUI = (props: ITextFieldProps) => {
           </Label>
         )}
 
-        {isRequired && !isDisabled && (
+        {required && !isDisabled && (
           <Text type="body" size="small" appearance="dark">
             (Required)
           </Text>
@@ -153,7 +153,7 @@ const TextFieldUI = (props: ITextFieldProps) => {
           minLength={minLength}
           max={max}
           min={min}
-          isRequired={isRequired}
+          required={required}
           size={size}
           state={state}
           isFullWidth={isFullWidth}

--- a/src/components/inputs/TextField/props.ts
+++ b/src/components/inputs/TextField/props.ts
@@ -82,7 +82,7 @@ const props = {
     description:
       "defines the minimum value that can be inserted (useful for components of type number)",
   },
-  isRequired: {
+  required: {
     description: "defines if the field is required or not",
     table: {
       defaultValue: { summary: false },

--- a/src/components/inputs/TextField/stories/TextField.Invalid.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Invalid.stories.tsx
@@ -22,7 +22,7 @@ Invalid.args = {
   type: "text",
   maxLength: 20,
   minLength: 1,
-  isRequired: true,
+  required: true,
   errorMessage: "Please enter only letters in this field",
   validMessage: "The field has been successfully validated",
   size: "wide",

--- a/src/components/inputs/TextField/stories/TextField.Number.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Number.stories.tsx
@@ -20,7 +20,7 @@ Number.args = {
   isDisabled: false,
   max: 10,
   min: 0,
-  isRequired: false,
+  required: false,
   size: "wide",
   isFullWidth: false,
 };

--- a/src/components/inputs/TextField/stories/TextField.Required.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Required.stories.tsx
@@ -21,7 +21,7 @@ const RequiredComponent = (args: ITextFieldProps) => {
 };
 
 const Required = (args: ITextFieldProps) => (
-  <RequiredComponent {...args} isRequired={true} />
+  <RequiredComponent {...args} required={true} />
 );
 Required.args = {
   label: "Username",

--- a/src/components/inputs/TextField/stories/TextField.Search.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Search.stories.tsx
@@ -20,7 +20,7 @@ Search.args = {
   placeholder: "Search...",
   isDisabled: false,
   iconAfter: <MdSearch />,
-  isRequired: false,
+  required: false,
   errorMessage: "",
   maxLength: 10,
   minLength: 1,

--- a/src/components/inputs/TextField/stories/TextField.Sizes.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Sizes.stories.tsx
@@ -35,7 +35,7 @@ const Size = {
     errorMessage: "Please enter only letters in this field",
     validMessage: "The field has been successfully validated",
     isFullWidth: false,
-    isRequired: false,
+    required: false,
     readOnly: false,
   },
   render: (args: ITextFieldProps) => <TextFieldComponent {...args} />,

--- a/src/components/inputs/TextField/stories/TextField.Valid.stories.tsx
+++ b/src/components/inputs/TextField/stories/TextField.Valid.stories.tsx
@@ -29,7 +29,7 @@ const Valid = {
     isDisabled: false,
     errorMessage: "Please enter only letters in this field",
     validMessage: "Field validation is successful",
-    isRequired: true,
+    required: true,
     state: "pending",
     type: "text",
     size: "wide",


### PR DESCRIPTION
This PR introduces a naming refinement for the `<Textfield />` component. Specifically, the `isRequired` prop has been renamed to simply `required`, making the prop name more direct and intuitive. This change is part of our ongoing effort to enhance prop naming conventions across our component library. Please review this update and ensure that every reference or usage of this prop within the codebase is appropriately adjusted.