### PR TITLE
`<Textfield />:` rename `handleFocus` prop to `onFocus`

### DIFF
--- a/src/components/inputs/Textfield/index.tsx
+++ b/src/components/inputs/Textfield/index.tsx
@@ -24,7 +24,7 @@ export interface ITextfieldProps {
   validMessage?: string;
   size?: Size;
   fullwidth?: boolean;
-  handleFocus?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onFocus?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleBlur?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   readOnly?: boolean;
   isFocused?: boolean;
@@ -58,7 +58,7 @@ const Textfield = (props: ITextfieldProps) => {
     validMessage,
     size = "wide",
     fullwidth = false,
-    handleFocus,
+    onFocus,
     handleBlur,
     readOnly,
   } = props;
@@ -69,8 +69,8 @@ const Textfield = (props: ITextfieldProps) => {
     if (!readOnly) {
       setIsFocused(true);
     }
-    if (typeof handleFocus === "function") {
-      handleFocus(e);
+    if (typeof onFocus === "function") {
+      onFocus(e);
     }
   };
 
@@ -119,7 +119,7 @@ const Textfield = (props: ITextfieldProps) => {
       validMessage={validMessage}
       fullwidth={transformedfullwidth}
       isFocused={isFocused}
-      handleFocus={interceptFocus}
+      onFocus={interceptFocus}
       handleBlur={interceptBlur}
       readOnly={transformedReadOnly}
     />

--- a/src/components/inputs/Textfield/interface.tsx
+++ b/src/components/inputs/Textfield/interface.tsx
@@ -92,7 +92,7 @@ const TextfieldUI = (props: ITextfieldProps) => {
     size,
     fullwidth,
     isFocused,
-    handleFocus,
+    onFocus,
     handleBlur,
     readOnly,
   } = props;
@@ -159,7 +159,7 @@ const TextfieldUI = (props: ITextfieldProps) => {
           fullwidth={fullwidth}
           isFocused={isFocused}
           onChange={onChange}
-          onFocus={handleFocus}
+          onFocus={onFocus}
           onBlur={handleBlur}
           readOnly={readOnly}
         />

--- a/src/components/inputs/Textfield/stories/TextfieldController.tsx
+++ b/src/components/inputs/Textfield/stories/TextfieldController.tsx
@@ -14,7 +14,7 @@ const TextfieldController = (props: ITextfieldProps) => {
     setForm({ value: e.target.value, state: "pending" });
   };
 
-  const handleFocus = () => {
+  const onFocus = () => {
     if (form.state === "invalid") {
       return setForm({ ...form, state: "invalid" });
     }
@@ -32,7 +32,7 @@ const TextfieldController = (props: ITextfieldProps) => {
       value={form.value}
       onChange={onChange}
       state={form.state}
-      handleFocus={handleFocus}
+      onFocus={onFocus}
       handleBlur={handleBlur}
     />
   );


### PR DESCRIPTION
This PR brings forth a naming revision for the `<Textfield />` component. Specifically, the `handleFocus` prop is being renamed to `onFocus`, a move towards more conventional naming practices and improved clarity. This adjustment is in line with our ongoing efforts to provide intuitive and consistent prop names throughout our component collection. 