### PR TITLE
`<Textfield />:` rename `handleBlur` prop to `onBlur`

### DIFF
--- a/src/components/inputs/Textfield/index.tsx
+++ b/src/components/inputs/Textfield/index.tsx
@@ -25,7 +25,7 @@ export interface ITextfieldProps {
   size?: Size;
   fullwidth?: boolean;
   handleFocus?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  handleBlur?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   readOnly?: boolean;
   isFocused?: boolean;
 }
@@ -59,7 +59,7 @@ const Textfield = (props: ITextfieldProps) => {
     size = "wide",
     fullwidth = false,
     handleFocus,
-    handleBlur,
+    onBlur,
     readOnly,
   } = props;
 
@@ -76,8 +76,8 @@ const Textfield = (props: ITextfieldProps) => {
 
   const interceptBlur = (e: React.ChangeEvent<HTMLInputElement>) => {
     setIsFocused(false);
-    if (typeof handleBlur === "function") {
-      handleBlur(e);
+    if (typeof onBlur === "function") {
+      onBlur(e);
     }
   };
 
@@ -120,7 +120,7 @@ const Textfield = (props: ITextfieldProps) => {
       fullwidth={transformedfullwidth}
       isFocused={isFocused}
       handleFocus={interceptFocus}
-      handleBlur={interceptBlur}
+      onBlur={interceptBlur}
       readOnly={transformedReadOnly}
     />
   );

--- a/src/components/inputs/Textfield/interface.tsx
+++ b/src/components/inputs/Textfield/interface.tsx
@@ -93,7 +93,7 @@ const TextfieldUI = (props: ITextfieldProps) => {
     fullwidth,
     isFocused,
     handleFocus,
-    handleBlur,
+    onBlur,
     readOnly,
   } = props;
 
@@ -160,7 +160,7 @@ const TextfieldUI = (props: ITextfieldProps) => {
           isFocused={isFocused}
           onChange={onChange}
           onFocus={handleFocus}
-          onBlur={handleBlur}
+          onBlur={onBlur}
           readOnly={readOnly}
         />
 

--- a/src/components/inputs/Textfield/stories/TextfieldController.tsx
+++ b/src/components/inputs/Textfield/stories/TextfieldController.tsx
@@ -21,7 +21,7 @@ const TextfieldController = (props: ITextfieldProps) => {
     setForm({ ...form, state: "pending" });
   };
 
-  const handleBlur = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onBlur = (e: React.ChangeEvent<HTMLInputElement>) => {
     const isValid = isAlphabetical(e.target.value);
     setForm({ ...form, state: isValid ? "valid" : "invalid" });
   };
@@ -33,7 +33,7 @@ const TextfieldController = (props: ITextfieldProps) => {
       onChange={onChange}
       state={form.state}
       handleFocus={handleFocus}
-      handleBlur={handleBlur}
+      onBlur={onBlur}
     />
   );
 };


### PR DESCRIPTION
In this PR, a naming change has been instituted for the `<Textfield />` component. The `handleBlur` prop has transitioned to `onBlur`, a naming convention that's more in line with standard practices and offers clearer understanding. This revision is part of our continuous pursuit to standardize and simplify prop names across our component portfolio