### PR TITLE
`<Textfield />:` refactor `errorMessage` and `validMessage` to use just a `message` prop

### DIFF
--- a/src/components/inputs/Textfield/index.tsx
+++ b/src/components/inputs/Textfield/index.tsx
@@ -3,6 +3,11 @@ import { useState } from "react";
 import { TextfieldUI } from "./interface";
 import { InputType, Size, State, inputTypes, states } from "./props";
 
+export interface IMessage {
+  content: string;
+  type: "success" | "invalid";
+}
+
 export interface ITextfieldProps {
   label?: string;
   name: string;
@@ -20,8 +25,7 @@ export interface ITextfieldProps {
   min?: number;
   required: boolean;
   state?: State;
-  errorMessage?: string;
-  validMessage?: string;
+  message?: IMessage;
   size?: Size;
   fullwidth?: boolean;
   handleFocus?: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -54,8 +58,7 @@ const Textfield = (props: ITextfieldProps) => {
     min,
     required = false,
     state = "pending",
-    errorMessage,
-    validMessage,
+    message,
     size = "wide",
     fullwidth = false,
     handleFocus,
@@ -115,8 +118,7 @@ const Textfield = (props: ITextfieldProps) => {
       required={transformedRequired}
       size={size}
       state={transformedState}
-      errorMessage={errorMessage}
-      validMessage={validMessage}
+      message={message}
       fullwidth={transformedfullwidth}
       isFocused={isFocused}
       handleFocus={interceptFocus}

--- a/src/components/inputs/Textfield/interface.tsx
+++ b/src/components/inputs/Textfield/interface.tsx
@@ -3,7 +3,7 @@ import { MdOutlineError, MdCheckCircle } from "react-icons/md";
 import { Label } from "@inputs/Label";
 import { Text } from "@data/Text";
 
-import { ITextfieldProps } from ".";
+import { IMessage, ITextfieldProps } from ".";
 
 import {
   StyledContainer,
@@ -19,8 +19,7 @@ import { Size, State } from "./props";
 export interface IMessageProps {
   state?: State;
   disabled?: boolean;
-  errorMessage?: string;
-  validMessage?: string;
+  message?: IMessage;
 }
 
 const getTypo = (size: Size) => {
@@ -31,8 +30,9 @@ const getTypo = (size: Size) => {
 };
 
 const Invalid = (props: IMessageProps) => {
-  const { disabled, state, errorMessage } = props;
-  const transformedErrorMessage = errorMessage && `(${errorMessage})`;
+  const { disabled, state, message } = props;
+
+  if (message?.type !== "invalid") return null;
 
   return (
     <StyledErrorMessageContainer disabled={disabled} state={state}>
@@ -44,14 +44,16 @@ const Invalid = (props: IMessageProps) => {
         appearance="error"
         disabled={disabled}
       >
-        {transformedErrorMessage}
+        {message?.content && `(${message.content})`}
       </Text>
     </StyledErrorMessageContainer>
   );
 };
 
 const Success = (props: IMessageProps) => {
-  const { disabled, state, validMessage } = props;
+  const { disabled, state, message } = props;
+
+  if (message?.type !== "success") return null;
 
   return (
     <StyledValidMessageContainer disabled={disabled} state={state}>
@@ -63,7 +65,7 @@ const Success = (props: IMessageProps) => {
         appearance="success"
         disabled={disabled}
       >
-        {validMessage}
+        {message?.content}
       </Text>
     </StyledValidMessageContainer>
   );
@@ -87,8 +89,7 @@ const TextfieldUI = (props: ITextfieldProps) => {
     min,
     required,
     state,
-    errorMessage,
-    validMessage,
+    message,
     size,
     fullwidth,
     isFocused,
@@ -97,7 +98,7 @@ const TextfieldUI = (props: ITextfieldProps) => {
     readOnly,
   } = props;
 
-  const transformedInvalid = state === "invalid" ? true : false;
+  const transformedInvalid = message?.type === "invalid";
 
   return (
     <StyledContainer fullwidth={fullwidth} disabled={disabled}>
@@ -171,19 +172,11 @@ const TextfieldUI = (props: ITextfieldProps) => {
         )}
       </StyledInputContainer>
 
-      {state === "invalid" && (
-        <Invalid
-          disabled={disabled}
-          state={state}
-          errorMessage={errorMessage}
-        />
+      {message?.type === "invalid" && (
+        <Invalid disabled={disabled} state={state} message={message} />
       )}
-      {state === "valid" && (
-        <Success
-          disabled={disabled}
-          state={state}
-          validMessage={validMessage}
-        />
+      {message?.type === "success" && (
+        <Success disabled={disabled} state={state} message={message} />
       )}
     </StyledContainer>
   );

--- a/src/components/inputs/Textfield/stories/Textfield.Invalid.stories.tsx
+++ b/src/components/inputs/Textfield/stories/Textfield.Invalid.stories.tsx
@@ -24,8 +24,10 @@ Invalid.args = {
   maxLength: 20,
   minLength: 1,
   required: true,
-  errorMessage: "Please enter only letters in this field",
-  validMessage: "The field has been successfully validated",
+  message: {
+    content: "Please enter only letters in this field",
+    type: "invalid",
+  },
   size: "wide",
   fullwidth: false,
 };

--- a/src/components/inputs/Textfield/stories/Textfield.Required.stories.tsx
+++ b/src/components/inputs/Textfield/stories/Textfield.Required.stories.tsx
@@ -1,4 +1,4 @@
-import { Textfield, ITextfieldProps } from "..";
+import { Textfield, ITextfieldProps, IMessage } from "..";
 import { TextfieldController } from "./TextfieldController";
 
 import { Stack } from "@layouts/Stack";
@@ -14,7 +14,7 @@ const story = {
 const RequiredComponent = (args: ITextfieldProps) => {
   return (
     <Stack justifyContent="space-evenly">
-      <TextfieldController {...args} />
+      <TextfieldController {...args} state="valid" />
       <TextfieldController {...args} size="compact" state="invalid" />
     </Stack>
   );
@@ -37,8 +37,6 @@ Required.args = {
   max: 10,
   min: 1,
   fullwidth: false,
-  errorMessage: "This field can not be blank",
-  validMessage: "Field validation is successful",
 };
 
 export default story;

--- a/src/components/inputs/Textfield/stories/Textfield.Search.stories.tsx
+++ b/src/components/inputs/Textfield/stories/Textfield.Search.stories.tsx
@@ -21,7 +21,7 @@ Search.args = {
   disabled: false,
   iconAfter: <MdSearch />,
   required: false,
-  errorMessage: "",
+  message: "",
   maxLength: 10,
   minLength: 1,
   max: 10,

--- a/src/components/inputs/Textfield/stories/Textfield.Sizes.stories.tsx
+++ b/src/components/inputs/Textfield/stories/Textfield.Sizes.stories.tsx
@@ -1,4 +1,4 @@
-import { Textfield, ITextfieldProps } from "..";
+import { Textfield, ITextfieldProps, IMessage } from "..";
 import { TextfieldController } from "./TextfieldController";
 import { Stack } from "@layouts/Stack";
 
@@ -13,7 +13,7 @@ const story = {
 const TextfieldComponent = (args: ITextfieldProps) => {
   return (
     <Stack justifyContent="space-evenly">
-      {sizes.map((size) => (
+      {sizes.map((size, index) => (
         <TextfieldController {...args} key={size} size={size} />
       ))}
     </Stack>
@@ -32,8 +32,6 @@ const Size = {
     type: "text",
     maxLength: 10,
     minLength: 1,
-    errorMessage: "Please enter only letters in this field",
-    validMessage: "The field has been successfully validated",
     fullwidth: false,
     required: false,
     readOnly: false,

--- a/src/components/inputs/Textfield/stories/Textfield.Valid.stories.tsx
+++ b/src/components/inputs/Textfield/stories/Textfield.Valid.stories.tsx
@@ -27,8 +27,10 @@ const Valid = {
     placeholder: "Write your full name",
     value: "LGARZON",
     disabled: false,
-    errorMessage: "Please enter only letters in this field",
-    validMessage: "Field validation is successful",
+    message: {
+      content: "Field validation is successful",
+      type: "success",
+    },
     required: true,
     state: "pending",
     type: "text",

--- a/src/components/inputs/Textfield/stories/Textfield.stories.tsx
+++ b/src/components/inputs/Textfield/stories/Textfield.stories.tsx
@@ -21,8 +21,6 @@ Default.args = {
   minLength: 1,
   min: 0,
   max: 0,
-  errorMessage: "Please enter only letters in this field",
-  validMessage: "The field has been successfully validated",
   size: "wide",
   readOnly: false,
 };

--- a/src/components/inputs/Textfield/stories/TextfieldController.tsx
+++ b/src/components/inputs/Textfield/stories/TextfieldController.tsx
@@ -1,29 +1,48 @@
 import { useState } from "react";
+import { Textfield, ITextfieldProps, IMessage } from "..";
+import { State } from "../props";
 
-import { Textfield, ITextfieldProps } from "..";
+interface IFormState {
+  value: any;
+  state: State;
+  message?: IMessage;
+}
 
 const TextfieldController = (props: ITextfieldProps) => {
   const { value = "", state = "pending" } = props;
-  const [form, setForm] = useState({ value, state });
 
-  function isAlphabetical(value: string) {
+  const [form, setForm] = useState<IFormState>({ value, state });
+
+  function isAlphabetical(value: string): boolean {
     return /^[a-zA-Z]+$/.test(value);
   }
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setForm({ value: e.target.value, state: "pending" });
+    setForm({ ...form, value: e.target.value, state: "pending" });
   };
 
   const handleFocus = () => {
     if (form.state === "invalid") {
-      return setForm({ ...form, state: "invalid" });
+      return setForm({ ...form, state: "invalid", message: form.message });
     }
     setForm({ ...form, state: "pending" });
   };
 
   const handleBlur = (e: React.ChangeEvent<HTMLInputElement>) => {
     const isValid = isAlphabetical(e.target.value);
-    setForm({ ...form, state: isValid ? "valid" : "invalid" });
+    if (isValid) {
+      setForm({
+        ...form,
+        state: "valid",
+        message: { content: "Input is valid.", type: "success" },
+      });
+    } else {
+      setForm({
+        ...form,
+        state: "invalid",
+        message: { content: "Input should be alphabetical.", type: "invalid" },
+      });
+    }
   };
 
   return (
@@ -32,6 +51,7 @@ const TextfieldController = (props: ITextfieldProps) => {
       value={form.value}
       onChange={onChange}
       state={form.state}
+      message={props.message ? props.message : form.message}
       handleFocus={handleFocus}
       handleBlur={handleBlur}
     />


### PR DESCRIPTION
[BREAKING CHANGE]

This PR introduces a significant refactor to the `<Textfield />` component. The `errorMessage` and `validMessage` props have been consolidated into a single `message` prop. This change streamlines the component's API and simplifies its usage. However, this is a breaking change, so developers need to adjust their implementations to accommodate this update.