### PR TITLE
`<Textfield />:` delete the `getTypo` function

### DIFF
--- a/src/components/inputs/Textfield/interface.tsx
+++ b/src/components/inputs/Textfield/interface.tsx
@@ -23,13 +23,6 @@ export interface IMessageProps {
   validMessage?: string;
 }
 
-const getTypo = (size: Size) => {
-  if (size === "compact") {
-    return "medium";
-  }
-  return "large";
-};
-
 const Invalid = (props: IMessageProps) => {
   const { disabled, state, errorMessage } = props;
 
@@ -106,7 +99,7 @@ const TextfieldUI = (props: ITextfieldProps) => {
             disabled={disabled}
             focused={focused}
             invalid={state === "invalid" ? true : false}
-            size={getTypo(size!)}
+            size={size === "compact" ? "medium" : "large"}
           >
             {label}
           </Label>

--- a/src/components/inputs/Textfield/interface.tsx
+++ b/src/components/inputs/Textfield/interface.tsx
@@ -14,7 +14,7 @@ import {
   StyledErrorMessageContainer,
   StyledValidMessageContainer,
 } from "./styles";
-import { Size, State } from "./props";
+import { State } from "./props";
 
 export interface IMessageProps {
   state?: State;


### PR DESCRIPTION
This PR removes the `getTypo` function from the `<Textfield />` component. After evaluating the component's current needs and architecture, it was determined that this function was no longer necessary or could be better handled through other means.