### PR TITLE
`<Textfield />:` export named variables in brackets

### DIFF
--- a/src/components/inputs/Textfield/props.ts
+++ b/src/components/inputs/Textfield/props.ts
@@ -1,4 +1,4 @@
-export const inputTypes = [
+const inputTypes = [
   "text",
   "email",
   "number",
@@ -6,13 +6,13 @@ export const inputTypes = [
   "search",
   "tel",
 ] as const;
-export type InputType = typeof inputTypes[number];
+type InputType = typeof inputTypes[number];
 
-export const sizes = ["wide", "compact"] as const;
-export type Size = typeof sizes[number];
+const sizes = ["wide", "compact"] as const;
+type Size = typeof sizes[number];
 
-export const states = ["valid", "invalid", "pending"] as const;
-export type State = typeof states[number];
+const states = ["valid", "invalid", "pending"] as const;
+type State = typeof states[number];
 
 const parameters = {
   docs: {
@@ -106,4 +106,6 @@ const props = {
   },
 };
 
-export { props, parameters };
+export type { InputType, Size, State };
+
+export { inputTypes, sizes, states, parameters, props };


### PR DESCRIPTION
This PR addresses a code consistency update for the `<Textfield />` component, specifically within the props.ts file. To maintain a singular approach to named exports, we've decided to use the bracket-style export at the end of the file.

Previously, variables or types might have been exported directly upon declaration. This PR transitions all such instances to a bracketed export list at the end of the file, as illustrated below:

```
const VARIABLE = {}
const CONSTANT = {}

export { VARIABLE, CONSTANT }
```