### PR TITLE
`<Textfield />:` refactor to use the new color tokens

### DIFF
--- a/src/components/inputs/Textfield/index.tsx
+++ b/src/components/inputs/Textfield/index.tsx
@@ -4,7 +4,7 @@ import { MdOutlineError, MdCheckCircle } from "react-icons/md";
 import { Label } from "@inputs/Label";
 import { Text } from "@data/Text";
 
-import { InputType, Size, State } from "./props";
+import { InputType, Size, State, Themed } from "./props";
 
 import {
   StyledContainer,
@@ -23,7 +23,7 @@ export interface IMessageProps {
   validMessage?: string;
 }
 
-export interface ITextfieldProps {
+export interface ITextfieldProps extends Themed {
   label?: string;
   name: string;
   id: string;

--- a/src/components/inputs/Textfield/props.ts
+++ b/src/components/inputs/Textfield/props.ts
@@ -1,3 +1,5 @@
+import { inube } from "@shared/tokens";
+
 const inputTypes = [
   "text",
   "email",
@@ -13,6 +15,8 @@ type Size = typeof sizes[number];
 
 const states = ["valid", "invalid", "pending"] as const;
 type State = typeof states[number];
+
+export type Themed = { theme?: typeof inube };
 
 const parameters = {
   docs: {

--- a/src/components/inputs/Textfield/styles.ts
+++ b/src/components/inputs/Textfield/styles.ts
@@ -32,17 +32,25 @@ const getGrid = (props: ITextfieldProps) => {
 const getColors = (props: ITextfieldProps) => {
   const { disabled, state, focused, theme } = props;
   if (disabled) {
-    return theme?.color?.text.gray?.disabled || inube.color.text.gray.disabled;
+    return (
+      theme?.color?.stroke.gray?.disabled || inube.color.stroke.gray.disabled
+    );
   }
 
   if (state === "invalid") {
-    return theme?.color?.text.error?.regular || inube.color.text.error.regular;
+    return (
+      theme?.color?.stroke.error?.regular || inube.color.stroke.error.regular
+    );
   }
 
   if (focused) {
-    return theme?.color?.text.primary?.hover || inube.color.text.primary.hover;
+    return (
+      theme?.color?.stroke.primary?.hover || inube.color.stroke.primary.hover
+    );
   }
-  return theme?.color?.surface.light?.hover || inube.color.surface.light.hover;
+  return (
+    theme?.color?.stroke.divider?.regular || inube.color.stroke.divider.regular
+  );
 };
 
 const getdisabled = (props: ITextfieldProps) => {

--- a/src/components/inputs/Textfield/styles.ts
+++ b/src/components/inputs/Textfield/styles.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { ITextfieldProps } from ".";
-import { colors } from "@shared/colors/colors";
 import { typography } from "@shared/typography/typography";
+import { inube } from "@shared/tokens";
 
 const sizeOptions = {
   compact: {
@@ -30,33 +30,35 @@ const getGrid = (props: ITextfieldProps) => {
 };
 
 const getColors = (props: ITextfieldProps) => {
-  const { disabled, state, focused } = props;
+  const { disabled, state, focused, theme } = props;
   if (disabled) {
-    return colors.ref.palette.neutral.n70;
+    return theme?.color?.text.gray?.disabled || inube.color.text.gray.disabled;
   }
 
   if (state === "invalid") {
-    return colors.sys.actions.remove.filled;
+    return theme?.color?.text.error?.regular || inube.color.text.error.regular;
   }
 
   if (focused) {
-    return colors.ref.palette.blue.b300;
+    return theme?.color?.text.primary?.hover || inube.color.text.primary.hover;
   }
-  return colors.ref.palette.neutral.n40;
+  return theme?.color?.surface.light?.hover || inube.color.surface.light.hover;
 };
 
 const getdisabled = (props: ITextfieldProps) => {
-  const { disabled, state } = props;
+  const { disabled, state, theme } = props;
   if (disabled) {
-    return colors.ref.palette.neutral.n70;
+    return theme?.color?.text.gray?.disabled || inube.color.text.gray.disabled;
   }
 
   if (state === "valid") {
-    return colors.sys.actions.confirm.filled;
+    return (
+      theme?.color?.text.success?.regular || inube.color.text.success.regular
+    );
   }
 
   if (state === "invalid") {
-    return colors.sys.actions.remove.filled;
+    return theme?.color?.text.error?.regular || inube.color.text.error.regular;
   }
 };
 
@@ -102,7 +104,8 @@ const StyledInputContainer = styled.div`
   box-sizing: border-box;
   border-radius: 8px;
   user-select: none;
-  background: ${colors.ref.palette.neutral.n10};
+  background: ${({ theme }: ITextfieldProps) =>
+    theme?.color?.text.light?.regular || inube.color.text.light.regular};
   grid-template-columns: ${(props: ITextfieldProps) => getGrid(props)};
   border: 1px solid ${(props: ITextfieldProps) => getColors(props)};
   ${({ disabled }: ITextfieldProps) =>
@@ -117,9 +120,12 @@ const StyledInput = styled.input`
   font-weight: ${typography.sys.typescale.bodyLarge.weight};
   line-height: ${typography.sys.typescale.bodyLarge.lineHeight};
   letter-spacing: ${typography.sys.typescale.bodyLarge.tracking};
-  color: ${({ disabled }: ITextfieldProps) =>
-    disabled ? colors.ref.palette.neutral.n70 : colors.sys.text.dark};
-  background: ${colors.ref.palette.neutral.n10};
+  color: ${({ disabled, theme }: ITextfieldProps) =>
+    disabled
+      ? theme?.color?.text.gray?.disabled || inube.color.text.gray.disabled
+      : theme?.color?.text.dark?.regular || inube.color.text.dark.regular};
+  background: ${({ theme }: ITextfieldProps) =>
+    theme?.color?.text.light?.regular || inube.color.text.light.regular};
   ${(props: ITextfieldProps) => getPadding(props)}
   width: ${({ fullwidth }: ITextfieldProps) =>
     fullwidth ? "calc(100% - 32px)" : "252px"};
@@ -127,7 +133,8 @@ const StyledInput = styled.input`
   border: none;
 
   ::placeholder {
-    color: ${colors.sys.text.secondary};
+    color: ${({ theme }: ITextfieldProps) =>
+      theme?.color?.text.gray?.regular || inube.color.text.gray.regular};
   }
 
   &:focus {
@@ -156,8 +163,9 @@ const StyledIcon = styled.div`
   padding-right: ${({ iconAfter }: ITextfieldProps) => iconAfter && "10px"};
   height: 24px;
   width: 24px;
-  color: ${({ disabled }: ITextfieldProps) =>
-    disabled && colors.ref.palette.neutral.n70};
+  color: ${({ disabled, theme }: ITextfieldProps) =>
+    disabled &&
+    (theme?.color?.text.gray?.disabled || inube.color.text.gray.disabled)};
 `;
 
 const StyledErrorMessageContainer = styled.div`

--- a/src/components/inputs/Textfield/styles.ts
+++ b/src/components/inputs/Textfield/styles.ts
@@ -104,8 +104,6 @@ const StyledInputContainer = styled.div`
   box-sizing: border-box;
   border-radius: 8px;
   user-select: none;
-  background: ${({ theme }: ITextfieldProps) =>
-    theme?.color?.text.light?.regular || inube.color.text.light.regular};
   grid-template-columns: ${(props: ITextfieldProps) => getGrid(props)};
   border: 1px solid ${(props: ITextfieldProps) => getColors(props)};
   ${({ disabled }: ITextfieldProps) =>
@@ -124,8 +122,6 @@ const StyledInput = styled.input`
     disabled
       ? theme?.color?.text.gray?.disabled || inube.color.text.gray.disabled
       : theme?.color?.text.dark?.regular || inube.color.text.dark.regular};
-  background: ${({ theme }: ITextfieldProps) =>
-    theme?.color?.text.light?.regular || inube.color.text.light.regular};
   ${(props: ITextfieldProps) => getPadding(props)}
   width: ${({ fullwidth }: ITextfieldProps) =>
     fullwidth ? "calc(100% - 32px)" : "252px"};


### PR DESCRIPTION
This PR introduces a refactor to the `<Textfield />` component, transitioning it to leverage the newly defined color tokens. As our design system evolves, adopting these standardized color tokens ensures that the component remains consistent with the broader application's look and feel.

The updates encompass:

- Replacing legacy color definitions with new color tokens.
- Ensuring that all color-based stylings are in sync with our latest design guidelines.

It's crucial to review the `<Textfield />` component visually to confirm that the new color schemes are applied correctly and resonate well within its various states and contexts.

