### PR TITLE
`<Textarea />:` rename `isDisabled` prop to just `disabled`

### DIFF
--- a/src/components/inputs/Textarea/index.jsx
+++ b/src/components/inputs/Textarea/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 
 const states = ["valid", "invalid", "pending"];
 
-const defaultIsDisabled = false;
+const defaultdisabled = false;
 const defaultIsRequired = false;
 const defaultState = "pending";
 const defaultIsFullWidth = false;
@@ -15,7 +15,7 @@ export const Textarea = (props) => {
     name,
     id,
     placeholder,
-    isDisabled = false,
+    disabled = false,
     handleChange,
     value,
     maxLength,
@@ -52,8 +52,8 @@ export const Textarea = (props) => {
     }
   };
 
-  const transformedIsDisabled =
-    typeof isDisabled === "boolean" ? isDisabled : defaultIsDisabled;
+  const transformeddisabled =
+    typeof disabled === "boolean" ? disabled : defaultdisabled;
 
   const transformedState = states.includes(state) ? state : defaultState;
 
@@ -71,7 +71,7 @@ export const Textarea = (props) => {
       name={name}
       id={id}
       placeholder={placeholder}
-      isDisabled={transformedIsDisabled}
+      disabled={transformeddisabled}
       value={value}
       maxLength={maxLength}
       minLength={minLength}
@@ -98,7 +98,7 @@ Textarea.propTypes = {
   name: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
   placeholder: PropTypes.string.isRequired,
-  isDisabled: PropTypes.bool,
+  disabled: PropTypes.bool,
   isFocused: PropTypes.bool,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   handleChange: PropTypes.func,

--- a/src/components/inputs/Textarea/interface.jsx
+++ b/src/components/inputs/Textarea/interface.jsx
@@ -26,7 +26,7 @@ const getAppearanceCounter = (valueLength, maxLength = 0, lengthThreshold) => {
 };
 
 const Counter = (props) => {
-  const { id, maxLength, lengthThreshold, isDisabled } = props;
+  const { id, maxLength, lengthThreshold, disabled } = props;
   const [valueLength, setValueLength] = useState(0);
 
   useEffect(() => {
@@ -48,20 +48,20 @@ const Counter = (props) => {
     <Text
       type="body"
       size="small"
-      disabled={isDisabled}
+      disabled={disabled}
       appearance={getAppearanceCounter(valueLength, maxLength, lengthThreshold)}
     >{`${valueLength}/${maxLength}`}</Text>
   );
 };
 
 const Invalid = (props) => {
-  const { isDisabled, state, errorMessage } = props;
+  const { disabled, state, errorMessage } = props;
   const transformedErrorMessage = errorMessage && `(${errorMessage})`;
 
   return (
-    <StyledErrorMessageContainer isDisabled={isDisabled} state={state}>
+    <StyledErrorMessageContainer disabled={disabled} state={state}>
       <MdOutlineError />
-      <Text type="body" size="small" appearance={"error"} disabled={isDisabled}>
+      <Text type="body" size="small" appearance={"error"} disabled={disabled}>
         {transformedErrorMessage}
       </Text>
     </StyledErrorMessageContainer>
@@ -69,17 +69,12 @@ const Invalid = (props) => {
 };
 
 const Success = (props) => {
-  const { isDisabled, state, validMessage } = props;
+  const { disabled, state, validMessage } = props;
 
   return (
-    <StyledValidMessageContainer isDisabled={isDisabled} state={state}>
+    <StyledValidMessageContainer disabled={disabled} state={state}>
       <MdCheckCircle />
-      <Text
-        type="body"
-        size="small"
-        appearance={"success"}
-        disabled={isDisabled}
-      >
+      <Text type="body" size="small" appearance={"success"} disabled={disabled}>
         {validMessage}
       </Text>
     </StyledValidMessageContainer>
@@ -92,7 +87,7 @@ const TextareaUI = (props) => {
     name,
     id,
     placeholder,
-    isDisabled,
+    disabled,
     value,
     maxLength,
     minLength,
@@ -115,18 +110,18 @@ const TextareaUI = (props) => {
   const transformedInvalid = state === "invalid" ? true : false;
 
   return (
-    <StyledContainer isFullWidth={isFullWidth} isDisabled={isDisabled}>
+    <StyledContainer isFullWidth={isFullWidth} disabled={disabled}>
       <StyledContainerLabel
         alignItems="center"
         wrap="wrap"
-        isDisabled={isDisabled}
+        disabled={disabled}
         label={label}
         counter={counter}
       >
         {label && (
           <Label
             htmlFor={id}
-            disabled={isDisabled}
+            disabled={disabled}
             focused={isFocused}
             invalid={transformedInvalid}
           >
@@ -134,17 +129,17 @@ const TextareaUI = (props) => {
           </Label>
         )}
 
-        {isRequired && !isDisabled && (
+        {isRequired && !disabled && (
           <Text type="body" size="small" appearance="dark">
             (Required)
           </Text>
         )}
-        {counter && !isDisabled && (
+        {counter && !disabled && (
           <Counter
             id={id}
             maxLength={maxLength}
             lengthThreshold={lengthThreshold}
-            isDisabled={isDisabled}
+            disabled={disabled}
           />
         )}
       </StyledContainerLabel>
@@ -153,7 +148,7 @@ const TextareaUI = (props) => {
         name={name}
         id={id}
         placeholder={placeholder}
-        isDisabled={isDisabled}
+        disabled={disabled}
         minLength={minLength}
         max={max}
         min={min}
@@ -170,14 +165,14 @@ const TextareaUI = (props) => {
 
       {state === "invalid" && (
         <Invalid
-          isDisabled={isDisabled}
+          disabled={disabled}
           state={state}
           errorMessage={errorMessage}
         />
       )}
       {state === "valid" && (
         <Success
-          isDisabled={isDisabled}
+          disabled={disabled}
           state={state}
           validMessage={validMessage}
         />

--- a/src/components/inputs/Textarea/props.js
+++ b/src/components/inputs/Textarea/props.js
@@ -23,7 +23,7 @@ const props = {
   placeholder: {
     description: "text to display in the text field whenever it is empty",
   },
-  isDisabled: {
+  disabled: {
     description:
       "sets the field as to appear disabled, users will not be able to interact with the text field",
     table: {

--- a/src/components/inputs/Textarea/stories/Textarea.stories.jsx
+++ b/src/components/inputs/Textarea/stories/Textarea.stories.jsx
@@ -17,7 +17,7 @@ Default.args = {
   id: "textarea",
   state: "pending",
   placeholder: "Storybook Textarea",
-  isDisabled: false,
+  disabled: false,
   counter: true,
   lengthThreshold: 20,
   isRequired: true,

--- a/src/components/inputs/Textarea/styles.js
+++ b/src/components/inputs/Textarea/styles.js
@@ -18,8 +18,8 @@ const getGrid = (label, counter) => {
   return "1fr";
 };
 
-const getColors = (isDisabled, state, isFocused) => {
-  if (isDisabled) {
+const getColors = (disabled, state, isFocused) => {
+  if (disabled) {
     return colors.ref.palette.neutral.n70;
   }
 
@@ -33,8 +33,8 @@ const getColors = (isDisabled, state, isFocused) => {
   return colors.ref.palette.neutral.n40;
 };
 
-const getIsDisabled = (isDisabled, state) => {
-  if (isDisabled) {
+const getdisabled = (disabled, state) => {
+  if (disabled) {
     return colors.ref.palette.neutral.n70;
   }
 
@@ -48,7 +48,7 @@ const getIsDisabled = (isDisabled, state) => {
 };
 
 const StyledContainer = styled.div`
-  cursor: ${({ isDisabled }) => isDisabled && "not-allowed"};
+  cursor: ${({ disabled }) => disabled && "not-allowed"};
   width: ${({ isFullWidth }) => (isFullWidth ? "100%" : "fit-content")};
 `;
 
@@ -56,7 +56,7 @@ const StyledContainerLabel = styled.div`
   display: grid;
   grid-template-columns: ${({ label, counter }) => getGrid(label, counter)};
   gap: 4px;
-  pointer-events: ${({ isDisabled }) => isDisabled && "none"};
+  pointer-events: ${({ disabled }) => disabled && "none"};
   align-items: center;
   margin-bottom: 4px;
 
@@ -75,13 +75,12 @@ const StyledTextarea = styled.textarea`
   letter-spacing: ${typography.sys.typescale.bodyLarge.letterSpacing};
   width: ${({ isFullWidth }) => (isFullWidth ? "calc(100% - 32px)" : "452px")};
   height: 120px;
-  color: ${({ isDisabled }) =>
-    isDisabled ? colors.ref.palette.neutral.n70 : colors.sys.text.dark};
+  color: ${({ disabled }) =>
+    disabled ? colors.ref.palette.neutral.n70 : colors.sys.text.dark};
   background: ${colors.ref.palette.neutral.n10};
   border: 2px solid
-    ${({ isDisabled, state, isFocused }) =>
-      getColors(isDisabled, state, isFocused)};
-  ${({ isDisabled }) => isDisabled && "pointer-events: none; opacity: 0.5;"}
+    ${({ disabled, state, isFocused }) => getColors(disabled, state, isFocused)};
+  ${({ disabled }) => disabled && "pointer-events: none; opacity: 0.5;"}
 
   ::placeholder {
     color: ${colors.sys.text.secondary};
@@ -105,7 +104,7 @@ const StyledIcon = styled.div`
   padding-right: ${({ iconAfter }) => iconAfter && "10px"};
   height: 24px;
   width: 24px;
-  color: ${({ isDisabled }) => isDisabled && colors.ref.palette.neutral.n70};
+  color: ${({ disabled }) => disabled && colors.ref.palette.neutral.n70};
 `;
 
 const StyledErrorMessageContainer = styled.div`
@@ -115,7 +114,7 @@ const StyledErrorMessageContainer = styled.div`
   align-items: center;
   padding-left: 12px;
   pointer-events: none;
-  color: ${({ isDisabled, state }) => getIsDisabled(isDisabled, state)};
+  color: ${({ disabled, state }) => getdisabled(disabled, state)};
 
   & svg {
     width: 14px;
@@ -124,7 +123,7 @@ const StyledErrorMessageContainer = styled.div`
 `;
 
 const StyledValidMessageContainer = styled(StyledErrorMessageContainer)`
-  color: ${({ isDisabled, state }) => getIsDisabled(isDisabled, state)}; ;
+  color: ${({ disabled, state }) => getdisabled(disabled, state)}; ;
 `;
 
 export {


### PR DESCRIPTION
This PR modifies the naming convention used in the `<Textarea />` component. The prop formerly identified as `isDisabled` has now been renamed to `disabled`. This change provides a more concise and convention-aligned naming pattern, making it straightforward for developers to understand and use.

Key adjustments:

- Update all instances of `isDisabled` to `disabled` within the `<Textarea />` component.
- Ensure any component that utilizes `<Textarea />` is aware of this prop naming update to prevent potential issues.

We recommend reviewing any implementation of the `<Textarea />` component across the codebase to ensure the renamed prop is correctly applied, ensuring smooth functionality.