### PR TITLE
`<Textarea />:` rename `isFullWidth` prop to just `fullwidth`

### DIFF
--- a/src/components/inputs/Textarea/index.jsx
+++ b/src/components/inputs/Textarea/index.jsx
@@ -7,7 +7,7 @@ const states = ["valid", "invalid", "pending"];
 const defaultdisabled = false;
 const defaultIsRequired = false;
 const defaultState = "pending";
-const defaultIsFullWidth = false;
+const defaultfullwidth = false;
 
 export const Textarea = (props) => {
   const {
@@ -26,7 +26,7 @@ export const Textarea = (props) => {
     state = "pending",
     errorMessage,
     validMessage,
-    isFullWidth = false,
+    fullwidth = false,
     handleFocus,
     handleBlur,
     readOnly,
@@ -60,8 +60,8 @@ export const Textarea = (props) => {
   const transformedIsRequired =
     typeof isRequired === "boolean" ? isRequired : defaultIsRequired;
 
-  const transformedIsFullWidth =
-    typeof isFullWidth === "boolean" ? isFullWidth : defaultIsFullWidth;
+  const transformedfullwidth =
+    typeof fullwidth === "boolean" ? fullwidth : defaultfullwidth;
 
   const transformedReadOnly = typeof readOnly === "boolean" ? readOnly : false;
 
@@ -81,7 +81,7 @@ export const Textarea = (props) => {
       state={transformedState}
       errorMessage={errorMessage}
       validMessage={validMessage}
-      isFullWidth={transformedIsFullWidth}
+      fullwidth={transformedfullwidth}
       isFocused={isFocused}
       handleChange={handleChange}
       handleFocus={interceptFocus}
@@ -109,7 +109,7 @@ Textarea.propTypes = {
   isRequired: PropTypes.bool,
   errorMessage: PropTypes.string,
   validMessage: PropTypes.string,
-  isFullWidth: PropTypes.bool,
+  fullwidth: PropTypes.bool,
   handleFocus: PropTypes.func,
   handleBlur: PropTypes.func,
   readOnly: PropTypes.bool,

--- a/src/components/inputs/Textarea/interface.jsx
+++ b/src/components/inputs/Textarea/interface.jsx
@@ -97,7 +97,7 @@ const TextareaUI = (props) => {
     state,
     errorMessage,
     validMessage,
-    isFullWidth,
+    fullwidth,
     isFocused,
     handleChange,
     handleFocus,
@@ -110,7 +110,7 @@ const TextareaUI = (props) => {
   const transformedInvalid = state === "invalid" ? true : false;
 
   return (
-    <StyledContainer isFullWidth={isFullWidth} disabled={disabled}>
+    <StyledContainer fullwidth={fullwidth} disabled={disabled}>
       <StyledContainerLabel
         alignItems="center"
         wrap="wrap"
@@ -154,7 +154,7 @@ const TextareaUI = (props) => {
         min={min}
         isRequired={isRequired}
         state={state}
-        isFullWidth={isFullWidth}
+        fullwidth={fullwidth}
         isFocused={isFocused}
         onChange={handleChange}
         onFocus={handleFocus}

--- a/src/components/inputs/Textarea/props.js
+++ b/src/components/inputs/Textarea/props.js
@@ -73,7 +73,7 @@ const props = {
   validMessage: {
     description: "show when the field is validated without errors",
   },
-  isFullWidth: {
+  fullwidth: {
     description: "option to fit field width to its parent width",
     table: {
       defaultValue: { summary: false },

--- a/src/components/inputs/Textarea/stories/Textarea.stories.jsx
+++ b/src/components/inputs/Textarea/stories/Textarea.stories.jsx
@@ -18,6 +18,7 @@ Default.args = {
   state: "pending",
   placeholder: "Storybook Textarea",
   disabled: false,
+  fullwidth: false,
   counter: true,
   lengthThreshold: 20,
   isRequired: true,

--- a/src/components/inputs/Textarea/styles.js
+++ b/src/components/inputs/Textarea/styles.js
@@ -49,7 +49,7 @@ const getdisabled = (disabled, state) => {
 
 const StyledContainer = styled.div`
   cursor: ${({ disabled }) => disabled && "not-allowed"};
-  width: ${({ isFullWidth }) => (isFullWidth ? "100%" : "fit-content")};
+  width: ${({ fullwidth }) => (fullwidth ? "100%" : "fit-content")};
 `;
 
 const StyledContainerLabel = styled.div`
@@ -73,7 +73,7 @@ const StyledTextarea = styled.textarea`
   font-weight: ${typography.sys.typescale.bodyLarge.weight};
   line-height: ${typography.sys.typescale.bodyLarge.lineHeight};
   letter-spacing: ${typography.sys.typescale.bodyLarge.letterSpacing};
-  width: ${({ isFullWidth }) => (isFullWidth ? "calc(100% - 32px)" : "452px")};
+  width: ${({ fullwidth }) => (fullwidth ? "calc(100% - 32px)" : "452px")};
   height: 120px;
   color: ${({ disabled }) =>
     disabled ? colors.ref.palette.neutral.n70 : colors.sys.text.dark};


### PR DESCRIPTION
This PR revises the naming convention within the `<Textarea />` component. The `isFullWidth` prop has been renamed to `fullwidth` for simplicity and to align with common naming patterns. This renaming aims to provide developers with a more intuitive understanding and cleaner syntax when working with the component.

Notable updates:

- Transitioning from `isFullWidth` to `fullwidth` within the component's codebase.
- Ensuring dependent components or features are updated to recognize this change to prevent any potential functional inconsistencies.

We advise a meticulous review of all implementations of the `<Textarea />` component to ensure that the newly renamed prop is used correctly and that the component remains consistent in its functionality.