### PR TITLE
`<Textfield />:` refactor `errorMessage` and `validMessage` to use just a message prop

### DIFF
--- a/src/components/inputs/Textfield/index.tsx
+++ b/src/components/inputs/Textfield/index.tsx
@@ -31,8 +31,7 @@ export interface ITextfieldProps extends Themed {
   iconAfter?: React.ReactNode;
   required: boolean;
   status?: Status;
-  errorMessage?: string;
-  validMessage?: string;
+  message?: string;
   size?: Size;
   fullwidth?: boolean;
   onFocus?: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -91,8 +90,7 @@ const Textfield = (props: ITextfieldProps) => {
     iconAfter,
     required = false,
     status = "pending",
-    errorMessage,
-    validMessage,
+    message,
     size = "wide",
     fullwidth = false,
     onFocus,
@@ -193,11 +191,7 @@ const Textfield = (props: ITextfieldProps) => {
       </StyledInputContainer>
 
       {status && (
-        <Message
-          disabled={disabled}
-          status={status}
-          message={status === "invalid" ? errorMessage : validMessage}
-        />
+        <Message disabled={disabled} status={status} message={message} />
       )}
     </StyledContainer>
   );

--- a/src/components/inputs/Textfield/props.ts
+++ b/src/components/inputs/Textfield/props.ts
@@ -85,11 +85,9 @@ const props = {
       defaultValue: { summary: "pending" },
     },
   },
-  errorMessage: {
-    description: "show when the field is validated and there is an error",
-  },
-  validMessage: {
-    description: "show when the field is validated without errors",
+  message: {
+    description:
+      "display a message, provided by the developer implementing the component, which can be either an error notification or a validation prompt",
   },
   size: {
     options: sizes,

--- a/src/components/inputs/Textfield/stories/Textfield.stories.tsx
+++ b/src/components/inputs/Textfield/stories/Textfield.stories.tsx
@@ -18,15 +18,12 @@ Default.args = {
   id: "Username",
   placeholder: "Write your full name",
   value: "",
-  errorMessage: "Please enter only letters in this field",
-  validMessage: "The field has been successfully validated",
   size: "wide",
   readOnly: false,
   disabled: false,
   required: false,
   type: "text",
-  errorMessages: "field cannot be empty, special characters cannot be used",
-  validMessages: "field has been successfully validated",
+  message: "",
 };
 
 const theme = {

--- a/src/components/inputs/Textfield/stories/TextfieldController.tsx
+++ b/src/components/inputs/Textfield/stories/TextfieldController.tsx
@@ -26,6 +26,11 @@ const TextfieldController = (props: ITextfieldProps) => {
     setForm({ ...form, status: isValid ? "valid" : "invalid" });
   };
 
+  const message =
+    form.status === "valid"
+      ? "The field has been successfully validated"
+      : "Please enter only letters in this field";
+
   return (
     <Textfield
       {...props}
@@ -34,6 +39,7 @@ const TextfieldController = (props: ITextfieldProps) => {
       status={form.status}
       onFocus={onFocus}
       onBlur={onBlur}
+      message={message}
     />
   );
 };


### PR DESCRIPTION
In a bid to simplify the `<Textfield />` component's interface, this PR combines the previously separate `errorMessage` and `validMessage` props into a singular `message` prop. This transition offers a cleaner and more unified approach to handle feedback messages, whether they are error alerts or validation confirmations.

Key refactoring steps include:

- Removing the individual `errorMessage` and `validMessage` props.
- Introducing the `message` prop to capture feedback content.
- Adjusting internal logic to correctly interpret and display the message based on the context (error or validation).
- Ensuring all usages of the `<Textfield />` component are updated with this new prop configuration.

A thorough review of instances where `<Textfield />` is implemented is essential to confirm the seamless integration of this prop restructuring and to guarantee that messages are displayed correctly based on their respective contexts.