### PR TITLE
`<Textarea />:` remove `maxLength` and `minLength` props

### DIFF
--- a/src/components/inputs/Textarea/index.jsx
+++ b/src/components/inputs/Textarea/index.jsx
@@ -7,7 +7,7 @@ const states = ["valid", "invalid", "pending"];
 const defaultdisabled = false;
 const defaultIsRequired = false;
 const defaultState = "pending";
-const defaultIsFullWidth = false;
+const defaultfullwidth = false;
 
 export const Textarea = (props) => {
   const {
@@ -18,15 +18,13 @@ export const Textarea = (props) => {
     disabled = false,
     handleChange,
     value,
-    maxLength,
-    minLength,
     max,
     min,
     isRequired = false,
     state = "pending",
     errorMessage,
     validMessage,
-    isFullWidth = false,
+    fullwidth = false,
     handleFocus,
     handleBlur,
     readOnly,
@@ -60,8 +58,8 @@ export const Textarea = (props) => {
   const transformedIsRequired =
     typeof isRequired === "boolean" ? isRequired : defaultIsRequired;
 
-  const transformedIsFullWidth =
-    typeof isFullWidth === "boolean" ? isFullWidth : defaultIsFullWidth;
+  const transformedfullwidth =
+    typeof fullwidth === "boolean" ? fullwidth : defaultfullwidth;
 
   const transformedReadOnly = typeof readOnly === "boolean" ? readOnly : false;
 
@@ -73,15 +71,13 @@ export const Textarea = (props) => {
       placeholder={placeholder}
       disabled={transformeddisabled}
       value={value}
-      maxLength={maxLength}
-      minLength={minLength}
       max={max}
       min={min}
       isRequired={transformedIsRequired}
       state={transformedState}
       errorMessage={errorMessage}
       validMessage={validMessage}
-      isFullWidth={transformedIsFullWidth}
+      fullwidth={transformedfullwidth}
       isFocused={isFocused}
       handleChange={handleChange}
       handleFocus={interceptFocus}
@@ -102,14 +98,12 @@ Textarea.propTypes = {
   isFocused: PropTypes.bool,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   handleChange: PropTypes.func,
-  maxLength: PropTypes.number,
-  minLength: PropTypes.number,
   max: PropTypes.number,
   min: PropTypes.number,
   isRequired: PropTypes.bool,
   errorMessage: PropTypes.string,
   validMessage: PropTypes.string,
-  isFullWidth: PropTypes.bool,
+  fullwidth: PropTypes.bool,
   handleFocus: PropTypes.func,
   handleBlur: PropTypes.func,
   readOnly: PropTypes.bool,

--- a/src/components/inputs/Textarea/interface.jsx
+++ b/src/components/inputs/Textarea/interface.jsx
@@ -1,7 +1,5 @@
 import { useState, useEffect } from "react";
-
 import { MdOutlineError, MdCheckCircle } from "react-icons/md";
-
 import { Label } from "@inputs/Label";
 import { Text } from "@data/Text";
 
@@ -13,20 +11,8 @@ import {
   StyledValidMessageContainer,
 } from "./styles";
 
-const getAppearanceCounter = (valueLength, maxLength = 0, lengthThreshold) => {
-  if (maxLength - valueLength <= lengthThreshold && valueLength <= maxLength) {
-    return "warning";
-  }
-
-  if (valueLength > maxLength) {
-    return "error";
-  }
-
-  return "gray";
-};
-
 const Counter = (props) => {
-  const { id, maxLength, lengthThreshold, disabled } = props;
+  const { id, lengthThreshold, disabled } = props;
   const [valueLength, setValueLength] = useState(0);
 
   useEffect(() => {
@@ -44,13 +30,15 @@ const Counter = (props) => {
     };
   }, [id]);
 
+  const appearance = valueLength > lengthThreshold ? "warning" : "gray";
+
   return (
     <Text
       type="body"
       size="small"
       disabled={disabled}
-      appearance={getAppearanceCounter(valueLength, maxLength, lengthThreshold)}
-    >{`${valueLength}/${maxLength}`}</Text>
+      appearance={appearance}
+    >{`${valueLength}`}</Text>
   );
 };
 
@@ -89,8 +77,6 @@ const TextareaUI = (props) => {
     placeholder,
     disabled,
     value,
-    maxLength,
-    minLength,
     max,
     min,
     isRequired,
@@ -134,10 +120,10 @@ const TextareaUI = (props) => {
             (Required)
           </Text>
         )}
+
         {counter && !disabled && (
           <Counter
             id={id}
-            maxLength={maxLength}
             lengthThreshold={lengthThreshold}
             disabled={disabled}
           />
@@ -149,7 +135,6 @@ const TextareaUI = (props) => {
         id={id}
         placeholder={placeholder}
         disabled={disabled}
-        minLength={minLength}
         max={max}
         min={min}
         isRequired={isRequired}
@@ -170,6 +155,7 @@ const TextareaUI = (props) => {
           errorMessage={errorMessage}
         />
       )}
+
       {state === "valid" && (
         <Success
           disabled={disabled}

--- a/src/components/inputs/Textarea/props.js
+++ b/src/components/inputs/Textarea/props.js
@@ -37,14 +37,6 @@ const props = {
     description:
       "allows you to control what to do when the user changes the value of the component",
   },
-  maxLength: {
-    description:
-      "defines how many characters maximum are received in the component value",
-  },
-  minLength: {
-    description:
-      "defines how many minimum characters the component receives as a value",
-  },
   max: {
     description:
       "defines the maximum value that can be inserted (useful for components of type number)",

--- a/src/components/inputs/Textarea/stories/TextareaController.jsx
+++ b/src/components/inputs/Textarea/stories/TextareaController.jsx
@@ -5,32 +5,30 @@ const TextareaController = (props) => {
   const { value = "", state = "pending" } = props;
   const [form, setForm] = useState({ value, state });
 
-  const maxLength = 220;
-
   const handleChange = (e) => {
     setForm({ value: e.target.value, state: "pending" });
-    return;
   };
 
   const handleFocus = () => {
     setForm({ ...form, state: "pending" });
   };
 
-  const handleBlur = (e) => {
-    if (e.target.value.length > maxLength) {
+  const handleBlur = () => {
+    if (form.value) {
+      setForm({ ...form, state: "valid" });
+    } else {
       setForm({ ...form, state: "invalid" });
-    } else setForm({ ...form, state: "valid" });
+    }
   };
+
   return (
     <Textarea
       {...props}
       value={form.value}
       state={form.state}
-      maxLength={maxLength}
       handleChange={handleChange}
       handleFocus={handleFocus}
       handleBlur={handleBlur}
-      errorMessage="The number the characters is too long"
     />
   );
 };


### PR DESCRIPTION
In our continuous efforts to streamline and optimize the `<Textarea />` component, this PR removes the `maxLength` and `minLength` props. We believe that handling these constraints should be managed externally, allowing for more flexibility and reducing the complexity within the component itself.

Main updates:

- The removal of `maxLength` and `minLength` props from the component and related functions.
- Ensuring that the component's behavior remains consistent post-removal.
- Updating documentation and usage guidelines to reflect this change.

It's recommended to review all instances of the `<Textarea />` component in the codebase, ensuring that any dependencies or functionalities reliant on these props are correctly adjusted to handle this change.