### PR TITLE
`<Textarea />:` remove `max` and `min` props

### DIFF
--- a/src/components/inputs/Textarea/index.jsx
+++ b/src/components/inputs/Textarea/index.jsx
@@ -20,8 +20,6 @@ export const Textarea = (props) => {
     value,
     maxLength,
     minLength,
-    max,
-    min,
     isRequired = false,
     state = "pending",
     errorMessage,
@@ -75,8 +73,6 @@ export const Textarea = (props) => {
       value={value}
       maxLength={maxLength}
       minLength={minLength}
-      max={max}
-      min={min}
       isRequired={transformedIsRequired}
       state={transformedState}
       errorMessage={errorMessage}
@@ -104,8 +100,6 @@ Textarea.propTypes = {
   handleChange: PropTypes.func,
   maxLength: PropTypes.number,
   minLength: PropTypes.number,
-  max: PropTypes.number,
-  min: PropTypes.number,
   isRequired: PropTypes.bool,
   errorMessage: PropTypes.string,
   validMessage: PropTypes.string,

--- a/src/components/inputs/Textarea/interface.jsx
+++ b/src/components/inputs/Textarea/interface.jsx
@@ -1,10 +1,7 @@
 import { useState, useEffect } from "react";
-
 import { MdOutlineError, MdCheckCircle } from "react-icons/md";
-
 import { Label } from "@inputs/Label";
 import { Text } from "@data/Text";
-
 import {
   StyledContainer,
   StyledContainerLabel,
@@ -91,8 +88,6 @@ const TextareaUI = (props) => {
     value,
     maxLength,
     minLength,
-    max,
-    min,
     isRequired,
     state,
     errorMessage,
@@ -150,8 +145,6 @@ const TextareaUI = (props) => {
         placeholder={placeholder}
         disabled={disabled}
         minLength={minLength}
-        max={max}
-        min={min}
         isRequired={isRequired}
         state={state}
         isFullWidth={isFullWidth}

--- a/src/components/inputs/Textarea/props.js
+++ b/src/components/inputs/Textarea/props.js
@@ -45,14 +45,6 @@ const props = {
     description:
       "defines how many minimum characters the component receives as a value",
   },
-  max: {
-    description:
-      "defines the maximum value that can be inserted (useful for components of type number)",
-  },
-  min: {
-    description:
-      "defines the minimum value that can be inserted (useful for components of type number)",
-  },
   isRequired: {
     description: "defines if the field is required or not",
     table: {


### PR DESCRIPTION
To further refine and declutter the `<Textarea />` component, this PR removes the `max` and `min` props. These constraints, often more applicable to numeric inputs, are deemed unnecessary within the context of a textarea. By removing them, we aim to maintain a focused and concise API for the component.

Highlights of the change:

- Deletion of `max` and `min` props from the component's definition and related logic.
- Verifying the component's behavior post the removal, ensuring consistency.
- Updating any associated documentation and usage guides to reflect this change.

We advise a thorough inspection of all instances where the `<Textarea />` component is used in the codebase to ensure that any dependencies or functionalities relying on these props have been suitably updated.