### PR TITLE
`<Textarea />:` rename `handleChange` prop to `onChange`

### DIFF
--- a/src/components/inputs/Textarea/index.jsx
+++ b/src/components/inputs/Textarea/index.jsx
@@ -16,7 +16,7 @@ export const Textarea = (props) => {
     id,
     placeholder,
     disabled = false,
-    handleChange,
+    onChange,
     value,
     maxLength,
     minLength,
@@ -79,7 +79,7 @@ export const Textarea = (props) => {
       validMessage={validMessage}
       fullwidth={transformedfullwidth}
       isFocused={isFocused}
-      handleChange={handleChange}
+      onChange={onChange}
       handleFocus={interceptFocus}
       handleBlur={interceptBlur}
       readOnly={transformedReadOnly}
@@ -97,7 +97,7 @@ Textarea.propTypes = {
   disabled: PropTypes.bool,
   isFocused: PropTypes.bool,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  handleChange: PropTypes.func,
+  onChange: PropTypes.func,
   maxLength: PropTypes.number,
   minLength: PropTypes.number,
   isRequired: PropTypes.bool,

--- a/src/components/inputs/Textarea/interface.jsx
+++ b/src/components/inputs/Textarea/interface.jsx
@@ -94,7 +94,7 @@ const TextareaUI = (props) => {
     validMessage,
     fullwidth,
     isFocused,
-    handleChange,
+    onChange,
     handleFocus,
     handleBlur,
     readOnly,
@@ -149,7 +149,7 @@ const TextareaUI = (props) => {
         state={state}
         fullwidth={fullwidth}
         isFocused={isFocused}
-        onChange={handleChange}
+        onChange={onChange}
         onFocus={handleFocus}
         onBlur={handleBlur}
         readOnly={readOnly}

--- a/src/components/inputs/Textarea/props.js
+++ b/src/components/inputs/Textarea/props.js
@@ -33,7 +33,7 @@ const props = {
   value: {
     description: "component initial value",
   },
-  handleChange: {
+  onChange: {
     description:
       "allows you to control what to do when the user changes the value of the component",
   },

--- a/src/components/inputs/Textarea/stories/TextareaController.jsx
+++ b/src/components/inputs/Textarea/stories/TextareaController.jsx
@@ -7,7 +7,7 @@ const TextareaController = (props) => {
 
   const maxLength = 220;
 
-  const handleChange = (e) => {
+  const onChange = (e) => {
     setForm({ value: e.target.value, state: "pending" });
     return;
   };
@@ -27,7 +27,7 @@ const TextareaController = (props) => {
       value={form.value}
       state={form.state}
       maxLength={maxLength}
-      handleChange={handleChange}
+      onChange={onChange}
       handleFocus={handleFocus}
       handleBlur={handleBlur}
       errorMessage="The number the characters is too long"


### PR DESCRIPTION
In a move to standardize and simplify prop naming conventions across our components, this PR renames the `handleChange` prop to `onChange` within the `<Textarea />` component. This brings the prop's name in line with conventional naming patterns in React and offers developers a more intuitive and familiar interface when interacting with the component.

Main updates:

- Replacing `handleChange` with `onChange` throughout the component's codebase.
- Adjusting any internal logic and event handlers to recognize and implement the renamed prop.
- Ensuring all external uses of the `<Textarea />` component are updated to employ the `onChange` prop.

For a seamless transition, it's essential to review all implementations of the `<Textarea />` component and confirm the renamed prop's correct and consistent usage across the platform.