### PR TITLE
`<Textarea />:` rename `handleBlur` prop to `onBlur`

### DIFF
--- a/src/components/inputs/Textarea/index.jsx
+++ b/src/components/inputs/Textarea/index.jsx
@@ -26,7 +26,7 @@ export const Textarea = (props) => {
     validMessage,
     fullwidth = false,
     handleFocus,
-    handleBlur,
+    onBlur,
     readOnly,
     counter,
     lengthThreshold,
@@ -45,8 +45,8 @@ export const Textarea = (props) => {
 
   const interceptBlur = (e) => {
     setIsFocused(false);
-    if (typeof handleBlur === "function") {
-      handleBlur(e);
+    if (typeof onBlur === "function") {
+      onBlur(e);
     }
   };
 
@@ -81,7 +81,7 @@ export const Textarea = (props) => {
       isFocused={isFocused}
       handleChange={handleChange}
       handleFocus={interceptFocus}
-      handleBlur={interceptBlur}
+      onBlur={interceptBlur}
       readOnly={transformedReadOnly}
       counter={counter}
       lengthThreshold={lengthThreshold}
@@ -105,7 +105,7 @@ Textarea.propTypes = {
   validMessage: PropTypes.string,
   fullwidth: PropTypes.bool,
   handleFocus: PropTypes.func,
-  handleBlur: PropTypes.func,
+  onBlur: PropTypes.func,
   readOnly: PropTypes.bool,
   counter: PropTypes.bool,
 };

--- a/src/components/inputs/Textarea/interface.jsx
+++ b/src/components/inputs/Textarea/interface.jsx
@@ -96,7 +96,7 @@ const TextareaUI = (props) => {
     isFocused,
     handleChange,
     handleFocus,
-    handleBlur,
+    onBlur,
     readOnly,
     counter,
     lengthThreshold,
@@ -151,7 +151,7 @@ const TextareaUI = (props) => {
         isFocused={isFocused}
         onChange={handleChange}
         onFocus={handleFocus}
-        onBlur={handleBlur}
+        onBlur={onBlur}
         readOnly={readOnly}
         value={value}
       />

--- a/src/components/inputs/Textarea/stories/TextareaController.jsx
+++ b/src/components/inputs/Textarea/stories/TextareaController.jsx
@@ -16,7 +16,7 @@ const TextareaController = (props) => {
     setForm({ ...form, state: "pending" });
   };
 
-  const handleBlur = (e) => {
+  const onBlur = (e) => {
     if (e.target.value.length > maxLength) {
       setForm({ ...form, state: "invalid" });
     } else setForm({ ...form, state: "valid" });
@@ -29,7 +29,7 @@ const TextareaController = (props) => {
       maxLength={maxLength}
       handleChange={handleChange}
       handleFocus={handleFocus}
-      handleBlur={handleBlur}
+      onBlur={onBlur}
       errorMessage="The number the characters is too long"
     />
   );


### PR DESCRIPTION
To maintain consistency and adhere to widely accepted naming conventions in React, this PR renames the `handleBlur` prop to `onBlur` within the `<Textarea />` component. This change promotes a more intuitive and familiar interface for developers, making interactions with the component more straightforward.

Key updates include:

- Substituting `handleBlur` with `onBlur` throughout the component's code.
- Modifying any internal logic and event handlers to accommodate the renamed prop.
- Updating all external usages of the `<Textarea />` component to utilize the `onBlur` prop.

To ensure a smooth integration of this change, we recommend a comprehensive review of all `<Textarea />` component implementations in the codebase, verifying the renamed prop's correct application and ensuring uniformity across different instances.