### PR TITLE
`<Textarea />:` rename `handleFocus` prop to `onFocus`

### DIFF
--- a/src/components/inputs/Textarea/index.jsx
+++ b/src/components/inputs/Textarea/index.jsx
@@ -25,7 +25,7 @@ export const Textarea = (props) => {
     errorMessage,
     validMessage,
     fullwidth = false,
-    handleFocus,
+    onFocus,
     handleBlur,
     readOnly,
     counter,
@@ -38,8 +38,8 @@ export const Textarea = (props) => {
     if (!readOnly) {
       setIsFocused(true);
     }
-    if (typeof handleFocus === "function") {
-      handleFocus(e);
+    if (typeof onFocus === "function") {
+      onFocus(e);
     }
   };
 
@@ -80,7 +80,7 @@ export const Textarea = (props) => {
       fullwidth={transformedfullwidth}
       isFocused={isFocused}
       handleChange={handleChange}
-      handleFocus={interceptFocus}
+      onFocus={interceptFocus}
       handleBlur={interceptBlur}
       readOnly={transformedReadOnly}
       counter={counter}
@@ -104,7 +104,7 @@ Textarea.propTypes = {
   errorMessage: PropTypes.string,
   validMessage: PropTypes.string,
   fullwidth: PropTypes.bool,
-  handleFocus: PropTypes.func,
+  onFocus: PropTypes.func,
   handleBlur: PropTypes.func,
   readOnly: PropTypes.bool,
   counter: PropTypes.bool,

--- a/src/components/inputs/Textarea/interface.jsx
+++ b/src/components/inputs/Textarea/interface.jsx
@@ -95,7 +95,7 @@ const TextareaUI = (props) => {
     fullwidth,
     isFocused,
     handleChange,
-    handleFocus,
+    onFocus,
     handleBlur,
     readOnly,
     counter,
@@ -150,7 +150,7 @@ const TextareaUI = (props) => {
         fullwidth={fullwidth}
         isFocused={isFocused}
         onChange={handleChange}
-        onFocus={handleFocus}
+        onFocus={onFocus}
         onBlur={handleBlur}
         readOnly={readOnly}
         value={value}

--- a/src/components/inputs/Textarea/stories/TextareaController.jsx
+++ b/src/components/inputs/Textarea/stories/TextareaController.jsx
@@ -12,7 +12,7 @@ const TextareaController = (props) => {
     return;
   };
 
-  const handleFocus = () => {
+  const onFocus = () => {
     setForm({ ...form, state: "pending" });
   };
 
@@ -28,7 +28,7 @@ const TextareaController = (props) => {
       state={form.state}
       maxLength={maxLength}
       handleChange={handleChange}
-      handleFocus={handleFocus}
+      onFocus={onFocus}
       handleBlur={handleBlur}
       errorMessage="The number the characters is too long"
     />


### PR DESCRIPTION
Aiming to align with the standard naming conventions in React, this PR renames the `handleFocus` prop to `onFocus` within the `<Textarea />` component. This renaming is part of our ongoing effort to offer developers a more predictable and familiar interface when interacting with our components.

Major changes encompass:

- Swapping out `handleFocus` for `onFocus` in the component's codebase.
- Adjusting internal logic and event handlers to correspond with the renamed prop.
- Ensuring that all instances where the `<Textarea />` component is employed are updated to reflect the `onFocus` prop.

To guarantee a smooth transition and consistent application, we advise conducting a thorough review of every implementation of the `<Textarea />` component in the codebase. It's essential to confirm that the renamed prop is correctly employed across various instances.