### PR TITLE
`<Textarea />:` directly assign the value received through props, don't transform values to defaults

### DIFF
--- a/src/components/inputs/Textarea/index.jsx
+++ b/src/components/inputs/Textarea/index.jsx
@@ -4,11 +4,6 @@ import PropTypes from "prop-types";
 
 const states = ["valid", "invalid", "pending"];
 
-const defaultdisabled = false;
-const defaultIsRequired = false;
-const defaultState = "pending";
-const defaultfullwidth = false;
-
 export const Textarea = (props) => {
   const {
     label,
@@ -50,39 +45,26 @@ export const Textarea = (props) => {
     }
   };
 
-  const transformeddisabled =
-    typeof disabled === "boolean" ? disabled : defaultdisabled;
-
-  const transformedState = states.includes(state) ? state : defaultState;
-
-  const transformedIsRequired =
-    typeof isRequired === "boolean" ? isRequired : defaultIsRequired;
-
-  const transformedfullwidth =
-    typeof fullwidth === "boolean" ? fullwidth : defaultfullwidth;
-
-  const transformedReadOnly = typeof readOnly === "boolean" ? readOnly : false;
-
   return (
     <TextareaUI
       label={label}
       name={name}
       id={id}
       placeholder={placeholder}
-      disabled={transformeddisabled}
+      disabled={disabled}
       value={value}
       maxLength={maxLength}
       minLength={minLength}
-      isRequired={transformedIsRequired}
-      state={transformedState}
+      isRequired={isRequired}
+      state={state}
       errorMessage={errorMessage}
       validMessage={validMessage}
-      fullwidth={transformedfullwidth}
+      fullwidth={fullwidth}
       isFocused={isFocused}
       onChange={onChange}
       onFocus={interceptFocus}
       onBlur={interceptBlur}
-      readOnly={transformedReadOnly}
+      readOnly={readOnly}
       counter={counter}
       lengthThreshold={lengthThreshold}
     />

--- a/src/components/inputs/Textarea/interface.jsx
+++ b/src/components/inputs/Textarea/interface.jsx
@@ -53,13 +53,12 @@ const Counter = (props) => {
 
 const Invalid = (props) => {
   const { disabled, state, errorMessage } = props;
-  const transformedErrorMessage = errorMessage && `(${errorMessage})`;
 
   return (
     <StyledErrorMessageContainer disabled={disabled} state={state}>
       <MdOutlineError />
       <Text type="body" size="small" appearance={"error"} disabled={disabled}>
-        {transformedErrorMessage}
+        {errorMessage && `(${errorMessage})`}
       </Text>
     </StyledErrorMessageContainer>
   );
@@ -102,8 +101,6 @@ const TextareaUI = (props) => {
     lengthThreshold,
   } = props;
 
-  const transformedInvalid = state === "invalid" ? true : false;
-
   return (
     <StyledContainer fullwidth={fullwidth} disabled={disabled}>
       <StyledContainerLabel
@@ -118,7 +115,7 @@ const TextareaUI = (props) => {
             htmlFor={id}
             disabled={disabled}
             focused={isFocused}
-            invalid={transformedInvalid}
+            invalid={state === "invalid" ? true : false}
           >
             {label}
           </Label>


### PR DESCRIPTION
This PR modifies the `<Textarea />` component to directly assign values received through props without applying any transformation to defaults. This change enhances the transparency of value assignments within the component and places the responsibility for value validation on the consuming developers, offering them greater control.

Highlights of the modifications:

- Removal of internal transformations or assignments to default values within the component.
- Direct assignment of values from props to the component's internal mechanisms.
- Adjustments to the component's documentation, highlighting the importance of passing validated values.

For developers consuming the `<Textarea />` component, it's essential to ensure that values passed to the component are validated and accurate, given the removal of internal default transformations.