### PR TITLE
Rename isRequired props to requirid in `<Textarea />`

### DIFF
--- a/src/components/inputs/Textarea/index.tsx
+++ b/src/components/inputs/Textarea/index.tsx
@@ -14,7 +14,7 @@ interface ITextareaProps {
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   maxLength?: number;
   minLength?: number;
-  isRequired?: boolean;
+  required?: boolean;
   errorMessage?: string;
   validMessage?: string;
   fullwidth?: boolean;
@@ -36,7 +36,7 @@ const Textarea = (props: ITextareaProps) => {
     value,
     maxLength,
     minLength,
-    isRequired = false,
+    required = false,
     state = "pending",
     errorMessage,
     validMessage,
@@ -76,7 +76,7 @@ const Textarea = (props: ITextareaProps) => {
       value={value}
       maxLength={maxLength}
       minLength={minLength}
-      isRequired={isRequired}
+      required={required}
       state={state}
       errorMessage={errorMessage}
       validMessage={validMessage}

--- a/src/components/inputs/Textarea/interface.tsx
+++ b/src/components/inputs/Textarea/interface.tsx
@@ -101,7 +101,7 @@ const TextareaUI = (props: ITextareaProps) => {
     value,
     maxLength,
     minLength,
-    isRequired,
+    required,
     state,
     errorMessage,
     validMessage,
@@ -138,7 +138,7 @@ const TextareaUI = (props: ITextareaProps) => {
           </Label>
         )}
 
-        {isRequired && !disabled && (
+        {required && !disabled && (
           <Text type="body" size="small" appearance="dark">
             (Required)
           </Text>
@@ -159,7 +159,7 @@ const TextareaUI = (props: ITextareaProps) => {
         placeholder={placeholder}
         disabled={disabled}
         minLength={minLength}
-        isRequired={isRequired}
+        required={required}
         state={state}
         fullwidth={fullwidth}
         isFocused={isFocused}

--- a/src/components/inputs/Textarea/props.ts
+++ b/src/components/inputs/Textarea/props.ts
@@ -47,7 +47,7 @@ const props = {
     description:
       "defines how many minimum characters the component receives as a value",
   },
-  isRequired: {
+  required: {
     description: "defines if the field is required or not",
     table: {
       defaultValue: { summary: false },

--- a/src/components/inputs/Textarea/stories/Textarea.stories.tsx
+++ b/src/components/inputs/Textarea/stories/Textarea.stories.tsx
@@ -21,7 +21,7 @@ Default.args = {
   fullwidth: false,
   counter: true,
   lengthThreshold: 20,
-  isRequired: true,
+  required: true,
   value:
     "Lorem ipsum dolor sit amet consectetur adipisicing elit. Nihil veniam, reiciendis ipsum itaque unde odio voluptatum ab cumque deleniti dolore magnam quas hic rem, mollitia adipisci. Officiis accusamus aut consectetur",
 };


### PR DESCRIPTION
Rename the props `isRequired` to `required` inside the `<Textarea />` component. This change guarantees clarity in the naming of accessories.

Updated all implementations of the `<Textarea />` component to reflect the renamed state property.

It is crucial to examine all uses of the `<Textarea />` component in our code base and ensure consistent application of the renamed prop across different instances.