### PR TITLE
`<Textarea />:` delete all stories and leave just `Default` and `Themed`

### DIFF
--- a/src/components/inputs/Textarea/stories/Textarea.stories.tsx
+++ b/src/components/inputs/Textarea/stories/Textarea.stories.tsx
@@ -1,7 +1,8 @@
 import { ITextareaProps, Textarea } from "..";
 import { TextareaController } from "./TextareaController";
-
+import { ThemeProvider } from "styled-components";
 import { props, parameters } from "../props";
+import { presente } from "@shared/themes/presente";
 
 const story = {
   title: "inputs/Textarea",
@@ -24,6 +25,20 @@ Default.args = {
   isRequired: true,
   value:
     "Lorem ipsum dolor sit amet consectetur adipisicing elit. Nihil veniam, reiciendis ipsum itaque unde odio voluptatum ab cumque deleniti dolore magnam quas hic rem, mollitia adipisci. Officiis accusamus aut consectetur",
+};
+
+const theme = {
+  ...presente,
+};
+
+export const Themed = (args: ITextareaProps) => (
+  <ThemeProvider theme={theme}>
+    <TextareaController {...args} />
+  </ThemeProvider>
+);
+
+Themed.args = {
+  ...Default.args,
 };
 
 export default story;


### PR DESCRIPTION
In a bid to simplify and focus our Storybook examples for the `<Textarea />` component, this PR deletes all current story variations, retaining only the essential 'Default' and 'Themed' stories. This approach offers developers a streamlined overview of the component's capabilities, emphasizing its primary usage and thematic customizations.

Notable changes include:

- Removal of all existing stories for the `<Textarea />` component, except for 'Default' and 'Themed'.
- Enhancements to the 'Default' and 'Themed' stories, ensuring they cover the core features and stylings of the component.
- Documentation updates to reflect these changes and guide developers on the component's primary and thematic usages.

By focusing on these principal stories, we hope to offer a clearer, more intuitive understanding of the `<Textarea />` component and its core functionalities.