### PR TITLE
`<Textarea />:` refactor to change the `Required` label to `Requerido` when the field is required

### DIFF
--- a/src/components/inputs/Textarea/interface.tsx
+++ b/src/components/inputs/Textarea/interface.tsx
@@ -140,7 +140,7 @@ const TextareaUI = (props: ITextareaProps) => {
 
         {isRequired && !disabled && (
           <Text type="body" size="small" appearance="dark">
-            (Required)
+            (Requerido)
           </Text>
         )}
         {counter && !disabled && (


### PR DESCRIPTION
This PR refactors the `<Textarea />` component to display the label `Requerido` instead of `Required` when a field is marked as mandatory. This update aims to cater to Spanish-speaking audiences, ensuring clearer and more relevant UI messaging.