### PR TITLE
move the state of the string length to index.tsx in `<Textarea />`

### DIFF
--- a/src/components/inputs/Textarea/index.tsx
+++ b/src/components/inputs/Textarea/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { TextareaUI } from "./interface";
-import { Status } from "./props";
+import { Appearence, Status } from "./props";
 
 interface ITextareaProps {
   label?: string;
@@ -52,7 +52,7 @@ const Textarea = (props: ITextareaProps) => {
 
   let valueLength = typeof value === "string" ? value.length : 0;
 
-  let appearance: "error" | "warning" | "gray" =
+  let appearance: Appearence =
     maxLength - valueLength <= lengthThreshold && valueLength <= maxLength
       ? "warning"
       : valueLength > maxLength

--- a/src/components/inputs/Textarea/index.tsx
+++ b/src/components/inputs/Textarea/index.tsx
@@ -10,7 +10,7 @@ interface ITextareaProps {
   disabled?: boolean;
   isFocused?: boolean;
   status?: Status;
-  value?: string | number;
+  value?: string;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   maxLength?: number;
   minLength?: number;
@@ -33,7 +33,7 @@ const Textarea = (props: ITextareaProps) => {
     placeholder,
     disabled = false,
     onChange,
-    value,
+    value = "",
     maxLength = 0,
     minLength = 0,
     required = false,
@@ -50,12 +50,10 @@ const Textarea = (props: ITextareaProps) => {
 
   const [isFocused, setIsFocused] = useState(false);
 
-  let valueLength = typeof value === "string" ? value.length : 0;
-
   let appearance: Appearence =
-    maxLength - valueLength <= lengthThreshold && valueLength <= maxLength
+    maxLength - value.length <= lengthThreshold && value.length <= maxLength
       ? "warning"
-      : valueLength > maxLength
+      : value!?.length > maxLength
       ? "error"
       : "gray";
 
@@ -97,7 +95,7 @@ const Textarea = (props: ITextareaProps) => {
       readOnly={readOnly}
       counter={counter}
       lengthThreshold={lengthThreshold}
-      valueLength={valueLength}
+      valueLength={value.length}
       appearance={appearance}
     />
   );

--- a/src/components/inputs/Textarea/index.tsx
+++ b/src/components/inputs/Textarea/index.tsx
@@ -34,8 +34,8 @@ const Textarea = (props: ITextareaProps) => {
     disabled = false,
     onChange,
     value,
-    maxLength,
-    minLength,
+    maxLength = 0,
+    minLength = 0,
     required = false,
     status = "pending",
     errorMessage,
@@ -49,6 +49,15 @@ const Textarea = (props: ITextareaProps) => {
   } = props;
 
   const [isFocused, setIsFocused] = useState(false);
+
+  let valueLength = typeof value === "string" ? value.length : 0;
+
+  let appearance: "error" | "warning" | "gray" =
+    maxLength - valueLength <= lengthThreshold && valueLength <= maxLength
+      ? "warning"
+      : valueLength > maxLength
+      ? "error"
+      : "gray";
 
   const interceptFocus = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!readOnly) {
@@ -88,6 +97,8 @@ const Textarea = (props: ITextareaProps) => {
       readOnly={readOnly}
       counter={counter}
       lengthThreshold={lengthThreshold}
+      valueLength={valueLength}
+      appearance={appearance}
     />
   );
 };

--- a/src/components/inputs/Textarea/interface.tsx
+++ b/src/components/inputs/Textarea/interface.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+//import { useState, useEffect } from "react";
 import { MdOutlineError, MdCheckCircle } from "react-icons/md";
 import { Label } from "@inputs/Label";
 import { Text } from "@data/Text";
@@ -11,7 +11,7 @@ import {
 } from "./styles";
 import { ITextareaProps } from ".";
 
-const getAppearanceCounter = (
+/* const getAppearanceCounter = (
   valueLength: number,
   maxLength = 0,
   lengthThreshold: number
@@ -25,41 +25,22 @@ const getAppearanceCounter = (
   }
 
   return "gray";
-};
+}; */
 
-const Counter = (props: ITextareaProps) => {
-  const { id, maxLength, lengthThreshold, disabled } = props;
-  const [valueLength, setValueLength] = useState(0);
-
-  useEffect(() => {
-    const textareaElement = document.getElementById(id);
-    if (textareaElement) {
-      setValueLength(textareaElement.textContent!.length);
-    }
-
-    const handleTextareaChange = () => {
-      if (textareaElement) {
-        setValueLength(textareaElement.textContent!.length);
-      }
-    };
-
-    textareaElement!.addEventListener("input", handleTextareaChange);
-
-    return () => {
-      textareaElement!.removeEventListener("input", handleTextareaChange);
-    };
-  }, [id]);
+const Counter = (
+  props: ITextareaProps & {
+    valueLength: number;
+    appearance: "error" | "warning" | "gray";
+  }
+) => {
+  const { maxLength, appearance, disabled, valueLength } = props;
 
   return (
     <Text
       type="body"
       size="small"
       disabled={disabled}
-      appearance={getAppearanceCounter(
-        valueLength,
-        maxLength,
-        lengthThreshold!
-      )}
+      appearance={appearance}
     >{`${valueLength}/${maxLength}`}</Text>
   );
 };
@@ -90,7 +71,12 @@ const Success = (props: Omit<ITextareaProps, "id">) => {
   );
 };
 
-const TextareaUI = (props: ITextareaProps) => {
+const TextareaUI = (
+  props: ITextareaProps & {
+    valueLength: number;
+    appearance: "error" | "warning" | "gray";
+  }
+) => {
   const {
     label,
     name,
@@ -112,6 +98,8 @@ const TextareaUI = (props: ITextareaProps) => {
     readOnly,
     counter,
     lengthThreshold,
+    valueLength,
+    appearance,
   } = props;
 
   return (
@@ -141,10 +129,11 @@ const TextareaUI = (props: ITextareaProps) => {
         )}
         {counter && !disabled && (
           <Counter
-            id={id}
+            appearance={appearance}
             maxLength={maxLength}
             lengthThreshold={lengthThreshold}
             disabled={disabled}
+            valueLength={valueLength}
           />
         )}
       </StyledContainerLabel>

--- a/src/components/inputs/Textarea/interface.tsx
+++ b/src/components/inputs/Textarea/interface.tsx
@@ -1,7 +1,10 @@
-//import { useState, useEffect } from "react";
 import { MdOutlineError, MdCheckCircle } from "react-icons/md";
+
+import { Appearence } from "./props";
 import { Label } from "@inputs/Label";
 import { Text } from "@data/Text";
+
+import { ITextareaProps } from ".";
 import {
   StyledContainer,
   StyledContainerLabel,
@@ -9,28 +12,11 @@ import {
   StyledErrorMessageContainer,
   StyledValidMessageContainer,
 } from "./styles";
-import { ITextareaProps } from ".";
-
-/* const getAppearanceCounter = (
-  valueLength: number,
-  maxLength = 0,
-  lengthThreshold: number
-) => {
-  if (maxLength - valueLength <= lengthThreshold && valueLength <= maxLength) {
-    return "warning";
-  }
-
-  if (valueLength > maxLength) {
-    return "error";
-  }
-
-  return "gray";
-}; */
 
 const Counter = (
-  props: ITextareaProps & {
+  props: Omit<ITextareaProps, "id"> & {
     valueLength: number;
-    appearance: "error" | "warning" | "gray";
+    appearance: Appearence;
   }
 ) => {
   const { maxLength, appearance, disabled, valueLength } = props;
@@ -74,7 +60,7 @@ const Success = (props: Omit<ITextareaProps, "id">) => {
 const TextareaUI = (
   props: ITextareaProps & {
     valueLength: number;
-    appearance: "error" | "warning" | "gray";
+    appearance: Appearence;
   }
 ) => {
   const {

--- a/src/components/inputs/Textarea/props.ts
+++ b/src/components/inputs/Textarea/props.ts
@@ -1,5 +1,7 @@
 const status = ["valid", "invalid", "pending"] as const;
 
+type Appearence = "error" | "warning" | "gray";
+
 type Status = typeof status[number];
 
 const parameters = {
@@ -91,5 +93,5 @@ const props = {
   },
 };
 
-export type { Status };
+export type { Status, Appearence };
 export { props, parameters };


### PR DESCRIPTION
The logical part of the counter is moved to the index.tsx file, this allows us to separate the layout from all the logical operations performed by the component. 

This change also refactors the logical operation to display the data and no longer makes use of the `useState `and `useEffect` hooks, but is done in a technically simpler way.  