### PR TITLE
`<Button />:` rename `isFullWidth` prop to `fullwidth`

### DIFF
--- a/src/components/inputs/Button/index.tsx
+++ b/src/components/inputs/Button/index.tsx
@@ -25,7 +25,7 @@ export interface IButtonProps {
   type?: Type;
   spacing?: Spacing;
   variant?: Variant;
-  isFullWidth?: boolean;
+  fullwidth?: boolean;
   handleClick?: (e?: Event) => void;
   path?: string;
 }
@@ -87,7 +87,7 @@ const Button = (props: IButtonProps) => {
     type = defaultType,
     spacing = defaultSpacing,
     variant = defaultVariant,
-    isFullWidth = false,
+    fullwidth = false,
     handleClick,
     path,
   } = props;
@@ -131,7 +131,7 @@ const Button = (props: IButtonProps) => {
         isdisabled={+isDisabled}
         variant={transformedVariant}
         appearance={transformedAppearance}
-        isfullwidth={+isFullWidth}
+        fullwidth={+fullwidth}
         onClick={transformedLinkHandleClick}
       >
         <StyledButton
@@ -139,7 +139,7 @@ const Button = (props: IButtonProps) => {
           isDisabled={isDisabled}
           spacing={transformedSpacing}
           variant={transformedVariant}
-          isFullWidth={isFullWidth}
+          fullwidth={fullwidth}
         >
           <StyledSpan isDisabled={isDisabled} variant={transformedVariant}>
             {iconBefore && <StyledIcon id="mdIcon">{iconBefore}</StyledIcon>}
@@ -161,7 +161,7 @@ const Button = (props: IButtonProps) => {
       type={transformedType}
       spacing={transformedSpacing}
       variant={transformedVariant}
-      isFullWidth={isFullWidth}
+      fullwidth={fullwidth}
       onClick={transformedHandleClick}
     >
       {isLoading && !isDisabled ? (

--- a/src/components/inputs/Button/props.ts
+++ b/src/components/inputs/Button/props.ts
@@ -102,7 +102,7 @@ const props = {
       defaultValue: { summary: "filled" },
     },
   },
-  isFullWidth: {
+  fullwidth: {
     options: [true, false],
     control: { type: "boolean" },
     description: "option to fit button width to its parent width",

--- a/src/components/inputs/Button/stories/Button.Appearances.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Appearances.stories.tsx
@@ -43,7 +43,7 @@ Appearances.args = {
   type: "button",
   spacing: "wide",
   variant: "filled",
-  isFullWidth: false,
+  fullwidth: false,
   handleClick: () => console.log("clicked"),
   path: "/privileges",
 };

--- a/src/components/inputs/Button/stories/Button.Disabled.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Disabled.stories.tsx
@@ -40,7 +40,7 @@ Disabled.args = {
   type: "button",
   spacing: "wide",
   variant: "filled",
-  isFullWidth: false,
+  fullwidth: false,
   handleClick: () => console.log("clicked"),
   path: "/privileges",
 };

--- a/src/components/inputs/Button/stories/Button.FullWidth.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.FullWidth.stories.tsx
@@ -22,7 +22,7 @@ const story = {
 const ButtonComponent = (props: IButtonProps) => {
   return (
     <StyledFlex>
-      <Button {...props} isFullWidth={true} />
+      <Button {...props} fullwidth={true} />
     </StyledFlex>
   );
 };

--- a/src/components/inputs/Button/stories/Button.Icons.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Icons.stories.tsx
@@ -44,7 +44,7 @@ Icons.args = {
   type: "button",
   spacing: "wide",
   variant: "filled",
-  isFullWidth: false,
+  fullwidth: false,
   handleClick: () => console.log("clicked"),
 };
 

--- a/src/components/inputs/Button/stories/Button.Loading.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Loading.stories.tsx
@@ -38,7 +38,7 @@ Loading.args = {
   type: "button",
   spacing: "wide",
   variant: "filled",
-  isFullWidth: false,
+  fullwidth: false,
   handleClick: () => console.log("clicked"),
 };
 

--- a/src/components/inputs/Button/stories/Button.Spacing.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Spacing.stories.tsx
@@ -40,7 +40,7 @@ Spacing.args = {
   iconBefore: <MdAdd />,
   type: "button",
   variant: "filled",
-  isFullWidth: false,
+  fullwidth: false,
   handleClick: () => console.log("clicked"),
   path: "/privileges",
 };

--- a/src/components/inputs/Button/stories/Button.Variants.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Variants.stories.tsx
@@ -40,7 +40,7 @@ Variants.args = {
   iconBefore: <MdAdd />,
   type: "button",
   spacing: "wide",
-  isFullWidth: false,
+  fullwidth: false,
   handleClick: () => console.log("clicked"),
   path: "/privileges",
 };

--- a/src/components/inputs/Button/stories/Button.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.stories.tsx
@@ -30,7 +30,7 @@ Default.args = {
   type: "button",
   spacing: "wide",
   variant: "filled",
-  isFullWidth: false,
+  fullwidth: false,
   handleClick: () => console.log("clicked from Default-story"),
 };
 

--- a/src/components/inputs/Button/styles.ts
+++ b/src/components/inputs/Button/styles.ts
@@ -252,8 +252,8 @@ function getBackgroundColor(
   return backgroundColor[variant].normal[appearance].filled;
 }
 
-function getWidth(isFullWidth: boolean | undefined) {
-  if (isFullWidth) {
+function getWidth(fullwidth: boolean | undefined) {
+  if (fullwidth) {
     return "100%";
   }
 
@@ -279,7 +279,7 @@ const containerStyles = css`
 const StyledButton = styled.button`
   padding: 0px 16px;
   ${containerStyles}
-  width: ${({ isFullWidth }: IButtonProps) => getWidth(isFullWidth)};
+  width: ${({ fullwidth }: IButtonProps) => getWidth(fullwidth)};
   background-color: ${({ isDisabled, variant, appearance }: IButtonProps) =>
     getBackgroundColor(isDisabled, variant!, appearance!)};
   border-style: ${(props: IButtonProps) =>
@@ -311,7 +311,7 @@ const StyledLink = styled(Link)`
   ${containerStyles}
   border-style: ${(props: IButtonProps) =>
     props.type === "link" ? "solid" : "none"};
-  width: ${({ isfullwidth }: any) => getWidth(!!isfullwidth)};
+  width: ${({ fullwidth }: any) => getWidth(!!fullwidth)};
   color: ${({ isdisabled, variant, appearance }: IButtonProps) =>
     getColor(!!isdisabled, variant!, appearance!)};
   border-color: ${({ isdisabled, variant, appearance }: IButtonProps) =>


### PR DESCRIPTION
This PR refines the `<Button />` component's API by renaming the `isFullWidth` prop to a more concise `fullwidth`. This change simplifies prop naming, aligns with other similar prop naming conventions, and aims to offer clearer intent.