### PR TITLE
`<Button />:` rename `isLoading` prop to `loading`

### DIFF
--- a/src/components/inputs/Button/index.tsx
+++ b/src/components/inputs/Button/index.tsx
@@ -17,7 +17,7 @@ import {
 export interface IButtonProps {
   children: React.ReactNode;
   appearance?: Appearance;
-  isLoading?: boolean;
+  loading?: boolean;
   isDisabled?: boolean;
   isdisabled?: number;
   iconBefore?: React.ReactElement;
@@ -80,7 +80,7 @@ const Button = (props: IButtonProps) => {
   const {
     children,
     appearance = defaultAppearance,
-    isLoading = false,
+    loading = false,
     isDisabled = false,
     iconBefore,
     iconAfter,
@@ -154,7 +154,7 @@ const Button = (props: IButtonProps) => {
   return (
     <StyledButton
       appearance={transformedAppearance}
-      isLoading={isLoading}
+      loading={loading}
       isDisabled={isDisabled}
       iconBefore={iconBefore}
       iconAfter={iconAfter}
@@ -164,7 +164,7 @@ const Button = (props: IButtonProps) => {
       isFullWidth={isFullWidth}
       onClick={transformedHandleClick}
     >
-      {isLoading && !isDisabled ? (
+      {loading && !isDisabled ? (
         <Spinner
           appearance={getSpinnerColor(
             transformedVariant,

--- a/src/components/inputs/Button/props.ts
+++ b/src/components/inputs/Button/props.ts
@@ -44,7 +44,7 @@ const props = {
     control: { type: "text" },
     description: "the text to be displayed",
   },
-  isLoading: {
+  loading: {
     options: [false, true],
     control: { type: "boolean" },
     description: "conditionally show a spinner over the top of a button",

--- a/src/components/inputs/Button/stories/Button.Appearances.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Appearances.stories.tsx
@@ -37,7 +37,7 @@ export const Appearances = (args: IButtonProps) => (
 );
 Appearances.args = {
   children: "Button",
-  isLoading: false,
+  loading: false,
   isDisabled: false,
   iconBefore: <MdAdd />,
   type: "button",

--- a/src/components/inputs/Button/stories/Button.Disabled.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Disabled.stories.tsx
@@ -35,7 +35,7 @@ export const Disabled = (args: IButtonProps) => <ButtonComponent {...args} />;
 Disabled.args = {
   children: "Button",
   appearance: "primary",
-  isLoading: false,
+  loading: false,
   iconBefore: <MdAdd />,
   type: "button",
   spacing: "wide",

--- a/src/components/inputs/Button/stories/Button.FullWidth.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.FullWidth.stories.tsx
@@ -31,7 +31,7 @@ export const FullWidth = (args: IButtonProps) => <ButtonComponent {...args} />;
 FullWidth.args = {
   children: "Button",
   appearance: "primary",
-  isLoading: false,
+  loading: false,
   isDisabled: false,
   iconBefore: <MdAdd />,
   type: "button",

--- a/src/components/inputs/Button/stories/Button.Icons.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Icons.stories.tsx
@@ -39,7 +39,7 @@ export const Icons = (args: IButtonProps) => <ButtonComponent {...args} />;
 Icons.args = {
   children: "Button",
   appearance: "primary",
-  isLoading: false,
+  loading: false,
   isDisabled: false,
   type: "button",
   spacing: "wide",

--- a/src/components/inputs/Button/stories/Button.Loading.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Loading.stories.tsx
@@ -23,7 +23,7 @@ const ButtonComponent = (props: IButtonProps) => {
     <StyledFlex>
       {variants.map((variant) => (
         <div key={variant}>
-          <Button {...props} variant={variant} isLoading={true} />
+          <Button {...props} variant={variant} loading={true} />
         </div>
       ))}
     </StyledFlex>

--- a/src/components/inputs/Button/stories/Button.Spacing.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Spacing.stories.tsx
@@ -35,7 +35,7 @@ export const Spacing = (args: IButtonProps) => <ButtonComponent {...args} />;
 Spacing.args = {
   children: "Button",
   appearance: "primary",
-  isLoading: false,
+  loading: false,
   isDisabled: false,
   iconBefore: <MdAdd />,
   type: "button",

--- a/src/components/inputs/Button/stories/Button.Variants.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Variants.stories.tsx
@@ -35,7 +35,7 @@ export const Variants = (args: IButtonProps) => <ButtonComponent {...args} />;
 Variants.args = {
   children: "Button",
   appearance: "primary",
-  isLoading: false,
+  loading: false,
   isDisabled: false,
   iconBefore: <MdAdd />,
   type: "button",

--- a/src/components/inputs/Button/stories/Button.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.stories.tsx
@@ -25,7 +25,7 @@ Default.args = {
   appearance: "primary",
   path: "/privilege",
   iconBefore: <MdAdd />,
-  isLoading: false,
+  loading: false,
   isDisabled: false,
   type: "button",
   spacing: "wide",

--- a/src/components/inputs/Button/styles.ts
+++ b/src/components/inputs/Button/styles.ts
@@ -180,13 +180,13 @@ const borderColors: IBorderColors = {
 
 const getPointer = (
   isDisabled: boolean | undefined,
-  isLoading: boolean = false
+  loading: boolean = false
 ) => {
   if (isDisabled) {
     return cursors.notAllowed;
   }
 
-  if (isLoading) {
+  if (loading) {
     return cursors.progress;
   }
 
@@ -292,8 +292,8 @@ const StyledButton = styled.button`
     getBorderColor(isDisabled, variant!, appearance!)};
   background-color: ${({ isDisabled, variant, appearance }: IButtonProps) =>
     getBackgroundColor(isDisabled, variant!, appearance!)};
-  cursor: ${({ isDisabled, isLoading }: IButtonProps) =>
-    getPointer(isDisabled, isLoading)};
+  cursor: ${({ isDisabled, loading }: IButtonProps) =>
+    getPointer(isDisabled, loading)};
 
   &:hover {
     color: ${({ isDisabled, variant, appearance }: IButtonProps) =>


### PR DESCRIPTION
In this PR, we've streamlined the `<Button />` component's API by renaming the `isLoading` prop to a succinct `loading`. This modification aims to simplify the naming convention, align with common terminologies, and present clearer developer intent.

