### PR TITLE
`<Button />:` rename `isDisabled` prop to `disabled`

### DIFF
--- a/src/components/inputs/Button/index.tsx
+++ b/src/components/inputs/Button/index.tsx
@@ -18,8 +18,7 @@ export interface IButtonProps {
   children: React.ReactNode;
   appearance?: Appearance;
   loading?: boolean;
-  isDisabled?: boolean;
-  isdisabled?: number;
+  disabled?: boolean;
   iconBefore?: React.ReactElement;
   iconAfter?: React.ReactElement;
   type?: Type;
@@ -81,7 +80,7 @@ const Button = (props: IButtonProps) => {
     children,
     appearance = defaultAppearance,
     loading = false,
-    isDisabled = false,
+    disabled = false,
     iconBefore,
     iconAfter,
     type = defaultType,
@@ -108,7 +107,7 @@ const Button = (props: IButtonProps) => {
 
   const transformedTransparentSpinner = transformedVariant === "filled";
 
-  const transformedHandleClick = isDisabled ? null : handleClick;
+  const transformedHandleClick = disabled ? null : handleClick;
 
   if (type === "link" && !path) {
     console.warn("You must provide a path to use a link button");
@@ -118,7 +117,7 @@ const Button = (props: IButtonProps) => {
     const transformedLinkHandleClick = (
       event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
     ) => {
-      if (isDisabled) {
+      if (disabled) {
         event.preventDefault();
       } else {
         handleClick && handleClick();
@@ -128,7 +127,7 @@ const Button = (props: IButtonProps) => {
     return (
       <StyledLink
         to={path}
-        isdisabled={+isDisabled}
+        disabled={+disabled}
         variant={transformedVariant}
         appearance={transformedAppearance}
         fullwidth={+fullwidth}
@@ -136,12 +135,12 @@ const Button = (props: IButtonProps) => {
       >
         <StyledButton
           appearance={transformedAppearance}
-          isDisabled={isDisabled}
+          disabled={disabled}
           spacing={transformedSpacing}
           variant={transformedVariant}
           fullwidth={fullwidth}
         >
-          <StyledSpan isDisabled={isDisabled} variant={transformedVariant}>
+          <StyledSpan disabled={disabled} variant={transformedVariant}>
             {iconBefore && <StyledIcon id="mdIcon">{iconBefore}</StyledIcon>}
             {children}
             {iconAfter && <StyledIcon id="mdIcon">{iconAfter}</StyledIcon>}
@@ -155,7 +154,7 @@ const Button = (props: IButtonProps) => {
     <StyledButton
       appearance={transformedAppearance}
       loading={loading}
-      isDisabled={isDisabled}
+      disabled={disabled}
       iconBefore={iconBefore}
       iconAfter={iconAfter}
       type={transformedType}
@@ -164,7 +163,7 @@ const Button = (props: IButtonProps) => {
       fullwidth={fullwidth}
       onClick={transformedHandleClick}
     >
-      {loading && !isDisabled ? (
+      {loading && !disabled ? (
         <Spinner
           appearance={getSpinnerColor(
             transformedVariant,
@@ -174,7 +173,7 @@ const Button = (props: IButtonProps) => {
           size={defaultSpinnerSize}
         />
       ) : (
-        <StyledSpan isDisabled={isDisabled} variant={transformedVariant}>
+        <StyledSpan disabled={disabled} variant={transformedVariant}>
           {iconBefore && <StyledIcon id="mdIcon">{iconBefore}</StyledIcon>}
           {children}
           {iconAfter && <StyledIcon id="mdIcon">{iconAfter}</StyledIcon>}

--- a/src/components/inputs/Button/props.ts
+++ b/src/components/inputs/Button/props.ts
@@ -60,7 +60,7 @@ const props = {
       defaultValue: { summary: "primary" },
     },
   },
-  isDisabled: {
+  disabled: {
     options: [true, false],
     control: { type: "boolean" },
     description: "set if the button is disabled",

--- a/src/components/inputs/Button/stories/Button.Appearances.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Appearances.stories.tsx
@@ -38,7 +38,7 @@ export const Appearances = (args: IButtonProps) => (
 Appearances.args = {
   children: "Button",
   loading: false,
-  isDisabled: false,
+  disabled: false,
   iconBefore: <MdAdd />,
   type: "button",
   spacing: "wide",

--- a/src/components/inputs/Button/stories/Button.Disabled.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Disabled.stories.tsx
@@ -24,7 +24,7 @@ const ButtonComponent = (props: IButtonProps) => {
     <StyledFlex>
       {appearances.map((appearance) => (
         <div key={appearance}>
-          <Button {...props} isDisabled={true} />
+          <Button {...props} disabled={true} />
         </div>
       ))}
     </StyledFlex>

--- a/src/components/inputs/Button/stories/Button.FullWidth.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.FullWidth.stories.tsx
@@ -32,7 +32,7 @@ FullWidth.args = {
   children: "Button",
   appearance: "primary",
   loading: false,
-  isDisabled: false,
+  disabled: false,
   iconBefore: <MdAdd />,
   type: "button",
   spacing: "wide",

--- a/src/components/inputs/Button/stories/Button.Icons.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Icons.stories.tsx
@@ -40,7 +40,7 @@ Icons.args = {
   children: "Button",
   appearance: "primary",
   loading: false,
-  isDisabled: false,
+  disabled: false,
   type: "button",
   spacing: "wide",
   variant: "filled",

--- a/src/components/inputs/Button/stories/Button.Loading.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Loading.stories.tsx
@@ -34,7 +34,7 @@ export const Loading = (args: IButtonProps) => <ButtonComponent {...args} />;
 Loading.args = {
   children: "Button",
   appearance: "primary",
-  isDisabled: false,
+  disabled: false,
   type: "button",
   spacing: "wide",
   variant: "filled",

--- a/src/components/inputs/Button/stories/Button.Spacing.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Spacing.stories.tsx
@@ -36,7 +36,7 @@ Spacing.args = {
   children: "Button",
   appearance: "primary",
   loading: false,
-  isDisabled: false,
+  disabled: false,
   iconBefore: <MdAdd />,
   type: "button",
   variant: "filled",

--- a/src/components/inputs/Button/stories/Button.Variants.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.Variants.stories.tsx
@@ -36,7 +36,7 @@ Variants.args = {
   children: "Button",
   appearance: "primary",
   loading: false,
-  isDisabled: false,
+  disabled: false,
   iconBefore: <MdAdd />,
   type: "button",
   spacing: "wide",

--- a/src/components/inputs/Button/stories/Button.stories.tsx
+++ b/src/components/inputs/Button/stories/Button.stories.tsx
@@ -26,7 +26,7 @@ Default.args = {
   path: "/privilege",
   iconBefore: <MdAdd />,
   loading: false,
-  isDisabled: false,
+  disabled: false,
   type: "button",
   spacing: "wide",
   variant: "filled",

--- a/src/components/inputs/Button/styles.ts
+++ b/src/components/inputs/Button/styles.ts
@@ -179,10 +179,10 @@ const borderColors: IBorderColors = {
 };
 
 const getPointer = (
-  isDisabled: boolean | undefined,
+  disabled: boolean | undefined,
   loading: boolean = false
 ) => {
-  if (isDisabled) {
+  if (disabled) {
     return cursors.notAllowed;
   }
 
@@ -194,12 +194,12 @@ const getPointer = (
 };
 
 const getColor = (
-  isDisabled: boolean | undefined,
+  disabled: boolean | undefined,
   variant: Variant,
   appearance: Appearance,
   isHover: boolean = false
 ) => {
-  if (isDisabled) {
+  if (disabled) {
     return textColors.filled.normal.disabled;
   }
 
@@ -211,7 +211,7 @@ const getColor = (
 };
 
 const getBorderColor = (
-  isDisabled: boolean | undefined,
+  disabled: boolean | undefined,
   variant: Variant,
   appearance: Appearance,
   isHover: boolean = false
@@ -220,7 +220,7 @@ const getBorderColor = (
     return borderColors[variant];
   }
 
-  if (isDisabled) {
+  if (disabled) {
     return borderColors[variant].normal.disabled.stroke;
   }
 
@@ -232,7 +232,7 @@ const getBorderColor = (
 };
 
 function getBackgroundColor(
-  isDisabled: boolean | undefined,
+  disabled: boolean | undefined,
   variant: Variant,
   appearance: Appearance,
   isHover: boolean = false
@@ -241,7 +241,7 @@ function getBackgroundColor(
     return backgroundColor[variant];
   }
 
-  if (isDisabled) {
+  if (disabled) {
     return backgroundColor[variant].normal.disabled.filled;
   }
 
@@ -280,28 +280,28 @@ const StyledButton = styled.button`
   padding: 0px 16px;
   ${containerStyles}
   width: ${({ fullwidth }: IButtonProps) => getWidth(fullwidth)};
-  background-color: ${({ isDisabled, variant, appearance }: IButtonProps) =>
-    getBackgroundColor(isDisabled, variant!, appearance!)};
+  background-color: ${({ disabled, variant, appearance }: IButtonProps) =>
+    getBackgroundColor(disabled, variant!, appearance!)};
   border-style: ${(props: IButtonProps) =>
     props.type !== "link" ? "solid" : "none"};
   ${(props: IButtonProps) => spacing[props.spacing!]};
 
-  color: ${({ isDisabled, variant, appearance }: IButtonProps) =>
-    getColor(isDisabled, variant!, appearance!)};
-  border-color: ${({ isDisabled, variant, appearance }: IButtonProps) =>
-    getBorderColor(isDisabled, variant!, appearance!)};
-  background-color: ${({ isDisabled, variant, appearance }: IButtonProps) =>
-    getBackgroundColor(isDisabled, variant!, appearance!)};
-  cursor: ${({ isDisabled, loading }: IButtonProps) =>
-    getPointer(isDisabled, loading)};
+  color: ${({ disabled, variant, appearance }: IButtonProps) =>
+    getColor(disabled, variant!, appearance!)};
+  border-color: ${({ disabled, variant, appearance }: IButtonProps) =>
+    getBorderColor(disabled, variant!, appearance!)};
+  background-color: ${({ disabled, variant, appearance }: IButtonProps) =>
+    getBackgroundColor(disabled, variant!, appearance!)};
+  cursor: ${({ disabled, loading }: IButtonProps) =>
+    getPointer(disabled, loading)};
 
   &:hover {
-    color: ${({ isDisabled, variant, appearance }: IButtonProps) =>
-      getColor(isDisabled, variant!, appearance!, true)};
-    border-color: ${({ isDisabled, variant, appearance }: IButtonProps) =>
-      getBorderColor(isDisabled, variant!, appearance!, true)};
-    background-color: ${({ isDisabled, variant, appearance }: IButtonProps) =>
-      getBackgroundColor(isDisabled, variant!, appearance!, true)};
+    color: ${({ disabled, variant, appearance }: IButtonProps) =>
+      getColor(disabled, variant!, appearance!, true)};
+    border-color: ${({ disabled, variant, appearance }: IButtonProps) =>
+      getBorderColor(disabled, variant!, appearance!, true)};
+    background-color: ${({ disabled, variant, appearance }: IButtonProps) =>
+      getBackgroundColor(disabled, variant!, appearance!, true)};
   }
 `;
 
@@ -312,21 +312,21 @@ const StyledLink = styled(Link)`
   border-style: ${(props: IButtonProps) =>
     props.type === "link" ? "solid" : "none"};
   width: ${({ fullwidth }: any) => getWidth(!!fullwidth)};
-  color: ${({ isdisabled, variant, appearance }: IButtonProps) =>
-    getColor(!!isdisabled, variant!, appearance!)};
-  border-color: ${({ isdisabled, variant, appearance }: IButtonProps) =>
-    getBorderColor(!!isdisabled, variant!, appearance!)};
-  background-color: ${({ isdisabled, variant, appearance }: IButtonProps) =>
-    getBackgroundColor(!!isdisabled, variant!, appearance!)};
-  cursor: ${({ isdisabled }: any) => getPointer(!!isdisabled)};
+  color: ${({ disabled, variant, appearance }: IButtonProps) =>
+    getColor(!!disabled, variant!, appearance!)};
+  border-color: ${({ disabled, variant, appearance }: IButtonProps) =>
+    getBorderColor(!!disabled, variant!, appearance!)};
+  background-color: ${({ disabled, variant, appearance }: IButtonProps) =>
+    getBackgroundColor(!!disabled, variant!, appearance!)};
+  cursor: ${({ disabled }: any) => getPointer(!!disabled)};
 
   &:hover {
-    color: ${({ isdisabled, variant, appearance }: IButtonProps) =>
-      getColor(!!isdisabled, variant!, appearance!, true)};
-    border-color: ${({ isdisabled, variant, appearance }: IButtonProps) =>
-      getBorderColor(!!isdisabled, variant!, appearance!, true)};
-    background-color: ${({ isdisabled, variant, appearance }: IButtonProps) =>
-      getBackgroundColor(!!isdisabled, variant!, appearance!, true)};
+    color: ${({ disabled, variant, appearance }: IButtonProps) =>
+      getColor(!!disabled, variant!, appearance!, true)};
+    border-color: ${({ disabled, variant, appearance }: IButtonProps) =>
+      getBorderColor(!!disabled, variant!, appearance!, true)};
+    background-color: ${({ disabled, variant, appearance }: IButtonProps) =>
+      getBackgroundColor(!!disabled, variant!, appearance!, true)};
   }
 `;
 


### PR DESCRIPTION
With this PR, we enhance the `<Button />` component's API by transitioning the `isDisabled` prop name to the more straightforward `disabled`. This shift is made to align the naming with standard HTML attributes and to provide a more intuitive and familiar interface for developers.