### PR TITLE
`<Textarea />:` refactor to just use a `message` prop

### DIFF
--- a/src/components/inputs/Textarea/index.tsx
+++ b/src/components/inputs/Textarea/index.tsx
@@ -15,8 +15,7 @@ interface ITextareaProps extends Themed {
   maxLength?: number;
   minLength?: number;
   required?: boolean;
-  errorMessage?: string;
-  validMessage?: string;
+  message?: string;
   fullwidth?: boolean;
   onFocus?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onBlur?: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -37,8 +36,7 @@ const Textarea = (props: ITextareaProps) => {
     minLength,
     required = false,
     status = "pending",
-    errorMessage,
-    validMessage,
+    message,
     fullwidth = false,
     onFocus,
     onBlur,
@@ -76,8 +74,7 @@ const Textarea = (props: ITextareaProps) => {
       minLength={minLength}
       required={required}
       status={status}
-      errorMessage={errorMessage}
-      validMessage={validMessage}
+      message={message}
       fullwidth={fullwidth}
       isFocused={isFocused}
       onChange={onChange}

--- a/src/components/inputs/Textarea/interface.tsx
+++ b/src/components/inputs/Textarea/interface.tsx
@@ -8,10 +8,10 @@ import { Stack } from "@layouts/Stack";
 import {
   StyledContainer,
   StyledTextarea,
-  StyledErrorMessageContainer,
-  StyledValidMessageContainer,
+  StyledMessageContainer,
 } from "./styles";
 import { ITextareaProps } from ".";
+import { Icon } from "@data/Icon";
 
 const getAppearanceCounter = (
   valueLength: number,
@@ -66,29 +66,28 @@ const Counter = (props: ITextareaProps) => {
   );
 };
 
-const Invalid = (props: Omit<ITextareaProps, "id">) => {
-  const { disabled, status, errorMessage } = props;
+const Message = (props: Omit<ITextareaProps, "id"> & { message?: string }) => {
+  const { disabled, status, message } = props;
 
   return (
-    <StyledErrorMessageContainer disabled={disabled} status={status}>
-      <MdOutlineError />
-      <Text type="body" size="small" appearance={"error"} disabled={disabled}>
-        {errorMessage && `(${errorMessage})`}
-      </Text>
-    </StyledErrorMessageContainer>
-  );
-};
-
-const Success = (props: Omit<ITextareaProps, "id">) => {
-  const { disabled, status, validMessage } = props;
-
-  return (
-    <StyledValidMessageContainer disabled={disabled} status={status}>
-      <MdCheckCircle />
-      <Text type="body" size="small" appearance={"success"} disabled={disabled}>
-        {validMessage}
-      </Text>
-    </StyledValidMessageContainer>
+    status !== "pending" && (
+      <StyledMessageContainer disabled={disabled} status={status}>
+        <Icon
+          appearance={status === "invalid" ? "error" : "success"}
+          disabled={disabled}
+          icon={status === "invalid" ? <MdOutlineError /> : <MdCheckCircle />}
+        />
+        <Text
+          type="body"
+          size="small"
+          margin="8px 0px 0px 4px"
+          appearance={status === "invalid" ? "error" : "success"}
+          disabled={disabled}
+        >
+          {message && `${message}`}
+        </Text>
+      </StyledMessageContainer>
+    )
   );
 };
 
@@ -104,8 +103,7 @@ const TextareaUI = (props: ITextareaProps) => {
     minLength,
     required,
     status,
-    errorMessage,
-    validMessage,
+    message,
     fullwidth,
     isFocused,
     onChange,
@@ -167,19 +165,8 @@ const TextareaUI = (props: ITextareaProps) => {
         value={value}
       />
 
-      {status === "invalid" && (
-        <Invalid
-          disabled={disabled}
-          status={status}
-          errorMessage={errorMessage}
-        />
-      )}
-      {status === "valid" && (
-        <Success
-          disabled={disabled}
-          status={status}
-          validMessage={validMessage}
-        />
+      {status && (
+        <Message disabled={disabled} status={status} message={message} />
       )}
     </StyledContainer>
   );

--- a/src/components/inputs/Textarea/interface.tsx
+++ b/src/components/inputs/Textarea/interface.tsx
@@ -66,7 +66,7 @@ const Counter = (props: ITextareaProps) => {
   );
 };
 
-const Message = (props: Omit<ITextareaProps, "id"> & { message?: string }) => {
+const Message = (props: Omit<ITextareaProps, "id">) => {
   const { disabled, status, message } = props;
 
   return (

--- a/src/components/inputs/Textarea/props.ts
+++ b/src/components/inputs/Textarea/props.ts
@@ -65,11 +65,9 @@ const props = {
       defaultValue: { summary: "pending" },
     },
   },
-  errorMessage: {
-    description: "show when the field is validated and there is an error",
-  },
-  validMessage: {
-    description: "show when the field is validated without errors",
+  message: {
+    description:
+      "display a message, provided by the developer implementing the component, which can be either an error notification or a validation prompt",
   },
   fullwidth: {
     description: "option to fit field width to its parent width",

--- a/src/components/inputs/Textarea/stories/TextareaController.tsx
+++ b/src/components/inputs/Textarea/stories/TextareaController.tsx
@@ -13,6 +13,9 @@ const TextareaController = (props: ITextareaProps) => {
   };
 
   const onFocus = () => {
+    if (form.status === "invalid") {
+      return setForm({ ...form, status: "invalid" });
+    }
     setForm({ ...form, status: "pending" });
   };
 
@@ -21,6 +24,10 @@ const TextareaController = (props: ITextareaProps) => {
       setForm({ ...form, status: "invalid" });
     } else setForm({ ...form, status: "valid" });
   };
+  const message =
+    form.status === "valid"
+      ? "The field has been successfully validated"
+      : "The number the characters is too long";
   return (
     <Textarea
       {...props}
@@ -30,7 +37,7 @@ const TextareaController = (props: ITextareaProps) => {
       onChange={onChange}
       onFocus={onFocus}
       onBlur={onBlur}
-      errorMessage="The number the characters is too long"
+      message={message}
     />
   );
 };

--- a/src/components/inputs/Textarea/styles.ts
+++ b/src/components/inputs/Textarea/styles.ts
@@ -68,12 +68,10 @@ const StyledTextarea = styled.textarea`
   }
 `;
 
-const StyledErrorMessageContainer = styled.div`
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 5px;
+const StyledMessageContainer = styled.div`
+  display: flex;
   align-items: center;
-  padding-left: 12px;
+  margin-left: ${inube.spacing.s200};
   pointer-events: none;
   color: ${({ disabled, status, theme }: ITextareaProps) => {
     if (disabled) {
@@ -98,34 +96,8 @@ const StyledErrorMessageContainer = styled.div`
   & svg {
     width: 14px;
     height: 14px;
+    margin-top: ${inube.spacing.s100};
   }
 `;
 
-const StyledValidMessageContainer = styled(StyledErrorMessageContainer)`
-  color: ${({ disabled, status, theme }: ITextareaProps) => {
-    if (disabled) {
-      return (
-        theme?.color?.text?.gray?.disabled || inube.color.text.gray.disabled
-      );
-    }
-
-    if (status === "valid") {
-      return (
-        theme?.color?.text?.success?.regular || inube.color.text.success.regular
-      );
-    }
-
-    if (status === "invalid") {
-      return (
-        theme?.color?.text?.error?.regular || inube.color.text.error.regular
-      );
-    }
-  }};
-`;
-
-export {
-  StyledContainer,
-  StyledTextarea,
-  StyledErrorMessageContainer,
-  StyledValidMessageContainer,
-};
+export { StyledContainer, StyledTextarea, StyledMessageContainer };


### PR DESCRIPTION
In this PR, we have refined the `<Textarea />` component's structure to leverage a unified `message` prop. Previously, multiple props might have been used to convey different messages. This simplification not only streamlines the component's API but also makes it more intuitive and easier to integrate.