### PR TITLE
directly assign the default value during props destructuration `<Button />`

### DIFF
--- a/src/components/inputs/Button/index.tsx
+++ b/src/components/inputs/Button/index.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from "@feedback/Spinner";
-import { colors } from "@shared/colors/colors";
+
 import {
   Appearance,
   Type,
@@ -24,12 +24,6 @@ export interface IButtonProps {
   handleClick?: (e?: Event) => void;
   path?: string;
 }
-
-const fixedColors: { [key: string]: any } = Object.assign(
-  {},
-  colors.sys.actions
-);
-delete fixedColors.disabled;
 
 const spinnerColorHomologation: SpinnerColorHomologation = {
   filled: {


### PR DESCRIPTION
remove variables with default values, assigning them directly in the destructuring of the props. This allows you to avoid unnecessary variable declaration and improves code readability.