### PR TITLE
`<Button />:` delete `getWidth` function and direclty use an arrow function when setting the CSS property

### DIFF
--- a/src/components/inputs/Button/index.tsx
+++ b/src/components/inputs/Button/index.tsx
@@ -124,7 +124,7 @@ const Button = (props: IButtonProps) => {
   return (
     <StyledButton
       appearance={appearance}
-      loading={loading}
+      loading={+loading}
       disabled={disabled}
       iconBefore={iconBefore}
       iconAfter={iconAfter}

--- a/src/components/inputs/Button/styles.ts
+++ b/src/components/inputs/Button/styles.ts
@@ -104,14 +104,6 @@ const cursors: ICursors = {
   progress: "progress",
 };
 
-function getWidth(fullwidth: boolean | undefined) {
-  if (fullwidth) {
-    return "100%";
-  }
-
-  return "fit-content";
-}
-
 const containerStyles = css`
   display: flex;
   justify-content: center;
@@ -131,7 +123,13 @@ const containerStyles = css`
 const StyledButton = styled.button`
   padding: 0px 16px;
   ${containerStyles}
-  width: ${({ fullwidth }: IButtonProps) => getWidth(fullwidth)};
+  width: ${({ fullwidth }: IButtonProps) => {
+    if (fullwidth) {
+      return "100%";
+    }
+
+    return "fit-content";
+  }};
   border-style: ${(props: IButtonProps) =>
     props.type !== "link" ? "solid" : "none"};
   ${(props: IButtonProps) => spacing[props.spacing!]};
@@ -232,7 +230,13 @@ const StyledLink = styled(Link)`
   ${containerStyles}
   border-style: ${(props: IButtonProps) =>
     props.type === "link" ? "solid" : "none"};
-  width: ${({ fullwidth }: IButtonProps) => getWidth(!!fullwidth)};
+  width: ${({ fullwidth }: IButtonProps) => {
+    if (fullwidth) {
+      return "100%";
+    }
+
+    return "fit-content";
+  }};
 
   ${StyledButton}
   cursor: ${({ disabled, loading }: IButtonProps) => {


### PR DESCRIPTION
This PR refines the `<Button />` component by eradicating the `getWidth` function and directly adopting an arrow function for setting the width CSS property. This direct strategy simplifies the codebase and augments the component's efficiency by bypassing redundant function invocations.