### PR TITLE
Rename `isDisabled` prop for just `disabled` in `<Tab />`

### DIFF
--- a/src/components/navigation/Tab/index.tsx
+++ b/src/components/navigation/Tab/index.tsx
@@ -5,14 +5,14 @@ import { StyledTab } from "./styles";
 export interface ITabProps {
   label: string;
   id: string;
-  isDisabled: boolean;
+  disabled: boolean;
   isSelected: boolean;
   handleClick: () => void;
 }
 
 const Tab = (props: ITabProps) => {
   const {
-    isDisabled = false,
+    disabled = false,
     isSelected = false,
     id,
     handleClick,
@@ -22,7 +22,7 @@ const Tab = (props: ITabProps) => {
   return (
     <StyledTab
       onClick={handleClick}
-      isDisabled={isDisabled}
+      disabled={disabled}
       isSelected={isSelected}
       id={id}
     >
@@ -30,7 +30,7 @@ const Tab = (props: ITabProps) => {
         type="label"
         size="medium"
         appearance={isSelected ? "primary" : "dark"}
-        disabled={isDisabled}
+        disabled={disabled}
       >
         {label}
       </Text>

--- a/src/components/navigation/Tab/props.ts
+++ b/src/components/navigation/Tab/props.ts
@@ -3,7 +3,7 @@ const props = {
     control: { type: "text" },
     description: "shall be the id for the text",
   },
-  isDisabled: {
+  disabled: {
     options: [true, false],
     control: { type: "boolean" },
     description:

--- a/src/components/navigation/Tab/stories/Tab.stories.tsx
+++ b/src/components/navigation/Tab/stories/Tab.stories.tsx
@@ -12,7 +12,7 @@ const story = {
 export const Default = (args: ITabProps) => <TabController {...args} />;
 Default.args = {
   id: "thisIsAnId",
-  isDisabled: false,
+  disabled: false,
   label: "General Information",
   isSelected: { control: null },
 };

--- a/src/components/navigation/Tab/stories/TabController.tsx
+++ b/src/components/navigation/Tab/stories/TabController.tsx
@@ -2,17 +2,17 @@ import { useState, useEffect } from "react";
 import { Tab, ITabProps } from "../index";
 
 const TabController = (props: ITabProps) => {
-  const { isDisabled = false } = props;
+  const { disabled = false } = props;
   const [tabSelected, setTabSelected] = useState(false);
 
   useEffect(() => {
-    if (isDisabled) {
+    if (disabled) {
       setTabSelected(false);
     }
-  }, [isDisabled]);
+  }, [disabled]);
 
   const handleClickTab = () => {
-    if (!isDisabled) {
+    if (!disabled) {
       setTabSelected(true);
     }
   };

--- a/src/components/navigation/Tab/styles.ts
+++ b/src/components/navigation/Tab/styles.ts
@@ -7,14 +7,14 @@ const StyledTab = styled.li`
   width: fit-content;
   user-select: none;
   list-style-type: none;
-  border-bottom: ${({ isSelected, isDisabled }: ITabProps) =>
+  border-bottom: ${({ isSelected, disabled }: ITabProps) =>
     isSelected &&
-    !isDisabled &&
+    !disabled &&
     `4px solid ${colors.sys.actions.primary.filled}`};
 
   & > p {
-    cursor: ${({ isDisabled }: ITabProps) =>
-      isDisabled ? "not-allowed" : "pointer"};
+    cursor: ${({ disabled }: ITabProps) =>
+      disabled ? "not-allowed" : "pointer"};
   }
 `;
 

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -64,7 +64,7 @@ const Tabs = ({
             </StyledIconWrapper>
             <Tab
               key={selectedTab}
-              isDisabled={transformedIsDisabled}
+              disabled={transformedIsDisabled}
               isSelected={true}
               id={selectedTab}
               handleClick={() => handleSelectedTab(selectedTab)}
@@ -90,7 +90,7 @@ const Tabs = ({
         {tabs.map((tab) => (
           <Tab
             key={tab.id}
-            isDisabled={tab.isDisabled}
+            disabled={tab.isDisabled}
             isSelected={tab.id === selectedTab}
             id={tab.id}
             handleClick={() => handleSelectedTab(tab.id)}


### PR DESCRIPTION
The name of the props `isDisabled` is adjusted to `disabled`, allowing it to be more descriptive and without unnecessary decorations, this is in line with the standards adopted for the naming of variables within the project. 