### PR TITLE
Rename `isSelected` prop for just `selected` in `<Tab />`

### DIFF
--- a/src/components/navigation/Tab/index.tsx
+++ b/src/components/navigation/Tab/index.tsx
@@ -6,14 +6,14 @@ export interface ITabProps {
   label: string;
   id: string;
   isDisabled: boolean;
-  isSelected: boolean;
+  selected: boolean;
   handleClick: () => void;
 }
 
 const Tab = (props: ITabProps) => {
   const {
     isDisabled = false,
-    isSelected = false,
+    selected = false,
     id,
     handleClick,
     label,
@@ -23,13 +23,13 @@ const Tab = (props: ITabProps) => {
     <StyledTab
       onClick={handleClick}
       isDisabled={isDisabled}
-      isSelected={isSelected}
+      selected={selected}
       id={id}
     >
       <Text
         type="label"
         size="medium"
-        appearance={isSelected ? "primary" : "dark"}
+        appearance={selected ? "primary" : "dark"}
         disabled={isDisabled}
       >
         {label}

--- a/src/components/navigation/Tab/props.ts
+++ b/src/components/navigation/Tab/props.ts
@@ -12,7 +12,7 @@ const props = {
       defaultValue: { summary: "false" },
     },
   },
-  isSelected: {
+  selected: {
     options: [true, false],
     control: { type: "boolean" },
     description:

--- a/src/components/navigation/Tab/stories/Tab.stories.tsx
+++ b/src/components/navigation/Tab/stories/Tab.stories.tsx
@@ -14,7 +14,7 @@ Default.args = {
   id: "thisIsAnId",
   isDisabled: false,
   label: "General Information",
-  isSelected: { control: null },
+  selected: { control: null },
 };
 
 export default story;

--- a/src/components/navigation/Tab/stories/TabController.tsx
+++ b/src/components/navigation/Tab/stories/TabController.tsx
@@ -17,9 +17,7 @@ const TabController = (props: ITabProps) => {
     }
   };
 
-  return (
-    <Tab {...props} isSelected={tabSelected} handleClick={handleClickTab} />
-  );
+  return <Tab {...props} selected={tabSelected} handleClick={handleClickTab} />;
 };
 
 export { TabController };

--- a/src/components/navigation/Tab/styles.ts
+++ b/src/components/navigation/Tab/styles.ts
@@ -7,8 +7,8 @@ const StyledTab = styled.li`
   width: fit-content;
   user-select: none;
   list-style-type: none;
-  border-bottom: ${({ isSelected, isDisabled }: ITabProps) =>
-    isSelected &&
+  border-bottom: ${({ selected, isDisabled }: ITabProps) =>
+    selected &&
     !isDisabled &&
     `4px solid ${colors.sys.actions.primary.filled}`};
 

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -65,7 +65,7 @@ const Tabs = ({
             <Tab
               key={selectedTab}
               isDisabled={transformedIsDisabled}
-              isSelected={true}
+              selected={true}
               id={selectedTab}
               handleClick={() => handleSelectedTab(selectedTab)}
               label={transformedLabel}
@@ -91,7 +91,7 @@ const Tabs = ({
           <Tab
             key={tab.id}
             isDisabled={tab.isDisabled}
-            isSelected={tab.id === selectedTab}
+            selected={tab.id === selectedTab}
             id={tab.id}
             handleClick={() => handleSelectedTab(tab.id)}
             label={tab.label}


### PR DESCRIPTION
The name of the props `isSelected` is adjusted to `selected`, allowing it to be more descriptive and without unnecessary grammatical decorations, in line with the standards adopted for the naming of variables within the project. 