### PR TITLE
Rename `handleClick` prop for `onClick` in `<Tab />`

### DIFF
--- a/src/components/navigation/Tab/index.tsx
+++ b/src/components/navigation/Tab/index.tsx
@@ -7,21 +7,15 @@ export interface ITabProps {
   id: string;
   isDisabled: boolean;
   isSelected: boolean;
-  handleClick: () => void;
+  onClick: () => void;
 }
 
 const Tab = (props: ITabProps) => {
-  const {
-    isDisabled = false,
-    isSelected = false,
-    id,
-    handleClick,
-    label,
-  } = props;
+  const { isDisabled = false, isSelected = false, id, onClick, label } = props;
 
   return (
     <StyledTab
-      onClick={handleClick}
+      onClick={onClick}
       isDisabled={isDisabled}
       isSelected={isSelected}
       id={id}

--- a/src/components/navigation/Tab/props.ts
+++ b/src/components/navigation/Tab/props.ts
@@ -21,7 +21,7 @@ const props = {
       defaultValue: { summary: "false" },
     },
   },
-  handleClick: {
+  onClick: {
     options: ["logState"],
     control: { type: "func" },
     description: "shall be determine the behavior of the click event",

--- a/src/components/navigation/Tab/stories/TabController.tsx
+++ b/src/components/navigation/Tab/stories/TabController.tsx
@@ -11,13 +11,13 @@ const TabController = (props: ITabProps) => {
     }
   }, [disabled]);
 
-  const handleClickTab = () => {
+  const onClickTab = () => {
     if (!disabled) {
       setTabSelected(true);
     }
   };
 
-  return <Tab {...props} selected={tabSelected} onClick={handleClickTab} />;
+  return <Tab {...props} selected={tabSelected} onClick={onClickTab} />;
 };
 
 export { TabController };

--- a/src/components/navigation/Tab/stories/TabController.tsx
+++ b/src/components/navigation/Tab/stories/TabController.tsx
@@ -17,9 +17,7 @@ const TabController = (props: ITabProps) => {
     }
   };
 
-  return (
-    <Tab {...props} isSelected={tabSelected} handleClick={handleClickTab} />
-  );
+  return <Tab {...props} isSelected={tabSelected} onClick={handleClickTab} />;
 };
 
 export { TabController };

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -67,7 +67,7 @@ const Tabs = ({
               isDisabled={transformedIsDisabled}
               isSelected={true}
               id={selectedTab}
-              handleClick={() => handleSelectedTab(selectedTab)}
+              onClick={() => handleSelectedTab(selectedTab)}
               label={transformedLabel}
             />
           </Stack>
@@ -93,7 +93,7 @@ const Tabs = ({
             isDisabled={tab.isDisabled}
             isSelected={tab.id === selectedTab}
             id={tab.id}
-            handleClick={() => handleSelectedTab(tab.id)}
+            onClick={() => handleSelectedTab(tab.id)}
             label={tab.label}
           />
         ))}


### PR DESCRIPTION
The name of the props `handleClick` is adjusted to `onClick`, allowing it to be more descriptive and without unnecessary decorations, this is in line with the standards adopted for the naming of variables within the project.