### PR TITLE
`<Button />:` delete `cursors` object and directly control the CSS property in an arrow function

### DIFF
--- a/src/components/inputs/Button/styles.ts
+++ b/src/components/inputs/Button/styles.ts
@@ -16,12 +16,6 @@ const spacing = {
   },
 };
 
-const cursors = {
-  pointer: "pointer",
-  notAllowed: "not-allowed",
-  progress: "progress",
-};
-
 const containerStyles = css`
   display: flex;
   justify-content: center;
@@ -93,14 +87,14 @@ const StyledButton = styled.button`
 
   cursor: ${({ disabled, loading }: IButtonProps) => {
     if (disabled) {
-      return cursors.notAllowed;
+      return "not-allowed";
     }
 
     if (loading) {
-      return cursors.progress;
+      return "progress";
     }
 
-    return cursors.pointer;
+    return "pointer";
   }};
 
   &:hover {
@@ -159,14 +153,14 @@ const StyledLink = styled(Link)`
   ${StyledButton}
   cursor: ${({ disabled, loading }: IButtonProps) => {
     if (disabled) {
-      return cursors.notAllowed;
+      return "not-allowed";
     }
 
     if (loading) {
-      return cursors.progress;
+      return "progress";
     }
 
-    return cursors.pointer;
+    return "pointer";
   }};
 `;
 


### PR DESCRIPTION
In our ongoing effort to streamline and optimize our components, this PR presents a modification to the `<Button />` component. We have eliminated the `cursors` object and, in its place, are leveraging a direct arrow function to control the cursor CSS property. This change not only declutters the codebase but also ensures a more straightforward and efficient approach to cursor property management.