### PR TITLE
`<Select />:` rename `handleBlur` for `onBlur`

### DIFF
--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -25,7 +25,7 @@ export interface ISelectProps {
   options: ISelectOptions[];
   handleChange?: (event: MouseEvent) => void;
   handleFocus?: (event: FocusEvent) => void;
-  handleBlur?: (event: FocusEvent) => void;
+  onBlur?: (event: FocusEvent) => void;
   handleClick?: (event: MouseEvent) => void;
 }
 
@@ -50,7 +50,7 @@ const Select = (props: ISelectProps) => {
     size = "wide",
     fullwidth = false,
     handleFocus,
-    handleBlur,
+    onBlur,
     options,
     handleClick,
   } = props;
@@ -70,8 +70,8 @@ const Select = (props: ISelectProps) => {
   const interceptBlur = (e: FocusEvent) => {
     setIsFocused(false);
 
-    if (typeof handleBlur === "function") {
-      handleBlur(e);
+    if (typeof onBlur === "function") {
+      onBlur(e);
     }
   };
 
@@ -121,7 +121,7 @@ const Select = (props: ISelectProps) => {
       fullwidth={transformedfullwidth}
       isFocused={isFocused}
       handleFocus={interceptFocus}
-      handleBlur={interceptBlur}
+      onBlur={interceptBlur}
       options={options}
       openOptions={open}
       handleClick={handleClick}

--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -96,7 +96,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
     fullwidth,
     isFocused,
     handleFocus,
-    handleBlur,
+    onBlur,
     options,
     openOptions,
     value,
@@ -169,7 +169,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
           isFocused={isFocused}
           onChange={handleChange}
           onFocus={handleFocus}
-          onBlur={handleBlur}
+          onBlur={onBlur}
           onClick={(e: MouseEvent) => interceptorOnClick(e)}
         />
         <StyledIcon isDisabled={isDisabled}>

--- a/src/components/inputs/Select/props.ts
+++ b/src/components/inputs/Select/props.ts
@@ -78,7 +78,7 @@ const props = {
     description:
       "allows you to control what to do when the onfocus event occurs.",
   },
-  handleBlur: {
+  onBlur: {
     description:
       "allows you to control what to do when the onblur event occurs.",
   },


### PR DESCRIPTION
In our mission to keep the API for our components intuitive and in line with common naming conventions, we've made a change to the `<Select />` component. Specifically, the prop previously named `handleBlur` has been renamed to `onBlur`.