### PR TITLE
`<Select />:` rename `handleChange` prop for `onChange`

### DIFF
--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -23,7 +23,7 @@ export interface ISelectProps {
   size?: Size;
   fullwidth?: boolean;
   options: ISelectOptions[];
-  handleChange?: (event: MouseEvent) => void;
+  onChange?: (event: MouseEvent) => void;
   handleFocus?: (event: FocusEvent) => void;
   handleBlur?: (event: FocusEvent) => void;
   handleClick?: (event: MouseEvent) => void;
@@ -42,7 +42,7 @@ const Select = (props: ISelectProps) => {
     placeholder,
     isDisabled = false,
     value = "",
-    handleChange,
+    onChange,
     required = false,
     state = "pending",
     errorMessage,
@@ -112,7 +112,7 @@ const Select = (props: ISelectProps) => {
       placeholder={placeholder}
       isDisabled={transformedIsDisabled}
       value={value}
-      handleChange={handleChange}
+      onChange={onChange}
       required={transformedrequired}
       size={size}
       state={transformedState}

--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -87,7 +87,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
     id,
     placeholder,
     isDisabled,
-    handleChange,
+    onChange,
     required,
     state,
     errorMessage,
@@ -167,7 +167,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
           state={state}
           fullwidth={fullwidth}
           isFocused={isFocused}
-          onChange={handleChange}
+          onChange={onChange}
           onFocus={handleFocus}
           onBlur={handleBlur}
           onClick={(e: MouseEvent) => interceptorOnClick(e)}

--- a/src/components/inputs/Select/props.ts
+++ b/src/components/inputs/Select/props.ts
@@ -39,7 +39,7 @@ const props = {
   value: {
     description: "component initial value",
   },
-  handleChange: {
+  onChange: {
     description:
       "allows you to control what to do when the user changes the value of the component",
   },

--- a/src/components/inputs/Select/stories/SelectController.tsx
+++ b/src/components/inputs/Select/stories/SelectController.tsx
@@ -5,7 +5,7 @@ const SelectController = (props: ISelectProps) => {
   const { value = "", state = "pending" } = props;
   const [form, setForm] = useState({ value, state });
 
-  const handleChange = (e: Event) => {
+  const onChange = (e: Event) => {
     const target = e.target as HTMLInputElement;
     const { value } = target;
 
@@ -23,7 +23,7 @@ const SelectController = (props: ISelectProps) => {
       {...props}
       value={form.value}
       state={form.state}
-      handleChange={handleChange}
+      onChange={onChange}
       handleFocus={handleFocus}
     />
   );


### PR DESCRIPTION
Consistency and clarity in prop naming are crucial for a seamless developer experience. In line with this, we've made an adjustment to the `<Select />` component's prop naming. Specifically, we've renamed the `handleChange` prop to the more conventional and widely used `onChange`.