### PR TITLE
Rename `state` prop for `status` in `<Select />`

### DIFF
--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 
 import { SelectUI } from "./interface";
-import { Size, States, states } from "./props";
+import { Size, States } from "./props";
 
 export interface ISelectOptions {
   id: string;
@@ -17,7 +17,7 @@ export interface ISelectProps {
   isDisabled?: boolean;
   value?: string | number;
   required?: boolean;
-  state?: States;
+  status?: States;
   errorMessage?: string;
   validMessage?: string;
   size?: Size;
@@ -31,7 +31,7 @@ export interface ISelectProps {
 
 const defaultIsDisabled = false;
 const defaultrequired = false;
-const defaultState = "pending";
+
 const defaultfullwidth = false;
 
 const Select = (props: ISelectProps) => {
@@ -44,7 +44,7 @@ const Select = (props: ISelectProps) => {
     value = "",
     handleChange,
     required = false,
-    state = "pending",
+    status = "pending",
     errorMessage,
     validMessage,
     size = "wide",
@@ -96,8 +96,6 @@ const Select = (props: ISelectProps) => {
   const transformedIsDisabled =
     typeof isDisabled === "boolean" ? isDisabled : defaultIsDisabled;
 
-  const transformedState = states.includes(state) ? state : defaultState;
-
   const transformedrequired =
     typeof required === "boolean" ? required : defaultrequired;
 
@@ -115,7 +113,7 @@ const Select = (props: ISelectProps) => {
       handleChange={handleChange}
       required={transformedrequired}
       size={size}
-      state={transformedState}
+      status={status}
       errorMessage={errorMessage}
       validMessage={validMessage}
       fullwidth={transformedfullwidth}

--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 
 import { SelectUI } from "./interface";
-import { Size, States } from "./props";
+import { Size, Status } from "./props";
 
 export interface ISelectOptions {
   id: string;
@@ -17,7 +17,7 @@ export interface ISelectProps {
   isDisabled?: boolean;
   value?: string | number;
   required?: boolean;
-  status?: States;
+  status?: Status;
   errorMessage?: string;
   validMessage?: string;
   size?: Size;

--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -9,6 +9,9 @@ import { Label } from "@inputs/Label";
 import { Text } from "@data/Text";
 import { DropdownMenu } from "@inputs/Select/DropdownMenu";
 
+import { Size } from "./props";
+
+import { ISelectProps } from ".";
 import {
   StyledContainer,
   StyledContainerLabel,
@@ -18,12 +21,10 @@ import {
   StyledErrorMessageContainer,
   StyledValidMessageContainer,
 } from "./styles";
-import { ISelectProps } from ".";
-import { Size } from "./props";
 
 export interface ISelectStateProps {
   isDisabled: boolean;
-  state: string;
+  status: string;
   validMessage?: string;
   errorMessage?: string;
 }
@@ -42,11 +43,11 @@ const getTypo = (size: Size) => {
 };
 
 const Invalid = (props: ISelectStateProps) => {
-  const { isDisabled, state, errorMessage } = props;
+  const { isDisabled, status, errorMessage } = props;
   const transformedErrorMessage = errorMessage && `(${errorMessage})`;
 
   return (
-    <StyledErrorMessageContainer isDisabled={isDisabled} state={state}>
+    <StyledErrorMessageContainer isDisabled={isDisabled} status={status}>
       <MdOutlineError />
       <Text
         type="body"
@@ -62,10 +63,10 @@ const Invalid = (props: ISelectStateProps) => {
 };
 
 const Success = (props: ISelectStateProps) => {
-  const { isDisabled, state, validMessage } = props;
+  const { isDisabled, status, validMessage } = props;
 
   return (
-    <StyledValidMessageContainer isDisabled={isDisabled} state={state}>
+    <StyledValidMessageContainer isDisabled={isDisabled} status={status}>
       <MdCheckCircle />
       <Text
         type="body"
@@ -89,7 +90,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
     isDisabled,
     handleChange,
     required,
-    state,
+    status,
     errorMessage,
     validMessage,
     size,
@@ -120,7 +121,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
     }
   };
 
-  const transformedInvalid = state === "invalid" ? true : false;
+  const transformedInvalid = status === "invalid";
 
   return (
     <StyledContainer fullwidth={fullwidth} isDisabled={isDisabled} ref={ref}>
@@ -152,7 +153,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
       <StyledInputContainer
         isDisabled={isDisabled}
         isFocused={isFocused}
-        state={state}
+        status={status}
       >
         <StyledInput
           autoComplete="off"
@@ -164,7 +165,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
           isDisabled={isDisabled}
           required={required}
           size={size}
-          state={state}
+          status={status}
           fullwidth={fullwidth}
           isFocused={isFocused}
           onChange={handleChange}
@@ -177,17 +178,17 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
         </StyledIcon>
       </StyledInputContainer>
 
-      {state === "invalid" && (
+      {status === "invalid" && (
         <Invalid
           isDisabled={isDisabled!}
-          state={state}
+          status={status}
           errorMessage={errorMessage}
         />
       )}
-      {state === "valid" && (
+      {status === "valid" && (
         <Success
           isDisabled={isDisabled!}
-          state={state}
+          status={status}
           validMessage={validMessage}
         />
       )}

--- a/src/components/inputs/Select/props.ts
+++ b/src/components/inputs/Select/props.ts
@@ -52,7 +52,7 @@ const props = {
   status: {
     options: status,
     control: { type: "select" },
-    description: "state of the component",
+    description: "status of the component",
     table: {
       defaultValue: { summary: "pending" },
     },

--- a/src/components/inputs/Select/props.ts
+++ b/src/components/inputs/Select/props.ts
@@ -1,8 +1,8 @@
 export const sizes = ["wide", "compact"] as const;
 export type Size = typeof sizes[number];
 
-export const states = ["valid", "invalid", "pending"] as const;
-export type States = typeof states[number];
+const status = ["valid", "invalid", "pending"] as const;
+type States = typeof status[number];
 
 const props = {
   parameters: {
@@ -49,8 +49,8 @@ const props = {
       defaultValue: { summary: false },
     },
   },
-  state: {
-    options: states,
+  status: {
+    options: status,
     control: { type: "select" },
     description: "state of the component",
     table: {
@@ -88,4 +88,5 @@ const props = {
   },
 };
 
+export type { States };
 export { props };

--- a/src/components/inputs/Select/props.ts
+++ b/src/components/inputs/Select/props.ts
@@ -2,7 +2,7 @@ export const sizes = ["wide", "compact"] as const;
 export type Size = typeof sizes[number];
 
 const status = ["valid", "invalid", "pending"] as const;
-type States = typeof status[number];
+type Status = typeof status[number];
 
 const props = {
   parameters: {
@@ -88,5 +88,5 @@ const props = {
   },
 };
 
-export type { States };
+export type { Status };
 export { props };

--- a/src/components/inputs/Select/stories/Select.form.Controller.tsx
+++ b/src/components/inputs/Select/stories/Select.form.Controller.tsx
@@ -5,25 +5,25 @@ import { StyledForm } from "./styles";
 import { Button } from "../../Button";
 
 const InForm = (props: ISelectProps) => {
-  const { value = "", state = "pending", required } = props;
-  const [form, setForm] = useState({ value, state });
+  const { value = "", status = "pending", required } = props;
+  const [form, setForm] = useState({ value, status });
 
   const handleClick = (e: Event) => {
     const element = document.getElementById("select") as HTMLInputElement;
     const valueElement = element.value;
     if (valueElement === "" && required) {
-      setForm({ ...form, state: "invalid" });
+      setForm({ ...form, status: "invalid" });
       e.preventDefault();
       return;
     } else {
-      setForm({ ...form, state: "valid" });
+      setForm({ ...form, status: "valid" });
       e.preventDefault();
     }
   };
 
   const handleFocus = (e?: Event) => {
     if (!value) {
-      setForm({ ...form, state: "pending" });
+      setForm({ ...form, status: "pending" });
     }
   };
 
@@ -31,7 +31,7 @@ const InForm = (props: ISelectProps) => {
     <StyledForm>
       <Select
         {...props}
-        state={form.state}
+        status={form.status}
         id="select"
         handleFocus={(e) => handleFocus(e)}
       />

--- a/src/components/inputs/Select/stories/SelectController.tsx
+++ b/src/components/inputs/Select/stories/SelectController.tsx
@@ -2,19 +2,19 @@ import { useState } from "react";
 import { Select, ISelectProps } from "..";
 
 const SelectController = (props: ISelectProps) => {
-  const { value = "", state = "pending" } = props;
-  const [form, setForm] = useState({ value, state });
+  const { value = "", status = "pending" } = props;
+  const [form, setForm] = useState({ value, status });
 
   const handleChange = (e: Event) => {
     const target = e.target as HTMLInputElement;
     const { value } = target;
 
-    setForm({ value, state: "pending" });
+    setForm({ value, status: "pending" });
   };
 
   const handleFocus = () => {
     if (!value) {
-      setForm({ ...form, state: "pending" });
+      setForm({ ...form, status: "pending" });
     }
   };
 
@@ -22,7 +22,7 @@ const SelectController = (props: ISelectProps) => {
     <Select
       {...props}
       value={form.value}
-      state={form.state}
+      status={form.status}
       handleChange={handleChange}
       handleFocus={handleFocus}
     />

--- a/src/components/inputs/Select/styles.ts
+++ b/src/components/inputs/Select/styles.ts
@@ -13,12 +13,12 @@ const sizeOptions = {
   },
 };
 
-const getColors = (isDisabled: boolean, state: string, isFocused: boolean) => {
+const getColors = (isDisabled: boolean, status: string, isFocused: boolean) => {
   if (isDisabled) {
     return colors.ref.palette.neutral.n70;
   }
 
-  if (state === "invalid") {
+  if (status === "invalid") {
     return colors.sys.actions.remove.filled;
   }
 
@@ -28,16 +28,16 @@ const getColors = (isDisabled: boolean, state: string, isFocused: boolean) => {
   return colors.ref.palette.neutral.n40;
 };
 
-const getIsDisabled = (isDisabled: boolean, state: string) => {
+const getIsDisabled = (isDisabled: boolean, status: string) => {
   if (isDisabled) {
     return colors.ref.palette.neutral.n70;
   }
 
-  if (state === "valid") {
+  if (status === "valid") {
     return colors.sys.actions.confirm.filled;
   }
 
-  if (state === "invalid") {
+  if (status === "invalid") {
     return colors.sys.actions.remove.filled;
   }
 };
@@ -71,8 +71,8 @@ const StyledInputContainer = styled.div`
   background: ${colors.ref.palette.neutral.n10};
   grid-template-columns: 1fr auto;
   border: 1px solid
-    ${({ isDisabled, state, isFocused }: ISelectInterfaceProps) =>
-      getColors(isDisabled!, state!, isFocused!)};
+    ${({ isDisabled, status, isFocused }: ISelectInterfaceProps) =>
+      getColors(isDisabled!, status!, isFocused!)};
   ${({ isDisabled }: ISelectInterfaceProps) =>
     isDisabled && "pointer-events: none; opacity: 0.5;"}
   cursor: ${({ isDisabled }: ISelectInterfaceProps) =>
@@ -138,8 +138,8 @@ const StyledErrorMessageContainer = styled.div`
   align-items: center;
   margin-left: 12px;
   pointer-events: none;
-  color: ${({ isDisabled, state }: ISelectInterfaceProps) =>
-    getIsDisabled(isDisabled!, state!)};
+  color: ${({ isDisabled, status }: ISelectInterfaceProps) =>
+    getIsDisabled(isDisabled!, status!)};
 
   & svg {
     width: 14px;
@@ -150,8 +150,8 @@ const StyledErrorMessageContainer = styled.div`
 `;
 
 const StyledValidMessageContainer = styled(StyledErrorMessageContainer)`
-  color: ${({ isDisabled, state }: ISelectInterfaceProps) =>
-    getIsDisabled(isDisabled!, state!)}; ;
+  color: ${({ isDisabled, status }: ISelectInterfaceProps) =>
+    getIsDisabled(isDisabled!, status!)}; ;
 `;
 
 export {


### PR DESCRIPTION
 While refining the `<Select />` component's prop names, we noticed a redundancy in the naming convention for the `state` prop. With this PR, we are confirming the consistent usage of the `status` prop name throughout the component.