### PR TITLE
`<Select />:` rename `handleFocus` prop for `onFocus`

### DIFF
--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -24,7 +24,7 @@ export interface ISelectProps {
   fullwidth?: boolean;
   options: ISelectOptions[];
   handleChange?: (event: MouseEvent) => void;
-  handleFocus?: (event: FocusEvent) => void;
+  onFocus?: (event: FocusEvent) => void;
   handleBlur?: (event: FocusEvent) => void;
   handleClick?: (event: MouseEvent) => void;
 }
@@ -49,7 +49,7 @@ const Select = (props: ISelectProps) => {
     validMessage,
     size = "wide",
     fullwidth = false,
-    handleFocus,
+    onFocus,
     handleBlur,
     options,
     handleClick,
@@ -62,8 +62,8 @@ const Select = (props: ISelectProps) => {
   const interceptFocus = (e: FocusEvent) => {
     setIsFocused(true);
 
-    if (typeof handleFocus === "function") {
-      handleFocus(e);
+    if (typeof onFocus === "function") {
+      onFocus(e);
     }
   };
 
@@ -120,7 +120,7 @@ const Select = (props: ISelectProps) => {
       validMessage={validMessage}
       fullwidth={transformedfullwidth}
       isFocused={isFocused}
-      handleFocus={interceptFocus}
+      onFocus={interceptFocus}
       handleBlur={interceptBlur}
       options={options}
       openOptions={open}

--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -95,7 +95,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
     size,
     fullwidth,
     isFocused,
-    handleFocus,
+    onFocus,
     handleBlur,
     options,
     openOptions,
@@ -168,7 +168,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
           fullwidth={fullwidth}
           isFocused={isFocused}
           onChange={handleChange}
-          onFocus={handleFocus}
+          onFocus={onFocus}
           onBlur={handleBlur}
           onClick={(e: MouseEvent) => interceptorOnClick(e)}
         />

--- a/src/components/inputs/Select/props.ts
+++ b/src/components/inputs/Select/props.ts
@@ -74,7 +74,7 @@ const props = {
       defaultValue: { summary: false },
     },
   },
-  handleFocus: {
+  onFocus: {
     description:
       "allows you to control what to do when the onfocus event occurs.",
   },

--- a/src/components/inputs/Select/stories/Select.form.Controller.tsx
+++ b/src/components/inputs/Select/stories/Select.form.Controller.tsx
@@ -21,7 +21,7 @@ const InForm = (props: ISelectProps) => {
     }
   };
 
-  const handleFocus = (e?: Event) => {
+  const onFocus = (e?: Event) => {
     if (!value) {
       setForm({ ...form, state: "pending" });
     }
@@ -33,7 +33,7 @@ const InForm = (props: ISelectProps) => {
         {...props}
         state={form.state}
         id="select"
-        handleFocus={(e) => handleFocus(e)}
+        onFocus={(e) => onFocus(e)}
       />
       <Button
         type="submit"

--- a/src/components/inputs/Select/stories/SelectController.tsx
+++ b/src/components/inputs/Select/stories/SelectController.tsx
@@ -12,7 +12,7 @@ const SelectController = (props: ISelectProps) => {
     setForm({ value, state: "pending" });
   };
 
-  const handleFocus = () => {
+  const onFocus = () => {
     if (!value) {
       setForm({ ...form, state: "pending" });
     }
@@ -24,7 +24,7 @@ const SelectController = (props: ISelectProps) => {
       value={form.value}
       state={form.state}
       handleChange={handleChange}
-      handleFocus={handleFocus}
+      onFocus={onFocus}
     />
   );
 };


### PR DESCRIPTION
Maintaining clear and consistent prop naming conventions ensures an intuitive developer experience. Continuing with this ethos, we've updated the naming of a prop within the `<Select />` component. The `handleFocus` prop has been renamed to the more conventional `onFocus`