### PR TITLE
Rename `handleClick` for `onClick` props in `<Select />`

### DIFF
--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -26,7 +26,7 @@ export interface ISelectProps {
   onChange?: (event: MouseEvent) => void;
   onFocus?: (event: FocusEvent) => void;
   onBlur?: (event: FocusEvent) => void;
-  handleClick?: (event: MouseEvent) => void;
+  onClick?: (event: MouseEvent) => void;
 }
 
 const defaultIsDisabled = false;
@@ -52,7 +52,7 @@ const Select = (props: ISelectProps) => {
     onFocus,
     onBlur,
     options,
-    handleClick,
+    onClick,
   } = props;
 
   const [isFocused, setIsFocused] = useState(false);
@@ -124,7 +124,7 @@ const Select = (props: ISelectProps) => {
       onBlur={interceptBlur}
       options={options}
       openOptions={open}
-      handleClick={handleClick}
+      onClick={onClick}
       onCloseOptions={handleCloseOptions}
       ref={selectRef}
     />

--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -100,7 +100,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
     options,
     openOptions,
     value,
-    handleClick,
+    onClick,
     onCloseOptions,
   } = props;
 
@@ -112,8 +112,8 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
   };
 
   const interceptorOnClick = (e: MouseEvent) => {
-    if (typeof handleClick === "function") {
-      handleClick(e);
+    if (typeof onClick === "function") {
+      onClick(e);
     }
     if (typeof onCloseOptions === "function") {
       onCloseOptions();

--- a/src/components/inputs/Select/props.ts
+++ b/src/components/inputs/Select/props.ts
@@ -4,18 +4,19 @@ export type Size = typeof sizes[number];
 export const states = ["valid", "invalid", "pending"] as const;
 export type States = typeof states[number];
 
-const props = {
-  parameters: {
-    docs: {
-      description: {
-        component:
-          "Select allows users to make a single selection or multiple selections from a list of options.",
-      },
-    },
-    controls: {
-      exclude: ["value", "state"],
+const parameters = {
+  docs: {
+    description: {
+      component:
+        "Select allows users to make a single selection or multiple selections from a list of options.",
     },
   },
+  controls: {
+    exclude: ["value", "state"],
+  },
+};
+
+const props = {
   label: {
     description: "prompts the user what value to enter",
   },
@@ -88,4 +89,4 @@ const props = {
   },
 };
 
-export { props };
+export { props, parameters };

--- a/src/components/inputs/Select/stories/Select.form.Controller.tsx
+++ b/src/components/inputs/Select/stories/Select.form.Controller.tsx
@@ -8,7 +8,7 @@ const InForm = (props: ISelectProps) => {
   const { value = "", state = "pending", required } = props;
   const [form, setForm] = useState({ value, state });
 
-  const handleClick = (e: Event) => {
+  const onClick = (e: Event) => {
     const element = document.getElementById("select") as HTMLInputElement;
     const valueElement = element.value;
     if (valueElement === "" && required) {
@@ -35,11 +35,7 @@ const InForm = (props: ISelectProps) => {
         id="select"
         onFocus={(e) => onFocus(e)}
       />
-      <Button
-        type="submit"
-        spacing="compact"
-        handleClick={(e) => handleClick(e!)}
-      >
+      <Button type="submit" spacing="compact" handleClick={(e) => onClick(e!)}>
         Submit
       </Button>
     </StyledForm>

--- a/src/components/inputs/Select/stories/Select.inForm.stories.tsx
+++ b/src/components/inputs/Select/stories/Select.inForm.stories.tsx
@@ -1,11 +1,12 @@
 import { Select, ISelectProps } from "..";
 import { InForm } from "./Select.form.Controller";
 
-import { props } from "../props";
+import { props, parameters } from "../props";
 
 const story = {
   title: "Inputs/Select",
   component: [Select],
+  parameters,
   argTypes: props,
 };
 

--- a/src/components/inputs/Select/stories/Select.stories.tsx
+++ b/src/components/inputs/Select/stories/Select.stories.tsx
@@ -1,10 +1,11 @@
 import { Select, ISelectProps } from "..";
 import { SelectController } from "./SelectController";
-import { props } from "../props";
+import { props, parameters } from "../props";
 
 const story = {
   title: "Inputs/Select",
   component: [Select],
+  parameters,
   argTypes: props,
 };
 


### PR DESCRIPTION
While refining the <Select /> component's prop names, we noticed a redundancy in the naming convention for the `handleClick` prop. With this PR, we are confirming the consistent usage of the `onClick` prop name throughout the component.