### PR TITLE
Rename const `handleCloseOptions` for `toggleOptionsMenu` in `<Select />` 

### DIFF
--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -75,7 +75,7 @@ const Select = (props: ISelectProps) => {
     }
   };
 
-  const handleCloseOptions = () => {
+  const toggleOptionsMenu = () => {
     setOpen(!open);
   };
 
@@ -125,7 +125,7 @@ const Select = (props: ISelectProps) => {
       options={options}
       openOptions={open}
       handleClick={handleClick}
-      onCloseOptions={handleCloseOptions}
+      onCloseOptions={toggleOptionsMenu}
       ref={selectRef}
     />
   );


### PR DESCRIPTION
rename the `handleCloseOptions` constant to `toggleOptionsMenu`, allowing it to better match the functionality of the handle, which corresponds to changing the state of the options to be displayed.