### PR TITLE
`<Tabs />:` refactor to use new color tokens

### DIFF
--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { MdKeyboardArrowDown } from "react-icons/md";
 
-import { Types, types } from "./props";
+import { Themed, Types, types } from "./props";
 import { Tab } from "@navigation/Tab";
 import { Stack } from "@layouts/Stack";
 import { DropdownMenu } from "@inputs/Select/DropdownMenu";
@@ -13,7 +13,7 @@ export interface ITabsItem {
   disabled: boolean;
 }
 
-export interface ITabsProps {
+export interface ITabsProps extends Themed {
   tabs: ITabsItem[];
   type?: Types;
   handleSelectedTab: (id: string) => void;

--- a/src/components/navigation/Tabs/props.ts
+++ b/src/components/navigation/Tabs/props.ts
@@ -1,5 +1,8 @@
+import { inube } from "@shared/tokens";
+
 export const types = ["select", "tabs"] as const;
 export type Types = typeof types[number];
+export type Themed = { theme?: typeof inube };
 
 const parameters = {
   docs: {

--- a/src/components/navigation/Tabs/styles.ts
+++ b/src/components/navigation/Tabs/styles.ts
@@ -1,13 +1,16 @@
 import styled from "styled-components";
-import { colors } from "@shared/colors/colors";
 import { ITabsProps } from ".";
+import { inube } from "@shared/tokens";
 
 const StyledTabs = styled.div`
   box-sizing: border-box;
   overflow-x: auto;
   white-space: nowrap;
   width: 100%;
-  border-bottom: 2px solid ${colors.ref.palette.neutral.n40};
+  border-bottom: 2px solid
+    ${({ theme }: ITabsProps) =>
+      theme?.color?.stroke?.divider?.regular ||
+      inube.color.stroke.divider.regular};
   padding: 0px 16px;
 
   & > div {
@@ -35,7 +38,8 @@ const StyledIconWrapper = styled.div`
   & > svg {
     width: 24px;
     height: 24px;
-    color: ${colors.sys.text.dark};
+    color: ${({ theme }: ITabsProps) =>
+      theme?.color?.text?.dark?.regular || inube.color.text.dark.regular};
     cursor: pointer;
   }
 `;


### PR DESCRIPTION
To ensure that our `<Tabs />` component aligns with our updated design system, we have refactored its styles to make use of the latest color tokens.