### PR TITLE
Not validate intercept function types in `<Select />`

### DIFF
--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -54,20 +54,16 @@ const Select = (props: ISelectProps) => {
   const [open, setOpen] = useState(false);
   const selectRef = useRef<{ contains: (e: EventTarget) => EventTarget }>(null);
 
-  const interceptFocus = (e: FocusEvent) => {
+  const handleFocus = (e: FocusEvent) => {
     setIsFocused(true);
 
-    if (typeof onFocus === "function") {
-      onFocus(e);
-    }
+    onFocus && onFocus(e);
   };
 
-  const interceptBlur = (e: FocusEvent) => {
+  const handleBlur = (e: FocusEvent) => {
     setIsFocused(false);
 
-    if (typeof onBlur === "function") {
-      onBlur(e);
-    }
+    onBlur && onBlur(e);
   };
 
   const toggleOptionsMenu = () => {
@@ -104,8 +100,8 @@ const Select = (props: ISelectProps) => {
       validMessage={validMessage}
       fullwidth={fullwidth}
       isFocused={isFocused}
-      onFocus={interceptFocus}
-      onBlur={interceptBlur}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
       options={options}
       openOptions={open}
       onClick={onClick}

--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -111,13 +111,10 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
     setSelectedOption(option?.label);
   };
 
-  const interceptorOnClick = (e: MouseEvent) => {
-    if (typeof onClick === "function") {
-      onClick(e);
-    }
-    if (typeof onCloseOptions === "function") {
-      onCloseOptions();
-    }
+  const handleClick = (e: MouseEvent) => {
+    onClick && onClick(e);
+
+    onCloseOptions();
   };
 
   return (
@@ -168,7 +165,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
           onChange={onChange}
           onFocus={onFocus}
           onBlur={onBlur}
-          onClick={(e: MouseEvent) => interceptorOnClick(e)}
+          onClick={(e: MouseEvent) => handleClick(e)}
         />
         <StyledIcon disabled={disabled}>
           <MdOutlineArrowDropDown onClick={onCloseOptions} />


### PR DESCRIPTION
With the implementation of TS, which provides us with typing, it is no longer necessary to validate `onFocus` and `onBlur` types as functions at runtime. within interceptor functions. 