### PR TITLE
Create the `type` to implement inside the generated `interface` for the `styled-components`

### DIFF
--- a/src/shared/Types/Types.ts
+++ b/src/shared/Types/Types.ts
@@ -1,0 +1,5 @@
+import { inube } from "../tokens";
+
+type Themed = typeof inube;
+
+export type { Themed };


### PR DESCRIPTION
In the `shared/Types/Types.ts` directory, the type Theme must be declared, in order to be used inside the interfaces for the styled-components components.