### PR TITLE
`<Select />:` an interface component should be `stateless`

### DIFF
--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -82,6 +82,19 @@ const Select = (props: ISelectProps) => {
     };
   }, [selectRef]);
 
+  const [selectedOption, setSelectedOption] = useState(value);
+
+  const handleOptionClick = (idOption: string) => {
+    const option = options.find((option) => option.id === idOption);
+    setSelectedOption(option!.label);
+  };
+
+  const handleClick = (e: MouseEvent) => {
+    onClick && onClick(e);
+
+    toggleOptionsMenu();
+  };
+
   return (
     <SelectUI
       label={label}
@@ -89,7 +102,7 @@ const Select = (props: ISelectProps) => {
       id={id}
       placeholder={placeholder}
       disabled={disabled}
-      value={value}
+      value={selectedOption || value}
       onChange={onChange}
       required={required}
       size={size}
@@ -101,7 +114,9 @@ const Select = (props: ISelectProps) => {
       onBlur={handleBlur}
       options={options}
       openOptions={open}
-      onClick={onClick}
+      onClick={handleClick}
+      selectedOption={selectedOption}
+      onOptionClick={handleOptionClick}
       onCloseOptions={toggleOptionsMenu}
       ref={selectRef}
     />

--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -1,4 +1,4 @@
-import { useState, forwardRef } from "react";
+import { forwardRef } from "react";
 import {
   MdOutlineError,
   MdCheckCircle,
@@ -32,6 +32,8 @@ export interface ISelectInterfaceProps extends ISelectProps {
   isFocused?: boolean;
   openOptions: boolean;
   onCloseOptions: () => void;
+  onOptionClick: (idOption: string) => void;
+  selectedOption?: string | number;
 }
 
 const getTypo = (size: Size) => {
@@ -67,6 +69,7 @@ const Message = (
     )
   );
 };
+
 const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
   const {
     label,
@@ -87,21 +90,9 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
     openOptions,
     value,
     onClick,
+    onOptionClick,
     onCloseOptions,
   } = props;
-
-  const [selectedOption, setSelectedOption] = useState(value);
-
-  const handleOptionClick = (idOption: string) => {
-    const option = options.find((option) => option.id === idOption);
-    setSelectedOption(option?.label);
-  };
-
-  const handleClick = (e: MouseEvent) => {
-    onClick && onClick(e);
-
-    onCloseOptions();
-  };
 
   return (
     <StyledContainer fullwidth={fullwidth} disabled={disabled} ref={ref}>
@@ -138,7 +129,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
         <StyledInput
           autoComplete="off"
           readOnly={true}
-          value={selectedOption || value}
+          value={value}
           name={name}
           id={id}
           placeholder={placeholder}
@@ -151,7 +142,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
           onChange={onChange}
           onFocus={onFocus}
           onBlur={onBlur}
-          onClick={(e: MouseEvent) => handleClick(e)}
+          onClick={onClick}
         />
         <StyledIcon disabled={disabled}>
           <MdOutlineArrowDropDown onClick={onCloseOptions} />
@@ -165,7 +156,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
         <DropdownMenu
           options={options}
           isOpenOptions={openOptions}
-          onClick={handleOptionClick}
+          onClick={onOptionClick}
           onCloseOptions={onCloseOptions}
         />
       )}


### PR DESCRIPTION
In the continuous journey of optimizing our codebase and adhering to best practices, we have undertaken the effort to separate the logic layer from the presentational layer in our components. This segregation not only clarifies the component's responsibility but also eases its maintenance, readability, and scalability.