### PR TITLE
`<OptionItem />:` refactor stories

### DIFF
--- a/src/components/inputs/Select/OptionItem/OptionItem.stories.tsx
+++ b/src/components/inputs/Select/OptionItem/OptionItem.stories.tsx
@@ -3,7 +3,7 @@ import { OptionItem, IOptionItemProps } from "./index";
 import { props } from "./props";
 
 const story = {
-  title: "Inputs/OptionItem",
+  title: "Inputs/Select/OptionItem",
   component: [OptionItem],
   argTypes: props,
 };
@@ -12,7 +12,7 @@ const Default = (args: IOptionItemProps) => <OptionItem {...args} />;
 
 Default.args = {
   children: "Item 1",
-  selected: false,
+  selectedId: undefined,
   disabled: false,
 };
 

--- a/src/components/inputs/Select/OptionItem/props.ts
+++ b/src/components/inputs/Select/OptionItem/props.ts
@@ -22,7 +22,7 @@ const props = {
     description:
       "(function): shall be determine the behavior of the click event and is not required.",
   },
-  selected: {
+  selectedId: {
     description:
       "It is designed to ascertain whether the tab has been clicked or not (by Default is false) and is not required.",
     table: {


### PR DESCRIPTION
In an effort to improve the organization and discoverability of our storybook components, we've adjusted the story structure for the `<OptionItem />` component. This change places the component under the `Inputs/Select` category, clearly linking it with the larger `<Select />` component.