### PR TITLE
`<Button />:` rename `handleClick` prop for `onClick`

### DIFF
--- a/src/components/inputs/Button/Button.stories.tsx
+++ b/src/components/inputs/Button/Button.stories.tsx
@@ -32,7 +32,7 @@ Default.args = {
   spacing: "wide",
   variant: "filled",
   fullwidth: false,
-  handleClick: () => console.log("clicked from Default-story"),
+  onClick: () => console.log("clicked from Default-story"),
 };
 
 const theme = {

--- a/src/components/inputs/Button/index.tsx
+++ b/src/components/inputs/Button/index.tsx
@@ -25,7 +25,7 @@ export interface IButtonProps {
   spacing?: Spacing;
   variant?: Variant;
   fullwidth?: boolean;
-  handleClick?: (e?: Event) => void;
+  onClick?: (e?: Event) => void;
   path?: string;
 }
 
@@ -49,7 +49,7 @@ const ButtonStructure = (props: IButtonStructureProps) => {
     spacing,
     variant,
     fullwidth,
-    handleClick,
+    onClick,
     hover,
     onMouseEnter,
     onMouseLeave,
@@ -67,7 +67,7 @@ const ButtonStructure = (props: IButtonStructureProps) => {
       spacing={spacing}
       variant={variant}
       fullwidth={fullwidth}
-      onClick={disabled ? null : handleClick}
+      onClick={disabled ? null : onClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
@@ -127,7 +127,7 @@ const Button = (props: IButtonProps) => {
     spacing = "wide",
     variant = "filled",
     fullwidth = false,
-    handleClick,
+    onClick,
     path,
   } = props;
 
@@ -163,7 +163,7 @@ const Button = (props: IButtonProps) => {
           spacing={spacing}
           variant={variant}
           fullwidth={fullwidth}
-          handleClick={handleClick}
+          onClick={onClick}
           hover={hover}
           onMouseEnter={() => toggleHover(true)}
           onMouseLeave={() => toggleHover(false)}
@@ -184,7 +184,7 @@ const Button = (props: IButtonProps) => {
       spacing={spacing}
       variant={variant}
       fullwidth={fullwidth}
-      handleClick={handleClick}
+      onClick={onClick}
       hover={hover}
       onMouseEnter={() => toggleHover(true)}
       onMouseLeave={() => toggleHover(false)}

--- a/src/components/inputs/Button/props.ts
+++ b/src/components/inputs/Button/props.ts
@@ -117,7 +117,7 @@ const props = {
       defaultValue: { summary: false },
     },
   },
-  handleClick: {
+  onClick: {
     options: ["logState"],
     control: { type: "func" },
     description: "function to control button click",

--- a/src/components/inputs/Label/styles.ts
+++ b/src/components/inputs/Label/styles.ts
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 import { inube } from "@shared/tokens";
 import { ILabelProps } from ".";
-import { Themed } from "@shared/Types/Types";
+import { Themed } from "@shared/types/types";
 
 interface IStyledLabelProps extends ILabelProps {
   theme?: Themed;

--- a/src/components/inputs/Select/stories/Select.form.Controller.tsx
+++ b/src/components/inputs/Select/stories/Select.form.Controller.tsx
@@ -40,7 +40,7 @@ const InForm = (props: ISelectProps) => {
         id="select"
         onFocus={(e) => onFocus(e)}
       />
-      <Button type="submit" spacing="compact" handleClick={(e) => onClick(e!)}>
+      <Button type="submit" spacing="compact" onClick={(e) => onClick(e!)}>
         Submit
       </Button>
     </StyledForm>

--- a/src/components/utils/Blanket/stories/Blanket.stories.tsx
+++ b/src/components/utils/Blanket/stories/Blanket.stories.tsx
@@ -32,7 +32,7 @@ const Default = (args: IBlanketProps) => {
 
   return (
     <>
-      <Button handleClick={handleShowBlanket}>Show Blanket</Button>
+      <Button onClick={handleShowBlanket}>Show Blanket</Button>
       {showBlanket && (
         <Blanket {...args}>
           <StyledBackdropBlanket onClick={() => setShowBlanket(false)} />


### PR DESCRIPTION
To ensure our prop naming is consistent and intuitive, we've updated the `<Button />` component's `handleClick` prop to `onClick`. This change aligns with common naming conventions used across other components and provides a more familiar API for developers integrating the `<Button />` component.