### PR TITLE
`<Button />:` remove the hover state

### DIFF
--- a/src/components/inputs/Button/index.tsx
+++ b/src/components/inputs/Button/index.tsx
@@ -30,13 +30,11 @@ export interface IButtonProps {
 }
 
 export interface IButtonStructureProps extends IButtonProps, Themed {
-  hover?: boolean;
-  onMouseEnter: () => void;
-  onMouseLeave: () => void;
   appearanceChildren: Appearance;
 }
 
 const darkWhenFilled: ButtonAppearanceType[] = ["warning", "gray", "light"];
+
 const ButtonStructure = (props: IButtonStructureProps) => {
   const {
     children,
@@ -50,9 +48,6 @@ const ButtonStructure = (props: IButtonStructureProps) => {
     variant,
     fullwidth,
     handleClick,
-    hover,
-    onMouseEnter,
-    onMouseLeave,
     appearanceChildren,
   } = props;
 
@@ -68,8 +63,6 @@ const ButtonStructure = (props: IButtonStructureProps) => {
       variant={variant}
       fullwidth={fullwidth}
       onClick={disabled ? null : handleClick}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
     >
       {loading && !disabled ? (
         <Spinner
@@ -78,7 +71,11 @@ const ButtonStructure = (props: IButtonStructureProps) => {
           size="small"
         />
       ) : (
-        <StyledSpan disabled={disabled} variant={variant}>
+        <StyledSpan
+          appearance={appearance}
+          disabled={disabled}
+          variant={variant}
+        >
           {iconBefore && (
             <Icon
               icon={iconBefore}
@@ -86,7 +83,6 @@ const ButtonStructure = (props: IButtonStructureProps) => {
               size="18px"
               appearance={appearanceChildren}
               disabled={disabled}
-              parentHover={hover}
             />
           )}
           <Text
@@ -94,7 +90,6 @@ const ButtonStructure = (props: IButtonStructureProps) => {
             size="large"
             appearance={appearanceChildren}
             disabled={disabled}
-            parentHover={hover}
             ellipsis={true}
           >
             {children}
@@ -106,7 +101,6 @@ const ButtonStructure = (props: IButtonStructureProps) => {
               size="18px"
               appearance={appearanceChildren}
               disabled={disabled}
-              parentHover={hover}
             />
           )}
         </StyledSpan>
@@ -131,12 +125,6 @@ const Button = (props: IButtonProps) => {
     path,
   } = props;
 
-  const [hover, setHover] = useState(false);
-  function toggleHover(newState: boolean): void {
-    if (variant !== "filled") {
-      setHover(newState);
-    }
-  }
   function appearanceChildrens() {
     if (variant === "filled") {
       if (darkWhenFilled.includes(appearance)) {
@@ -164,9 +152,6 @@ const Button = (props: IButtonProps) => {
           variant={variant}
           fullwidth={fullwidth}
           handleClick={handleClick}
-          hover={hover}
-          onMouseEnter={() => toggleHover(true)}
-          onMouseLeave={() => toggleHover(false)}
           appearanceChildren={appearanceChildrens()}
         >
           {children}
@@ -174,6 +159,7 @@ const Button = (props: IButtonProps) => {
       </StyledLink>
     );
   }
+
   return (
     <ButtonStructure
       appearance={appearance}
@@ -185,9 +171,6 @@ const Button = (props: IButtonProps) => {
       variant={variant}
       fullwidth={fullwidth}
       handleClick={handleClick}
-      hover={hover}
-      onMouseEnter={() => toggleHover(true)}
-      onMouseLeave={() => toggleHover(false)}
       appearanceChildren={appearanceChildrens()}
     >
       {children}

--- a/src/components/inputs/Button/styles.ts
+++ b/src/components/inputs/Button/styles.ts
@@ -145,6 +145,26 @@ const StyledSpan = styled.span`
   justify-content: space-between;
   gap: 4px;
   overflow: hidden;
+  &:hover * {
+    color: ${({
+      theme,
+      appearance,
+      variant,
+      disabled,
+    }: IButtonStructureProps) => {
+      if (!disabled) {
+        if (variant === "filled") {
+          return (
+            theme?.color?.stroke?.light?.hover || inube.color.stroke.light.hover
+          );
+        }
+        return (
+          theme?.color?.stroke?.[appearance!]?.hover ||
+          inube.color.stroke[appearance!].hover
+        );
+      }
+    }};
+  }
 `;
 
 export { StyledButton, StyledSpan, StyledLink };


### PR DESCRIPTION
As part of our recent design updates, we have decided to remove the hover state from the `<Button />` component. This change aims to simplify interactions and provide a consistent experience across different user agents and devices.