### PR TITLE
`<Button />:` remove unnecessary typography css properties

### DIFF
--- a/src/components/inputs/Button/styles.ts
+++ b/src/components/inputs/Button/styles.ts
@@ -1,7 +1,6 @@
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 
-import { typography } from "@shared/typography/typography";
 import { IButtonStructureProps } from ".";
 import { inube } from "@shared/tokens";
 import { Themed } from "@src/shared/types/types";
@@ -29,11 +28,6 @@ const StyledButton = styled.button`
   border-radius: 8px;
   border: none;
   border-width: 1px;
-  font-family: ${typography.ref.typeface.brand};
-  font-size: ${typography.sys.typescale.labelLarge.size};
-  font-weight: ${typography.sys.typescale.labelLarge.weight};
-  line-height: ${typography.sys.typescale.labelLarge.lineHeight};
-  letter-spacing: ${typography.sys.typescale.labelLarge.tracking};
   width: ${({ fullwidth }: IStyledButtonStructureProps) => {
     if (fullwidth) {
       return "100%";


### PR DESCRIPTION
In an effort to maintain clean and DRY code, we've identified that the `<Button />` component has redundant typography CSS properties. Since we're utilizing the `<Text />` component within the button, there's no need to redefine those styles.