### PR TITLE
`<Button />:` add `cursorHover` and `parentHover` props

### DIFF
--- a/src/components/inputs/Button/Button.stories.tsx
+++ b/src/components/inputs/Button/Button.stories.tsx
@@ -33,6 +33,8 @@ Default.args = {
   variant: "filled",
   fullwidth: false,
   onClick: () => console.log("clicked from Default-story"),
+  cursorHover: false,
+  parentHover: false,
 };
 
 const theme = {

--- a/src/components/inputs/Button/index.tsx
+++ b/src/components/inputs/Button/index.tsx
@@ -25,6 +25,8 @@ export interface IButtonProps {
   fullwidth?: boolean;
   onClick?: (e?: Event) => void;
   path?: string;
+  cursorHover?: boolean;
+  parentHover?: boolean;
 }
 
 export interface IButtonStructureProps extends IButtonProps {
@@ -47,6 +49,8 @@ const ButtonStructure = (props: IButtonStructureProps) => {
     fullwidth,
     onClick,
     appearanceChildren,
+    cursorHover,
+    parentHover,
   } = props;
 
   return (
@@ -61,6 +65,8 @@ const ButtonStructure = (props: IButtonStructureProps) => {
       variant={variant}
       fullwidth={fullwidth}
       onClick={disabled ? null : onClick}
+      cursorHover={cursorHover}
+      parentHover={parentHover}
     >
       {loading && !disabled ? (
         <Spinner
@@ -73,6 +79,8 @@ const ButtonStructure = (props: IButtonStructureProps) => {
           appearance={appearance}
           disabled={disabled}
           variant={variant}
+          cursorHover={cursorHover}
+          parentHover={parentHover}
         >
           {iconBefore && (
             <Icon
@@ -121,6 +129,8 @@ const Button = (props: IButtonProps) => {
     fullwidth = false,
     onClick,
     path,
+    cursorHover,
+    parentHover,
   } = props;
 
   function appearanceChildrens() {
@@ -151,6 +161,8 @@ const Button = (props: IButtonProps) => {
           fullwidth={fullwidth}
           onClick={onClick}
           appearanceChildren={appearanceChildrens()}
+          cursorHover={cursorHover}
+          parentHover={parentHover}
         >
           {children}
         </ButtonStructure>
@@ -170,6 +182,8 @@ const Button = (props: IButtonProps) => {
       fullwidth={fullwidth}
       onClick={onClick}
       appearanceChildren={appearanceChildrens()}
+      cursorHover={cursorHover}
+      parentHover={parentHover}
     >
       {children}
     </ButtonStructure>

--- a/src/components/inputs/Button/props.ts
+++ b/src/components/inputs/Button/props.ts
@@ -124,6 +124,22 @@ const props = {
     description:
       "Is the path where the button is going to navigate when is used as button for navigation",
   },
+  cursorHover: {
+    options: [false, true],
+    control: { type: "boolean" },
+    description: "whether the button changes upon cursor hover",
+    table: {
+      defaultValue: { summary: false },
+    },
+  },
+  parentHover: {
+    options: [false, true],
+    control: { type: "boolean" },
+    description: "whether the button changes upon its parent hover",
+    table: {
+      defaultValue: { summary: false },
+    },
+  },
 };
 
 export { props };

--- a/src/components/inputs/Button/styles.ts
+++ b/src/components/inputs/Button/styles.ts
@@ -44,6 +44,7 @@ const StyledButton = styled.button`
     appearance,
     variant,
     disabled,
+    parentHover,
   }: IStyledButtonStructureProps) => {
     if (variant === "filled") {
       if (disabled) {
@@ -52,6 +53,11 @@ const StyledButton = styled.button`
           inube.color.surface[appearance!].disabled
         );
       }
+      if (parentHover)
+        return (
+          theme?.color?.surface?.[appearance!]?.hover ||
+          inube.color.surface[appearance!].hover
+        );
       return (
         theme?.color?.surface?.[appearance!]?.regular ||
         inube.color.surface[appearance!].regular
@@ -66,6 +72,7 @@ const StyledButton = styled.button`
     appearance,
     variant,
     disabled,
+    parentHover,
   }: IStyledButtonStructureProps) => {
     if (disabled) {
       return (
@@ -73,6 +80,11 @@ const StyledButton = styled.button`
         inube.color.stroke[appearance!].disabled
       );
     }
+    if (parentHover && variant !== "none")
+      return (
+        theme?.color?.stroke?.[appearance!]?.hover ||
+        inube.color.stroke[appearance!].hover
+      );
     if (variant === "none") {
       return "transparent";
     }
@@ -83,13 +95,22 @@ const StyledButton = styled.button`
     );
   }};
 
-  cursor: ${({ disabled, loading }: IStyledButtonStructureProps) => {
+  cursor: ${({
+    disabled,
+    loading,
+    cursorHover,
+    variant,
+  }: IStyledButtonStructureProps) => {
     if (disabled) {
       return "not-allowed";
     }
 
     if (loading) {
       return "progress";
+    }
+
+    if (!cursorHover || variant === "filled") {
+      return "default";
     }
 
     return "pointer";
@@ -101,8 +122,9 @@ const StyledButton = styled.button`
       appearance,
       variant,
       disabled,
+      cursorHover,
     }: IStyledButtonStructureProps) => {
-      if (!disabled) {
+      if (!disabled && cursorHover) {
         if (variant === "none") {
           return "transparent";
         }
@@ -118,17 +140,16 @@ const StyledButton = styled.button`
       appearance,
       variant,
       disabled,
+      cursorHover,
     }: IStyledButtonStructureProps) => {
-      if (!disabled) {
-        if (variant === "filled") {
-          return (
-            theme?.color?.surface?.[appearance!]?.hover ||
-            inube.color.surface[appearance!].hover
-          );
-        }
-        if (variant === "none") {
-          return "transparent";
-        }
+      if (!disabled && cursorHover && variant === "filled") {
+        return (
+          theme?.color?.surface?.[appearance!]?.hover ||
+          inube.color.surface[appearance!].hover
+        );
+      }
+      if (!disabled && cursorHover && variant === "none") {
+        return "transparent";
       }
     }};
   }
@@ -143,14 +164,42 @@ const StyledSpan = styled.span`
   justify-content: space-between;
   gap: 4px;
   overflow: hidden;
+  & * {
+    color: ${({
+      theme,
+      appearance,
+      variant,
+      disabled,
+      parentHover,
+    }: IStyledButtonStructureProps) => {
+      if (!disabled) {
+        if (variant === "filled") {
+          return (
+            theme?.color?.stroke?.light?.hover || inube.color.stroke.light.hover
+          );
+        }
+        if (parentHover) {
+          return (
+            theme?.color?.stroke?.[appearance!]?.hover ||
+            inube.color.stroke[appearance!].hover
+          );
+        }
+        return (
+          theme?.color?.text?.[appearance!]?.regular ||
+          inube.color.text[appearance!].regular
+        );
+      }
+    }};
+  }
   &:hover * {
     color: ${({
       theme,
       appearance,
       variant,
       disabled,
+      cursorHover,
     }: IStyledButtonStructureProps) => {
-      if (!disabled) {
+      if (!disabled && cursorHover) {
         if (variant === "filled") {
           return (
             theme?.color?.stroke?.light?.hover || inube.color.stroke.light.hover

--- a/src/components/inputs/Button/styles.ts
+++ b/src/components/inputs/Button/styles.ts
@@ -92,12 +92,7 @@ const StyledButton = styled.button`
     );
   }};
 
-  cursor: ${({
-    disabled,
-    loading,
-    cursorHover,
-    variant,
-  }: IStyledButtonProps) => {
+  cursor: ${({ disabled, loading }: IStyledButtonProps) => {
     if (disabled) {
       return "not-allowed";
     }

--- a/src/components/inputs/Button/styles.ts
+++ b/src/components/inputs/Button/styles.ts
@@ -102,10 +102,9 @@ const StyledButton = styled.button`
       return "not-allowed";
     }
 
-    if (loading) {
+    if (loading!.toString() === "true") {
       return "progress";
     }
-
     if (!cursorHover || variant === "filled") {
       return "default";
     }
@@ -156,59 +155,4 @@ const StyledLink = styled(Link)`
   text-decoration: none;
 `;
 
-const StyledSpan = styled.span`
-  display: flex;
-  justify-content: space-between;
-  gap: 4px;
-  overflow: hidden;
-  & * {
-    color: ${({
-      theme,
-      appearance,
-      variant,
-      disabled,
-      parentHover,
-    }: IStyledButtonProps) => {
-      if (!disabled) {
-        if (variant === "filled") {
-          return (
-            theme?.color?.stroke?.light?.hover || inube.color.stroke.light.hover
-          );
-        }
-        if (parentHover) {
-          return (
-            theme?.color?.stroke?.[appearance!]?.hover ||
-            inube.color.stroke[appearance!].hover
-          );
-        }
-        return (
-          theme?.color?.text?.[appearance!]?.regular ||
-          inube.color.text[appearance!].regular
-        );
-      }
-    }};
-  }
-  &:hover * {
-    color: ${({
-      theme,
-      appearance,
-      variant,
-      disabled,
-      cursorHover,
-    }: IStyledButtonProps) => {
-      if (!disabled && cursorHover) {
-        if (variant === "filled") {
-          return (
-            theme?.color?.stroke?.light?.hover || inube.color.stroke.light.hover
-          );
-        }
-        return (
-          theme?.color?.stroke?.[appearance!]?.hover ||
-          inube.color.stroke[appearance!].hover
-        );
-      }
-    }};
-  }
-`;
-
-export { StyledButton, StyledSpan, StyledLink };
+export { StyledButton, StyledLink };

--- a/src/components/inputs/Button/styles.ts
+++ b/src/components/inputs/Button/styles.ts
@@ -105,9 +105,6 @@ const StyledButton = styled.button`
     if (loading!.toString() === "true") {
       return "progress";
     }
-    if (!cursorHover || variant === "filled") {
-      return "default";
-    }
 
     return "pointer";
   }};


### PR DESCRIPTION
To provide greater flexibility and interactivity, this PR introduces two new optional props to the `<Button />` component: `cursorHover` and `parentHover`.