### PR TITLE
Make it a wrapper that just render children in `<OptionList />`

### DIFF
--- a/src/components/data/Icon/index.tsx
+++ b/src/components/data/Icon/index.tsx
@@ -11,7 +11,7 @@ export interface IIconProps {
   variant?: Variant;
   shape?: Shape;
   size?: string;
-  onClick?: () => void;
+  onClick?: (e: Event) => void;
 }
 
 const Icon = (props: IIconProps) => {

--- a/src/components/inputs/Select/OptionList/index.tsx
+++ b/src/components/inputs/Select/OptionList/index.tsx
@@ -9,18 +9,13 @@ interface optionItemProps {
 export interface OptionListProps {
   options: optionItemProps[];
   onClick?: (id: string) => void;
-  onCloseOptions?: () => void;
-  onSelect?: (id: string) => void;
-  isOpenOptions?: boolean;
 }
 
 const OptionList = (props: OptionListProps) => {
-  const { options, onClick, onSelect, onCloseOptions } = props;
+  const { options, onClick } = props;
 
   const handleOptionClick = (id: string) => {
     if (onClick) onClick(id);
-    if (onSelect) onSelect(id);
-    if (onCloseOptions) onCloseOptions();
   };
 
   return (

--- a/src/components/inputs/Select/OptionList/styled.ts
+++ b/src/components/inputs/Select/OptionList/styled.ts
@@ -9,7 +9,7 @@ interface IStyledOptionListProps extends OptionListProps {
 const StyledOptionList = styled.ul`
   display: flex;
   flex-direction: column;
-  padding: 4px 0px;
+  padding: ${inube.spacing.s050} ${inube.spacing.s0};
   background: ${({ theme }: IStyledOptionListProps) => {
     return (
       theme?.color?.surface?.light?.clear || inube.color.surface.light.clear

--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -22,10 +22,10 @@ export interface ISelectProps {
   size?: Size;
   fullwidth?: boolean;
   options: ISelectOptions[];
-  onChange?: (event: MouseEvent) => void;
+  onChange?: (event: Event) => void;
   onFocus?: (event: FocusEvent) => void;
   onBlur?: (event: FocusEvent) => void;
-  onClick?: (event: MouseEvent) => void;
+  onClick?: (event: Event) => void;
 }
 
 const Select = (props: ISelectProps) => {
@@ -64,11 +64,7 @@ const Select = (props: ISelectProps) => {
     onBlur && onBlur(e);
   };
 
-  const toggleOptionsMenu = () => {
-    setOpen(!open);
-  };
-
-  const handleClickOutside = (event: MouseEvent) => {
+  const handleClickOutside = (event: Event) => {
     if (selectRef.current && !selectRef.current.contains(event.target!)) {
       setOpen(false);
     }
@@ -91,12 +87,12 @@ const Select = (props: ISelectProps) => {
     setOpen(false);
   };
 
-  const handleClick = (e: MouseEvent) => {
+  const handleClick = (e: Event) => {
     onClick && onClick(e);
 
-    toggleOptionsMenu();
+    setOpen(!open);
   };
-  console.log(open, "open");
+
   return (
     <SelectUI
       label={label}

--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -86,7 +86,9 @@ const Select = (props: ISelectProps) => {
 
   const handleOptionClick = (idOption: string) => {
     const option = options.find((option) => option.id === idOption);
+
     setSelectedOption(option!.label);
+    setOpen(false);
   };
 
   const handleClick = (e: MouseEvent) => {
@@ -94,7 +96,7 @@ const Select = (props: ISelectProps) => {
 
     toggleOptionsMenu();
   };
-
+  console.log(open, "open");
   return (
     <SelectUI
       label={label}
@@ -114,10 +116,9 @@ const Select = (props: ISelectProps) => {
       onBlur={handleBlur}
       options={options}
       openOptions={open}
-      onClick={handleClick}
+      onClick={(e) => handleClick(e)}
       selectedOption={selectedOption}
       onOptionClick={handleOptionClick}
-      onCloseOptions={toggleOptionsMenu}
       ref={selectRef}
     />
   );

--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -147,6 +147,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
           size="24px"
           spacing="none"
           disabled={disabled}
+          onClick={onClick}
         />
       </StyledInputContainer>
 

--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -17,7 +17,6 @@ import {
   StyledContainerLabel,
   StyledInputContainer,
   StyledInput,
-  StyledIcon,
   StyledMessageContainer,
 } from "./styles";
 
@@ -31,7 +30,6 @@ export interface ISelectStateProps {
 export interface ISelectInterfaceProps extends ISelectProps {
   isFocused?: boolean;
   openOptions: boolean;
-  onCloseOptions: () => void;
   onOptionClick: (idOption: string) => void;
   selectedOption?: string | number;
 }
@@ -91,7 +89,6 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
     value,
     onClick,
     onOptionClick,
-    onCloseOptions,
   } = props;
 
   return (
@@ -144,21 +141,20 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
           onBlur={onBlur}
           onClick={onClick}
         />
-        <StyledIcon disabled={disabled}>
-          <MdOutlineArrowDropDown onClick={onCloseOptions} />
-        </StyledIcon>
+        <Icon
+          appearance="dark"
+          icon={<MdOutlineArrowDropDown />}
+          size="24px"
+          spacing="none"
+          disabled={disabled}
+        />
       </StyledInputContainer>
 
       {status && (
         <Message disabled={disabled} status={status} message={message} />
       )}
       {openOptions && !disabled && (
-        <OptionList
-          options={options}
-          isOpenOptions={openOptions}
-          onClick={onOptionClick}
-          onCloseOptions={onCloseOptions}
-        />
+        <OptionList options={options} onClick={onOptionClick} />
       )}
     </StyledContainer>
   );

--- a/src/components/inputs/Select/styles.ts
+++ b/src/components/inputs/Select/styles.ts
@@ -127,7 +127,7 @@ const StyledInput = styled.input`
   }
 `;
 
-const StyledIcon = styled.div`
+/* const StyledIcon = styled.div`
   display: grid;
   justify-content: center;
   align-items: center;
@@ -137,7 +137,7 @@ const StyledIcon = styled.div`
   color: ${({ theme, disabled }: IStyledSelectInterfaceProps) =>
     disabled &&
     (theme?.color?.text?.dark?.hover || inube.color.text.dark.hover)};
-`;
+`; */
 
 const StyledMessageContainer = styled.div`
   display: flex;
@@ -176,6 +176,5 @@ export {
   StyledContainerLabel,
   StyledInputContainer,
   StyledInput,
-  StyledIcon,
   StyledMessageContainer,
 };

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -23,19 +23,23 @@ const Tabs = ({
   onSelectTab,
 }: ITabsProps) => {
   const [isDropDownOpen, setIsDropDownOpen] = useState(false);
-  //const [selectedTabLabel, setSelectedTabLabel] = useState<string>(selectedTab);
-  //const [selectedTabIsDisabled, setSelectedTabIsDisabled] =
-  //useState<boolean>(false);
+  const [selectedTabLabel, setSelectedTabLabel] = useState<string>(selectedTab);
 
   if (type === "select") {
-    const selected = tabs.find((tab) => tab.id === selectedTab);
     const dropDownOptions = tabs.map((tab) => ({
       id: tab.id,
       label: tab.label,
       disabled: tab.disabled,
     }));
 
-    console.log(dropDownOptions, "dropDownOptions", "selected ->", selected);
+    const handleOptionClick = (id: string) => {
+      const selected = tabs.find((tab) => tab.id === id);
+      if (selected) {
+        setSelectedTabLabel(selected.label);
+        setIsDropDownOpen(false);
+      }
+    };
+
     return (
       <>
         <StyledTabs type={type}>
@@ -50,18 +54,14 @@ const Tabs = ({
 
             <Tab
               key={selectedTab}
-              label={selected?.label || selectedTab}
+              label={selectedTabLabel}
               selected={true}
               id={selectedTab}
-              onClick={() => onSelectTab(selected?.label!)}
             />
           </Stack>
         </StyledTabs>
         {isDropDownOpen && (
-          <OptionList
-            options={dropDownOptions}
-            onClick={() => setIsDropDownOpen(!isDropDownOpen)}
-          />
+          <OptionList options={dropDownOptions} onClick={handleOptionClick} />
         )}
       </>
     );

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -35,7 +35,7 @@ const Tabs = ({
       disabled: tab.disabled,
     }));
 
-    //console.log(dropDownOptions, "dropDownOptions", "selected ->", selected);
+    console.log(dropDownOptions, "dropDownOptions", "selected ->", selected);
     return (
       <>
         <StyledTabs type={type}>

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { MdKeyboardArrowDown } from "react-icons/md";
 
 import { OptionList } from "@inputs/Select/OptionList";
@@ -6,7 +6,8 @@ import { Stack } from "@layouts/Stack";
 import { ITabProps, Tab } from "@navigation/Tabs/Tab";
 
 import { Types } from "./props";
-import { StyledTabs, StyledIconWrapper } from "./styles";
+import { StyledTabs } from "./styles";
+import { Icon } from "@src/components/data/Icon";
 
 export interface ITabsProps {
   tabs: ITabProps[];
@@ -22,49 +23,44 @@ const Tabs = ({
   onSelectTab,
 }: ITabsProps) => {
   const [isDropDownOpen, setIsDropDownOpen] = useState(false);
-  const [selectedTabLabel, setSelectedTabLabel] = useState<string>("");
-  const [selectedTabIsDisabled, setSelectedTabIsDisabled] =
-    useState<boolean>(false);
-
-  useEffect(() => {
-    const selected = tabs.find((tab) => tab.id === selectedTab);
-    if (selected) {
-      setSelectedTabLabel(selected.label);
-      setSelectedTabIsDisabled(selected?.disabled ?? false);
-    }
-  }, [selectedTab, tabs]);
+  //const [selectedTabLabel, setSelectedTabLabel] = useState<string>(selectedTab);
+  //const [selectedTabIsDisabled, setSelectedTabIsDisabled] =
+  //useState<boolean>(false);
 
   if (type === "select") {
+    const selected = tabs.find((tab) => tab.id === selectedTab);
     const dropDownOptions = tabs.map((tab) => ({
       id: tab.id,
       label: tab.label,
       disabled: tab.disabled,
     }));
+
+    //console.log(dropDownOptions, "dropDownOptions", "selected ->", selected);
     return (
       <>
         <StyledTabs type={type}>
           <Stack gap="8px">
-            <StyledIconWrapper
+            <Icon
+              appearance="dark"
+              icon={<MdKeyboardArrowDown />}
+              size="24px"
+              spacing="none"
               onClick={() => setIsDropDownOpen(!isDropDownOpen)}
-            >
-              <MdKeyboardArrowDown />
-            </StyledIconWrapper>
+            />
+
             <Tab
               key={selectedTab}
-              disabled={selectedTabIsDisabled}
+              label={selected?.label || selectedTab}
               selected={true}
               id={selectedTab}
-              onClick={() => onSelectTab(selectedTab)}
-              label={selectedTabLabel}
+              onClick={() => onSelectTab(selected?.label!)}
             />
           </Stack>
         </StyledTabs>
         {isDropDownOpen && (
           <OptionList
             options={dropDownOptions}
-            onSelect={onSelectTab}
-            isOpenOptions={isDropDownOpen}
-            onCloseOptions={() => setIsDropDownOpen(false)}
+            onClick={() => setIsDropDownOpen(!isDropDownOpen)}
           />
         )}
       </>


### PR DESCRIPTION
Let’s prevent a props drilling problem that may cause that the `<Select />` component as a whole becomes harder to maintain.

Make `<OptionList />`a component that is only useful as a styled **container** that renders children and that’s it.

The **styles** are defined so that it appears or disappear when necessary and looks nice behind to the select input and nothing more.