### PR TITLE
Rename isFocused state for just focused in `<Select />`

### DIFF
--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -48,18 +48,18 @@ const Select = (props: ISelectProps) => {
     onClick,
   } = props;
 
-  const [isFocused, setIsFocused] = useState(false);
+  const [focused, setFocused] = useState(false);
   const [open, setOpen] = useState(false);
   const selectRef = useRef<{ contains: (e: EventTarget) => EventTarget }>(null);
 
   const handleFocus = (e: FocusEvent) => {
-    setIsFocused(true);
+    setFocused(true);
 
     onFocus && onFocus(e);
   };
 
   const handleBlur = (e: FocusEvent) => {
-    setIsFocused(false);
+    setFocused(false);
 
     onBlur && onBlur(e);
   };
@@ -109,7 +109,7 @@ const Select = (props: ISelectProps) => {
       status={status}
       message={message}
       fullwidth={fullwidth}
-      isFocused={isFocused}
+      focused={focused}
       onFocus={handleFocus}
       onBlur={handleBlur}
       options={options}

--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -29,7 +29,7 @@ export interface ISelectStateProps {
 }
 
 export interface ISelectInterfaceProps extends ISelectProps {
-  isFocused?: boolean;
+  focused?: boolean;
   openOptions: boolean;
   onCloseOptions: () => void;
   onOptionClick: (idOption: string) => void;
@@ -83,7 +83,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
     message,
     size,
     fullwidth,
-    isFocused,
+    focused,
     onFocus,
     onBlur,
     options,
@@ -106,7 +106,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
           <Label
             htmlFor={id}
             disabled={disabled}
-            focused={isFocused}
+            focused={focused}
             invalid={status === "invalid" ? true : false}
             size={getTypo(size!)}
           >
@@ -123,7 +123,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
 
       <StyledInputContainer
         disabled={disabled}
-        isFocused={isFocused}
+        focused={focused}
         status={status}
       >
         <StyledInput
@@ -138,7 +138,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
           size={size}
           status={status}
           fullwidth={fullwidth}
-          isFocused={isFocused}
+          focused={focused}
           onChange={onChange}
           onFocus={onFocus}
           onBlur={onBlur}

--- a/src/components/inputs/Select/styles.ts
+++ b/src/components/inputs/Select/styles.ts
@@ -48,7 +48,7 @@ const StyledInputContainer = styled.div`
     theme?.color?.surface?.light?.clear || inube.color.surface.light.clear};
   grid-template-columns: 1fr auto;
   border: 1px solid
-    ${({ theme, disabled, status, isFocused }: IStyledSelectInterfaceProps) => {
+    ${({ theme, disabled, status, focused }: IStyledSelectInterfaceProps) => {
       if (disabled) {
         return (
           (theme?.color?.text?.dark?.disabled ||
@@ -56,7 +56,7 @@ const StyledInputContainer = styled.div`
           "; pointer-events: none; opacity: 0.5;"
         );
       }
-      if (isFocused) {
+      if (focused) {
         return (
           theme?.color?.text?.primary?.hover || inube.color.text.primary.hover
         );


### PR DESCRIPTION
the name of the `isFocused ` **status** is adjusted to `focused`, which is in line with the standards of the project, and is also more understandable and helps to quickly identify its functionality.