### PR TITLE
Remove the `toggleOptionsMenu` function `<Select />`

### DIFF
--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -64,10 +64,6 @@ const Select = (props: ISelectProps) => {
     onBlur && onBlur(e);
   };
 
-  const toggleOptionsMenu = () => {
-    setOpen(!open);
-  };
-
   const handleClickOutside = (event: MouseEvent) => {
     if (selectRef.current && !selectRef.current.contains(event.target!)) {
       setOpen(false);
@@ -92,7 +88,7 @@ const Select = (props: ISelectProps) => {
   const handleClick = (e: MouseEvent) => {
     onClick && onClick(e);
 
-    toggleOptionsMenu();
+    setOpen(!open);
   };
 
   return (
@@ -117,7 +113,7 @@ const Select = (props: ISelectProps) => {
       onClick={handleClick}
       selectedOption={selectedOption}
       onOptionClick={handleOptionClick}
-      onCloseOptions={toggleOptionsMenu}
+      onCloseOptions={() => setOpen(!open)}
       ref={selectRef}
     />
   );


### PR DESCRIPTION
Remove the `toggleOptionsMenu` function, as this is only used to update the show/not show status of the `OptionList` component, and this could be done in a straightforward way without declaring functions to execute this change. 