### PR TITLE
 Import `OptionItem` interface and delete `ISelectOptions`

### DIFF
--- a/src/components/inputs/Select/OptionItem/OptionItem.stories.tsx
+++ b/src/components/inputs/Select/OptionItem/OptionItem.stories.tsx
@@ -14,7 +14,7 @@ export const Default = (args: IOptionItemProps) => <OptionItem {...args} />;
 
 Default.args = {
   id: "Item 1",
-  children: "Item 1",
+  label: "Item 1",
 };
 
 const theme = {

--- a/src/components/inputs/Select/OptionItem/index.tsx
+++ b/src/components/inputs/Select/OptionItem/index.tsx
@@ -3,16 +3,16 @@ import { StyledOptionItem } from "./styles";
 
 export interface IOptionItemProps {
   id: string;
-  children: string;
+  label: string;
   onClick: (id: string) => void;
 }
 
 const OptionItem = (props: IOptionItemProps) => {
-  const { id, children, onClick } = props;
+  const { id, label, onClick } = props;
 
   return (
     <StyledOptionItem id={id} onClick={onClick}>
-      <Text size="medium">{children}</Text>
+      <Text size="medium">{label}</Text>
     </StyledOptionItem>
   );
 };

--- a/src/components/inputs/Select/OptionItem/props.ts
+++ b/src/components/inputs/Select/OptionItem/props.ts
@@ -18,7 +18,7 @@ const props = {
       "(function): shall be determine the behavior of the click event and is not required.",
   },
 
-  children: {
+  label: {
     description: "The content of the component.",
   },
 };

--- a/src/components/inputs/Select/OptionList/index.tsx
+++ b/src/components/inputs/Select/OptionList/index.tsx
@@ -1,13 +1,8 @@
-import { OptionItem } from "@inputs/Select/OptionItem";
+import { IOptionItemProps, OptionItem } from "@inputs/Select/OptionItem";
 import { StyledOptionList } from "./styled";
 
-interface optionItemProps {
-  id: string;
-  label: string;
-}
-
 export interface OptionListProps {
-  options: optionItemProps[];
+  options: IOptionItemProps[];
   onClick?: (id: string) => void;
   onCloseOptions?: () => void;
   onSelect?: (id: string) => void;
@@ -29,10 +24,9 @@ const OptionList = (props: OptionListProps) => {
         <OptionItem
           key={optionItem.id}
           id={optionItem.id}
+          label={optionItem.label}
           onClick={() => handleOptionClick(optionItem.id)}
-        >
-          {optionItem.label}
-        </OptionItem>
+        />
       ))}
     </StyledOptionList>
   );

--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -1,8 +1,8 @@
 import { useState, useRef, useEffect } from "react";
 
-import { SelectUI } from "./interface";
-import { Size, Status } from "./props";
 import { IOptionItemProps } from "./OptionItem";
+import { Size, Status } from "./props";
+import { SelectUI } from "./interface";
 
 export interface ISelectProps {
   label?: string;

--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -2,12 +2,7 @@ import { useState, useRef, useEffect } from "react";
 
 import { SelectUI } from "./interface";
 import { Size, Status } from "./props";
-
-export interface ISelectOptions {
-  id: string;
-  label: string;
-  disabled: boolean;
-}
+import { IOptionItemProps } from "./OptionItem";
 
 export interface ISelectProps {
   label?: string;
@@ -21,7 +16,7 @@ export interface ISelectProps {
   message?: string;
   size?: Size;
   fullwidth?: boolean;
-  options: ISelectOptions[];
+  options: IOptionItemProps[];
   onChange?: (event: MouseEvent) => void;
   onFocus?: (event: FocusEvent) => void;
   onBlur?: (event: FocusEvent) => void;

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -35,11 +35,14 @@ const Tabs = ({
   }, [selectedTab, tabs]);
 
   if (type === "select") {
-    const dropDownOptions = tabs.map((tab) => ({
-      id: tab.id,
-      label: tab.label,
-      disabled: tab.disabled,
-    }));
+    const dropDownOptions = tabs.map((tab) => {
+      return {
+        id: tab.id,
+        label: tab.label,
+        disabled: tab.disabled,
+        onClick: () => onSelectTab(tab.id),
+      };
+    });
     return (
       <>
         <StyledTabs type={type}>


### PR DESCRIPTION
In this pull request (PR), we have modified the way the properties of the options object are handled, which is passed as a prop to `<OptionList />`. Instead of creating a new interface, we are now using the native `<OptionItem />` interface. In addition, we have updated the interface's `children` property to `label`. This improvement simplifies property management and makes the code more consistent and easier to maintain.