### PR TITLE
Delete `ISelectStateProps` interface in `<Select />`

### DIFF
--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -21,13 +21,6 @@ import {
   StyledMessageContainer,
 } from "./styles";
 
-export interface ISelectStateProps {
-  disabled: boolean;
-  status: string;
-  validMessage?: string;
-  errorMessage?: string;
-}
-
 export interface ISelectInterfaceProps extends ISelectProps {
   focused?: boolean;
   openOptions: boolean;


### PR DESCRIPTION
The `ISelectStateProps` interface is removed, as when the component is refactored, it is no longer used. 