### PR TITLE
`<Header />:` `StyledHeader` should be a `<header>` html element, not a div

### DIFF
--- a/src/components/navigation/Header/styles.ts
+++ b/src/components/navigation/Header/styles.ts
@@ -7,7 +7,7 @@ interface IStyledHeaderProps extends IHeaderProps {
   theme?: Themed;
 }
 
-const StyledHeader = styled.div`
+const StyledHeader = styled.header`
   display: flex;
   justify-content: space-between;
   align-items: center;


### PR DESCRIPTION
This pull request updates the `<StyledHeader>` component to leverage the `<header>` HTML element, ensuring better semantic structuring and potential accessibility improvements.