### PR TITLE
`<Header />:` rename `logo` for `logoURL`

### DIFF
--- a/src/components/navigation/Header/index.tsx
+++ b/src/components/navigation/Header/index.tsx
@@ -7,7 +7,7 @@ import { StyledHeader } from "./styles";
 export interface IHeaderProps {
   portalId: string;
   navigation: INavigation;
-  logo: JSX.Element;
+  logoURL: JSX.Element;
   logoutPath: string;
   logoutTitle: string;
   userName: string;
@@ -28,11 +28,17 @@ const shouldDisplayNav = (matches: { [key: string]: boolean }) =>
 const LogoAndNav = (
   props: Pick<
     IHeaderProps,
-    "portalId" | "navigation" | "logoutPath" | "logoutTitle" | "logo"
+    "portalId" | "navigation" | "logoutPath" | "logoutTitle" | "logoURL"
   > & { shouldDisplay?: boolean }
 ) => {
-  const { portalId, navigation, logoutPath, logoutTitle, logo, shouldDisplay } =
-    props;
+  const {
+    portalId,
+    navigation,
+    logoutPath,
+    logoutTitle,
+    logoURL,
+    shouldDisplay,
+  } = props;
   return (
     <Stack justifyContent="space-between" gap="23px">
       {shouldDisplay && (
@@ -43,7 +49,7 @@ const LogoAndNav = (
           logoutTitle={logoutTitle}
         />
       )}
-      {logo}
+      {logoURL}
     </Stack>
   );
 };
@@ -54,7 +60,7 @@ const Header = (props: IHeaderProps) => {
     navigation,
     logoutPath,
     logoutTitle,
-    logo,
+    logoURL,
     userName,
     businessUnit,
     isBusinessUnit = false,
@@ -73,7 +79,7 @@ const Header = (props: IHeaderProps) => {
         navigation={navigation}
         logoutPath={logoutPath}
         logoutTitle={logoutTitle}
-        logo={logo}
+        logoURL={logoURL}
         shouldDisplay={shouldDisplayLogoAndNav}
       />
       <User

--- a/src/components/navigation/Header/props.ts
+++ b/src/components/navigation/Header/props.ts
@@ -12,7 +12,7 @@ const props = {
     description:
       "The primary object that will organize and store the requisite paths for the correct operation of the Nav component is forthcoming and is required",
   },
-  logo: {
+  logoURL: {
     description:
       "prop accepts a component to be used as the logo in the header. This component can be an image, an icon, stylized text or any other visual element that represents the brand identity.",
   },

--- a/src/components/navigation/Header/stories/Header.stories.tsx
+++ b/src/components/navigation/Header/stories/Header.stories.tsx
@@ -100,7 +100,7 @@ Default.args = {
   },
   logoutPath: "/logout",
   logoutTitle: "Logout",
-  logo: <Logo />,
+  logoURL: <Logo />,
   userName: "Leonardo Garzón",
   businessUnit: "Sistemas Enlínea S.A",
   isBusinessUnit: true,


### PR DESCRIPTION
This pull request renames the logo prop to `logoURL` in the `<Header />` component to better reflect its purpose and ensure clarity for developers.