### PR TITLE
Refactor `width` of `StyledInput` in `<Select />` styles

### DIFF
--- a/src/components/inputs/Select/styles.ts
+++ b/src/components/inputs/Select/styles.ts
@@ -22,7 +22,7 @@ const StyledContainer = styled.div`
   cursor: ${({ disabled }: IStyledSelectInterfaceProps) =>
     disabled && "not-allowed"};
   width: ${({ fullwidth }: IStyledSelectInterfaceProps) =>
-    fullwidth ? "100%" : "fit-content"};
+    fullwidth ? "100%" : "300px"};
 `;
 
 const StyledContainerLabel = styled.div`
@@ -108,8 +108,7 @@ const StyledInput = styled.input`
     theme?.color?.surface?.light?.clear || inube.color.surface.light.clear};
   cursor: ${({ disabled }: IStyledSelectInterfaceProps) =>
     disabled ? "not-allowed" : "pointer"};
-  width: ${({ fullwidth }: IStyledSelectInterfaceProps) =>
-    fullwidth ? "252px" : "calc(100% - 32px)"};
+
   ${({ size }: IStyledSelectInterfaceProps) => sizeOptions[size!]};
 
   ::placeholder {


### PR DESCRIPTION
The parent is a Grid, and the parent controls the width of the whole component. The input only has to be 100% in width and it will take all the space that the parent decides.

So, `fullwidth` should be useless for `StyledInput`, it works fine in the container and the input just uses whatever space is given to it.