### PR TITLE
`<Header />:` Remove `logoutPath` and `logoutTitle` props

### DIFF
--- a/src/components/navigation/Header/index.tsx
+++ b/src/components/navigation/Header/index.tsx
@@ -26,21 +26,19 @@ const shouldDisplayNav = (matches: { [key: string]: boolean }) =>
   matches[SMALL_SCREEN] || matches[MEDIUM_SCREEN];
 
 const LogoAndNav = (
-  props: Pick<
-    IHeaderProps,
-    "portalId" | "navigation" | "logoutPath" | "logoutTitle" | "logo"
-  > & { shouldDisplay?: boolean }
+  props: Pick<IHeaderProps, "portalId" | "navigation" | "logo"> & {
+    shouldDisplay?: boolean;
+  }
 ) => {
-  const { portalId, navigation, logoutPath, logoutTitle, logo, shouldDisplay } =
-    props;
+  const { portalId, navigation, logo, shouldDisplay } = props;
   return (
     <Stack justifyContent="space-between" gap="23px">
       {shouldDisplay && (
         <FullscreenNav
           portalId={portalId}
           navigation={navigation}
-          logoutPath={logoutPath}
-          logoutTitle={logoutTitle}
+          logoutPath="/logout"
+          logoutTitle="Logout"
         />
       )}
       {logo}
@@ -52,8 +50,6 @@ const Header = (props: IHeaderProps) => {
   const {
     portalId,
     navigation,
-    logoutPath,
-    logoutTitle,
     logo,
     userName,
     businessUnit,
@@ -71,8 +67,6 @@ const Header = (props: IHeaderProps) => {
       <LogoAndNav
         portalId={portalId}
         navigation={navigation}
-        logoutPath={logoutPath}
-        logoutTitle={logoutTitle}
         logo={logo}
         shouldDisplay={shouldDisplayLogoAndNav}
       />

--- a/src/components/navigation/Header/index.tsx
+++ b/src/components/navigation/Header/index.tsx
@@ -8,8 +8,6 @@ export interface IHeaderProps {
   portalId: string;
   navigation: INavigation;
   logo: JSX.Element;
-  logoutPath: string;
-  logoutTitle: string;
   userName: string;
   businessUnit: string;
   isBusinessUnit: boolean;

--- a/src/components/navigation/Header/props.ts
+++ b/src/components/navigation/Header/props.ts
@@ -16,10 +16,6 @@ const props = {
     description:
       "prop accepts a component to be used as the logo in the header. This component can be an image, an icon, stylized text or any other visual element that represents the brand identity.",
   },
-  logoutPath: {
-    description:
-      "is the path where the user is going to navigate when he wants to logout and is required",
-  },
   userName: {
     description: "shall be the displayed username",
     table: {

--- a/src/components/navigation/Header/stories/Header.stories.tsx
+++ b/src/components/navigation/Header/stories/Header.stories.tsx
@@ -98,8 +98,6 @@ Default.args = {
       },
     },
   },
-  logoutPath: "/logout",
-  logoutTitle: "Logout",
   logo: <Logo />,
   userName: "Leonardo Garzón",
   businessUnit: "Sistemas Enlínea S.A",


### PR DESCRIPTION
This pull request removes the `logoutPath` and `logoutTitle` props from the `<Header />` component. Their functionalities have been either deprecated or integrated in a different manner, making these props obsolete.