### PR TITLE
Refactor extension of `ISelectProps` in `<Select />`

### DIFF
--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -104,7 +104,6 @@ const Select = (props: ISelectProps) => {
       displayList={displayList}
       onClick={handleClick}
       onOptionClick={handleInsideClick}
-      onCloseOptions={() => setDisplayList(!displayList)}
       ref={selectRef}
     />
   );

--- a/src/components/inputs/Select/index.tsx
+++ b/src/components/inputs/Select/index.tsx
@@ -20,7 +20,7 @@ export interface ISelectProps {
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onFocus?: (event: FocusEvent) => void;
   onBlur?: (event: FocusEvent) => void;
-  onClick?: (event: MouseEvent) => void;
+  onClick?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 const Select = (props: ISelectProps) => {
@@ -73,12 +73,12 @@ const Select = (props: ISelectProps) => {
     };
   }, [selectRef]);
 
-  const handleInsideClick = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onInsideClick = (e: React.ChangeEvent<HTMLInputElement>) => {
     onChange(e);
     setDisplayList(false);
   };
 
-  const handleClick = (e: MouseEvent) => {
+  const handleClick = (e: React.ChangeEvent<HTMLInputElement>) => {
     onClick && onClick(e);
     setDisplayList(!displayList);
   };
@@ -103,7 +103,7 @@ const Select = (props: ISelectProps) => {
       options={options}
       displayList={displayList}
       onClick={handleClick}
-      onOptionClick={handleInsideClick}
+      onOptionClick={onInsideClick}
       ref={selectRef}
     />
   );

--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -149,7 +149,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
         <Message disabled={disabled} status={status} message={message} />
       )}
       {displayList && !disabled && (
-        <OptionList onClick={onOptionClick}>
+        <OptionList onClick={onOptionClick!}>
           {options.map((optionItem) => (
             <OptionItem
               key={optionItem.id}

--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -26,7 +26,6 @@ export interface ISelectInterfaceProps extends ISelectProps {
   displayList: boolean;
   onCloseOptions: () => void;
   onOptionClick: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  selectedOption?: string | number;
 }
 
 const getTypo = (size: Size) => {

--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -24,7 +24,6 @@ import { OptionItem } from "./OptionItem";
 export interface ISelectInterfaceProps extends ISelectProps {
   focused?: boolean;
   displayList: boolean;
-  onCloseOptions: () => void;
   onOptionClick: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -83,7 +82,6 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
     value,
     onClick,
     onOptionClick,
-    onCloseOptions,
   } = props;
 
   return (
@@ -117,6 +115,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
         disabled={disabled}
         focused={focused}
         status={status}
+        onClick={onClick}
       >
         <StyledInput
           autoComplete="off"
@@ -140,7 +139,6 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
         <Icon
           appearance="dark"
           icon={<MdOutlineArrowDropDown />}
-          onClick={onCloseOptions}
           size="24px"
           spacing="none"
           disabled={disabled}


### PR DESCRIPTION
Its ok to extend for focused and displayList.

**selectedOption:**

Delete this from the interface. The interface doesn’t need to know which option was selected and doesn’t need to transmit that information to the child components.

**onCloseOptions:**

This is used to allow the icon of the Select to close the list.

We already have a `handleClick` in index.tsx to toggle the list, we don’t have to create a new prop for SelectUI (onCloseOptions) and assing a new arrow function that also toggles the list.

You must create an event for the <select> as a whole. Use bubbling so that if the user clicks on the icon it also executes the callback of the event.

Don’t refactor icon so that it receives an `onClick`. Use bubbling.

**onOptionClick:**

We’re extending `ISelectProps` to create `onOptionClick`. Which is ok.

This function is passed to `OptionList` so that component can create an onClick event and trigger the execution of handleInsideClick (we have `onOptionClick={handleInsideClick}`)

If would be better to rename the prop to `onInsideClick` so it is easier to see that this prop transmits handleInsideClick to `<OptionList />`.