### PR TITLE
`<Header />:` remove `isBusinessUnit` prop

### DIFF
--- a/src/components/navigation/Header/index.tsx
+++ b/src/components/navigation/Header/index.tsx
@@ -10,7 +10,6 @@ export interface IHeaderProps {
   logoURL: JSX.Element;
   userName: string;
   client: string;
-  isClient: boolean;
 }
 
 const SMALL_SCREEN = "(min-width: 320px)";
@@ -45,21 +44,13 @@ const LogoAndNav = (
 };
 
 const Header = (props: IHeaderProps) => {
-  const {
-    portalId,
-    navigation,
-    logoURL,
-    userName,
-    client,
-    isClient = false,
-  } = props;
+  const { portalId, navigation, logoURL, userName, client } = props;
 
   const matches = useMediaQueries([SMALL_SCREEN, MEDIUM_SCREEN, LARGE_SCREEN]);
 
   const shouldDisplayLogoAndNav =
     !matches[LARGE_SCREEN] && shouldDisplayNav(matches);
 
-  const transformedClient = isClient ? client : "";
   return (
     <StyledHeader alignItems="center" justifyContent="space-between">
       <LogoAndNav
@@ -68,11 +59,7 @@ const Header = (props: IHeaderProps) => {
         logoURL={logoURL}
         shouldDisplay={shouldDisplayLogoAndNav}
       />
-      <User
-        userName={userName}
-        client={transformedClient}
-        size={getScreenSize(matches)}
-      />
+      <User userName={userName} client={client} size={getScreenSize(matches)} />
     </StyledHeader>
   );
 };

--- a/src/components/navigation/Header/props.ts
+++ b/src/components/navigation/Header/props.ts
@@ -31,10 +31,6 @@ const props = {
   portalId: {
     description: "id of the portal element",
   },
-  isClient: {
-    description:
-      "ascertain whether the 'header-component' displays the attribute 'client' or not",
-  },
 };
 
 export { props, parameters };

--- a/src/components/navigation/Header/stories/Header.stories.tsx
+++ b/src/components/navigation/Header/stories/Header.stories.tsx
@@ -101,7 +101,6 @@ Default.args = {
   logoURL: <Logo />,
   userName: "Leonardo Garzón",
   client: "Sistemas Enlínea S.A",
-  isClient: true,
 };
 
 const theme = structuredClone(presente);


### PR DESCRIPTION
This pull request removes the `isBusinessUnit` prop from the `<Header />` component. All logic, styling, or rendering that was previously dependent on this prop has been updated or refactored to not require it.