### PR TITLE
Rename isDisabled prop to disabled in `<NavLink />`

### DIFF
--- a/src/components/navigation/NavLink/index.tsx
+++ b/src/components/navigation/NavLink/index.tsx
@@ -6,7 +6,7 @@ export interface INavLinkProps {
   id: string;
   label: string;
   path: string;
-  isDisabled?: boolean;
+  disabled?: boolean;
   isSelected?: boolean;
   icon?: React.ReactNode;
   handleClick?: () => void;
@@ -18,7 +18,7 @@ const NavLink = (props: INavLinkProps) => {
     id,
     label,
     path,
-    isDisabled = false,
+    disabled = false,
     isSelected = false,
     icon,
     handleClick,
@@ -27,9 +27,9 @@ const NavLink = (props: INavLinkProps) => {
 
   return (
     <StyledNavList>
-      <StyledLink to={path} isdisabled={+isDisabled}>
+      <StyledLink to={path} isdisabled={+disabled}>
         <StyledNavLink
-          isDisabled={isDisabled}
+          disabled={disabled}
           isSelected={isSelected}
           id={id}
           onClick={handleClick}

--- a/src/components/navigation/NavLink/props.ts
+++ b/src/components/navigation/NavLink/props.ts
@@ -1,13 +1,13 @@
-const props = {
-  parameters: {
-    docs: {
-      description: {
-        component:
-          "Buttons that allow the user to navigate within the side menu",
-      },
+const parameters = {
+  docs: {
+    description: {
+      component: "Buttons that allow the user to navigate within the side menu",
     },
   },
-  isDisabled: {
+};
+
+const props = {
+  disabled: {
     description:
       "shall be determine if the tab is disabled (by Default is false) and is not required.",
     table: {
@@ -42,4 +42,4 @@ const props = {
   },
 };
 
-export { props };
+export { props, parameters };

--- a/src/components/navigation/NavLink/stories/NavLink.stories.tsx
+++ b/src/components/navigation/NavLink/stories/NavLink.stories.tsx
@@ -4,11 +4,12 @@ import { MdHouse } from "react-icons/md";
 import { NavLink, INavLinkProps } from "..";
 import { NavLinkController } from "./NavLink.Controller";
 
-import { props } from "../props";
+import { props, parameters } from "../props";
 
 const story = {
   title: "navigation/NavLink",
   components: [NavLink],
+  parameters,
   argTypes: props,
   decorators: [
     (Story: React.ElementType) => (
@@ -25,7 +26,7 @@ Default.args = {
   id: "privileges",
   label: "Privileges",
   path: "/privileges",
-  isDisabled: false,
+  disabled: false,
   icon: <MdHouse />,
 };
 

--- a/src/components/navigation/NavLink/styles.ts
+++ b/src/components/navigation/NavLink/styles.ts
@@ -15,16 +15,16 @@ const getGrid = (props: INavLinkProps) => {
 };
 
 const getColorLabel = (props: INavLinkProps) => {
-  const { isDisabled } = props;
-  if (isDisabled) {
+  const { disabled } = props;
+  if (disabled) {
     return colors.sys.text.disabled;
   }
   return colors.sys.text.dark;
 };
 
 const getBorderLeft = (props: INavLinkProps) => {
-  const { isDisabled, isSelected } = props;
-  if (isSelected && !isDisabled) {
+  const { disabled, isSelected } = props;
+  if (isSelected && !disabled) {
     return `5px solid ${colors.ref.palette.neutral.n900}`;
   }
 
@@ -32,12 +32,12 @@ const getBorderLeft = (props: INavLinkProps) => {
 };
 
 const getBackgroundColor = (props: INavLinkProps) => {
-  const { isDisabled, isSelected } = props;
+  const { disabled, isSelected } = props;
   let color = "transparent";
-  if (isDisabled) {
+  if (disabled) {
     return color;
   }
-  if (isSelected && !isDisabled) {
+  if (isSelected && !disabled) {
     color = colors.ref.palette.neutral.n30;
     return color;
   }
@@ -46,12 +46,12 @@ const getBackgroundColor = (props: INavLinkProps) => {
 };
 
 const getColorIcon = (props: INavLinkProps) => {
-  const { isDisabled, isSelected } = props;
-  if (isDisabled) {
+  const { disabled, isSelected } = props;
+  if (disabled) {
     return colors.ref.palette.neutral.n70;
   }
 
-  if (isSelected && !isDisabled) {
+  if (isSelected && !disabled) {
     return colors.sys.actions.primary.filled;
   }
 
@@ -81,14 +81,14 @@ const StyledNavLink = styled.div`
 
   border-left: ${(props: INavLinkProps) => getBorderLeft(props)};
   background-color: ${(props: INavLinkProps) => getBackgroundColor(props)};
-  color: ${({ isDisabled }: INavLinkProps) =>
-    isDisabled && colors.ref.palette.neutral.n70};
+  color: ${({ disabled }: INavLinkProps) =>
+    disabled && colors.ref.palette.neutral.n70};
 
   & > svg:last-child {
     ${iconStyles};
     color: ${colors.ref.palette.neutral.n900};
-    display: ${({ isDisabled, isSelected }: INavLinkProps) =>
-      (isDisabled || !isSelected) && "none"};
+    display: ${({ disabled, isSelected }: INavLinkProps) =>
+      (disabled || !isSelected) && "none"};
   }
 
   & > svg:first-child {
@@ -96,8 +96,8 @@ const StyledNavLink = styled.div`
     color: ${(props: INavLinkProps) => getColorIcon(props)};
   }
 
-  ${({ isDisabled }: INavLinkProps) =>
-    !isDisabled &&
+  ${({ disabled }: INavLinkProps) =>
+    !disabled &&
     `
     cursor: pointer;
       &:hover {


### PR DESCRIPTION
While refining the `<NavLink />` component's prop names, we noticed a redundancy in the naming convention for the `isDisabled` prop. With this PR, we are confirming the consistent usage of the `disabled` prop name throughout the component.