### PR TITLE
Rename `isSelected` prop to `selected` in `NavLink />`

### DIFF
--- a/src/components/navigation/Nav/index.tsx
+++ b/src/components/navigation/Nav/index.tsx
@@ -50,8 +50,6 @@ const Links = (props: INavLinkProps) => {
   const location = useLocation();
   const currentUrl = location.pathname;
 
-  const selected = (url: string) => currentUrl.startsWith(url);
-
   const LinkElements = section.map((sectionObject) => (
     <NavLink
       key={sectionObject.id}
@@ -59,7 +57,7 @@ const Links = (props: INavLinkProps) => {
       label={sectionObject.label}
       icon={sectionObject.icon}
       path={sectionObject.path}
-      selected={selected(sectionObject.path)}
+      selected={currentUrl.startsWith(sectionObject.path)}
     />
   ));
   return <>{LinkElements} </>;

--- a/src/components/navigation/Nav/index.tsx
+++ b/src/components/navigation/Nav/index.tsx
@@ -59,7 +59,7 @@ const Links = (props: INavLinkProps) => {
       label={sectionObject.label}
       icon={sectionObject.icon}
       path={sectionObject.path}
-      isSelected={isSelected(sectionObject.path)}
+      selected={isSelected(sectionObject.path)}
     />
   ));
   return <>{LinkElements} </>;

--- a/src/components/navigation/Nav/index.tsx
+++ b/src/components/navigation/Nav/index.tsx
@@ -50,7 +50,7 @@ const Links = (props: INavLinkProps) => {
   const location = useLocation();
   const currentUrl = location.pathname;
 
-  const isSelected = (url: string) => currentUrl.startsWith(url);
+  const selected = (url: string) => currentUrl.startsWith(url);
 
   const LinkElements = section.map((sectionObject) => (
     <NavLink
@@ -59,7 +59,7 @@ const Links = (props: INavLinkProps) => {
       label={sectionObject.label}
       icon={sectionObject.icon}
       path={sectionObject.path}
-      selected={isSelected(sectionObject.path)}
+      selected={selected(sectionObject.path)}
     />
   ));
   return <>{LinkElements} </>;

--- a/src/components/navigation/NavLink/index.tsx
+++ b/src/components/navigation/NavLink/index.tsx
@@ -7,7 +7,7 @@ export interface INavLinkProps {
   label: string;
   path: string;
   isDisabled?: boolean;
-  isSelected?: boolean;
+  selected?: boolean;
   icon?: React.ReactNode;
   handleClick?: () => void;
   handleBlur?: () => void;
@@ -19,7 +19,7 @@ const NavLink = (props: INavLinkProps) => {
     label,
     path,
     isDisabled = false,
-    isSelected = false,
+    selected = false,
     icon,
     handleClick,
     handleBlur,
@@ -30,7 +30,7 @@ const NavLink = (props: INavLinkProps) => {
       <StyledLink to={path} isdisabled={+isDisabled}>
         <StyledNavLink
           isDisabled={isDisabled}
-          isSelected={isSelected}
+          selected={selected}
           id={id}
           onClick={handleClick}
           icon={icon}

--- a/src/components/navigation/NavLink/props.ts
+++ b/src/components/navigation/NavLink/props.ts
@@ -14,7 +14,7 @@ const props = {
       defaultValue: { summary: false },
     },
   },
-  isSelected: {
+  selected: {
     description:
       "It is designed to ascertain whether the tab has been clicked or not (by Default is false) and is not required.",
     table: {

--- a/src/components/navigation/NavLink/stories/NavLink.Controller.tsx
+++ b/src/components/navigation/NavLink/stories/NavLink.Controller.tsx
@@ -16,7 +16,7 @@ const NavLinkController = (props: INavLinkProps) => {
     <ul>
       <NavLink
         {...props}
-        isSelected={select}
+        selected={select}
         handleClick={handleClick}
         handleBlur={handleBlur}
       />

--- a/src/components/navigation/NavLink/styles.ts
+++ b/src/components/navigation/NavLink/styles.ts
@@ -23,8 +23,8 @@ const getColorLabel = (props: INavLinkProps) => {
 };
 
 const getBorderLeft = (props: INavLinkProps) => {
-  const { isDisabled, isSelected } = props;
-  if (isSelected && !isDisabled) {
+  const { isDisabled, selected } = props;
+  if (selected && !isDisabled) {
     return `5px solid ${colors.ref.palette.neutral.n900}`;
   }
 
@@ -32,12 +32,12 @@ const getBorderLeft = (props: INavLinkProps) => {
 };
 
 const getBackgroundColor = (props: INavLinkProps) => {
-  const { isDisabled, isSelected } = props;
+  const { isDisabled, selected } = props;
   let color = "transparent";
   if (isDisabled) {
     return color;
   }
-  if (isSelected && !isDisabled) {
+  if (selected && !isDisabled) {
     color = colors.ref.palette.neutral.n30;
     return color;
   }
@@ -46,12 +46,12 @@ const getBackgroundColor = (props: INavLinkProps) => {
 };
 
 const getColorIcon = (props: INavLinkProps) => {
-  const { isDisabled, isSelected } = props;
+  const { isDisabled, selected } = props;
   if (isDisabled) {
     return colors.ref.palette.neutral.n70;
   }
 
-  if (isSelected && !isDisabled) {
+  if (selected && !isDisabled) {
     return colors.sys.actions.primary.filled;
   }
 
@@ -87,8 +87,8 @@ const StyledNavLink = styled.div`
   & > svg:last-child {
     ${iconStyles};
     color: ${colors.ref.palette.neutral.n900};
-    display: ${({ isDisabled, isSelected }: INavLinkProps) =>
-      (isDisabled || !isSelected) && "none"};
+    display: ${({ isDisabled, selected }: INavLinkProps) =>
+      (isDisabled || !selected) && "none"};
   }
 
   & > svg:first-child {


### PR DESCRIPTION
While refining the <NavLink /> component's prop names, we noticed a redundancy in the naming convention for the `isSelected` prop. With this PR, we are confirming the consistent usage of the `selected` prop name throughout the component.