### PR TITLE
Delete `background-size` CSS property in `<NavLink />`

### DIFF
--- a/src/components/navigation/NavLink/styles.ts
+++ b/src/components/navigation/NavLink/styles.ts
@@ -75,7 +75,6 @@ const StyledNavLink = styled.div`
   min-width: 180px;
   align-items: center;
   box-sizing: border-box;
-  background-size: cover;
   gap: 24px;
   padding: 0px 16px;
 


### PR DESCRIPTION
Remove the CSS property `background-size`, as it is not performing functionality in the component styles. 