### PR TITLE
`<Tabs />:` rename `isDropDownOpen` state to `displayList`

### DIFF
--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -22,7 +22,7 @@ const Tabs = ({
   selectedTab,
   onSelectTab,
 }: ITabsProps) => {
-  const [isDropDownOpen, setIsDropDownOpen] = useState(false);
+  const [displayList, setDisplayList] = useState(false);
   const [selectedTabLabel, setSelectedTabLabel] = useState<string | null>(
     selectedTab
   );
@@ -37,16 +37,14 @@ const Tabs = ({
     const handleOptionClick = (e: React.ChangeEvent<HTMLInputElement>) => {
       if (e) {
         setSelectedTabLabel(e.target.textContent);
-        setIsDropDownOpen(false);
+        setDisplayList(false);
       }
     };
     return (
       <>
         <StyledTabs type={type}>
           <Stack gap="8px">
-            <StyledIconWrapper
-              onClick={() => setIsDropDownOpen(!isDropDownOpen)}
-            >
+            <StyledIconWrapper onClick={() => setDisplayList(!displayList)}>
               <MdKeyboardArrowDown />
             </StyledIconWrapper>
             <Tab
@@ -58,7 +56,7 @@ const Tabs = ({
             />
           </Stack>
         </StyledTabs>
-        {isDropDownOpen && (
+        {displayList && (
           <OptionList onClick={handleOptionClick}>
             {dropDownOptions.map((optionItem) => (
               <OptionItem


### PR DESCRIPTION
This pull request renames the state variable `isDropDownOpen` to displayList in the `<Tabs />` component. This naming more clearly communicates the state's intent and functionality, improving readability and comprehension.