### PR TITLE
`<Tabs />:` rename `onSelectTab` prop to `onChange`

### DIFF
--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -12,16 +12,11 @@ import { StyledTabs, StyledIconWrapper } from "./styles";
 export interface ITabsProps {
   tabs: ITabProps[];
   type?: Types;
-  onSelectTab: (id: string) => void;
+  onChange: (id: string) => void;
   selectedTab: string;
 }
 
-const Tabs = ({
-  tabs,
-  type = "tabs",
-  selectedTab,
-  onSelectTab,
-}: ITabsProps) => {
+const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
   const [isDropDownOpen, setIsDropDownOpen] = useState(false);
   const [selectedTabLabel, setSelectedTabLabel] = useState<string | null>(
     selectedTab
@@ -53,7 +48,7 @@ const Tabs = ({
               key={selectedTab}
               selected={true}
               id={selectedTab}
-              onClick={() => onSelectTab(selectedTab)}
+              onClick={() => onChange(selectedTab)}
               label={selectedTabLabel!}
             />
           </Stack>
@@ -82,7 +77,7 @@ const Tabs = ({
             disabled={tab.disabled}
             selected={tab.id === selectedTab}
             id={tab.id}
-            onClick={() => onSelectTab(tab.id)}
+            onClick={() => onChange(tab.id)}
             label={tab.label}
           />
         ))}

--- a/src/components/navigation/Tabs/props.ts
+++ b/src/components/navigation/Tabs/props.ts
@@ -26,7 +26,7 @@ const props = {
       defaultValue: { summary: "idOfOneTab" },
     },
   },
-  onSelectTab: {
+  onChange: {
     options: ["logState"],
     control: { type: "func" },
     description:

--- a/src/components/navigation/Tabs/stories/TabsController.tsx
+++ b/src/components/navigation/Tabs/stories/TabsController.tsx
@@ -5,7 +5,7 @@ const TabsController = (props: ITabsProps) => {
   const { tabs, type, selectedTab } = props;
   const [selectedTabController, setSelectedTab] = useState(selectedTab);
 
-  const onSelectTab = (tabId: string) => {
+  const onChange = (tabId: string) => {
     setSelectedTab(tabId);
   };
 
@@ -13,7 +13,7 @@ const TabsController = (props: ITabsProps) => {
     <Tabs
       tabs={tabs}
       type={type}
-      onSelectTab={onSelectTab}
+      onChange={onChange}
       selectedTab={selectedTabController}
     />
   );

--- a/src/components/navigation/Tabs/stories/TabsResponsiveController.tsx
+++ b/src/components/navigation/Tabs/stories/TabsResponsiveController.tsx
@@ -36,7 +36,7 @@ const TabsResponsiveController = (props: ITabsProps) => {
       <Tabs
         tabs={tabs}
         type={type}
-        onSelectTab={setSelectedTab}
+        onChange={setSelectedTab}
         selectedTab={selectedTabController}
       />
     </div>


### PR DESCRIPTION
This pull request renames the prop `onSelectTab` to `onChange` within the `<Tabs />` component. The new name offers a more generic and widely-accepted convention, making the component's API more intuitive.