### PR TITLE
`<Tab />:` delete `onClick` prop and use bubbling

### DIFF
--- a/src/components/navigation/Tabs/Tab/index.tsx
+++ b/src/components/navigation/Tabs/Tab/index.tsx
@@ -6,19 +6,13 @@ export interface ITabProps {
   id: string;
   disabled?: boolean;
   selected?: boolean;
-  onClick?: () => void;
 }
 
 const Tab = (props: ITabProps) => {
-  const { disabled = false, selected = false, id, onClick, label } = props;
+  const { disabled = false, selected = false, id, label } = props;
 
   return (
-    <StyledTab
-      onClick={disabled ? undefined : onClick}
-      disabled={disabled}
-      selected={selected}
-      id={id}
-    >
+    <StyledTab disabled={disabled} selected={selected} id={id} data-tab-id={id}>
       <Text
         type="label"
         size="medium"

--- a/src/components/navigation/Tabs/Tab/stories/Tab.stories.tsx
+++ b/src/components/navigation/Tabs/Tab/stories/Tab.stories.tsx
@@ -1,10 +1,10 @@
 import { ThemeProvider } from "styled-components";
 import { Tab, ITabProps } from "../index";
-import { TabController } from "./TabController";
 
 import { props } from "../props";
 
 import { presente } from "@shared/themes/presente";
+import { TabController } from "./TabController";
 
 const story = {
   title: "navigation/Tab",
@@ -17,7 +17,6 @@ Default.args = {
   id: "thisIsAnId",
   disabled: false,
   label: "General Information",
-  selected: { control: null },
 };
 
 const theme = structuredClone(presente);

--- a/src/components/navigation/Tabs/Tab/stories/TabController.tsx
+++ b/src/components/navigation/Tabs/Tab/stories/TabController.tsx
@@ -1,23 +1,22 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Tab, ITabProps } from "../index";
 
 const TabController = (props: ITabProps) => {
   const { disabled = false } = props;
-  const [tabSelected, setTabSelected] = useState(false);
 
-  useEffect(() => {
-    if (disabled) {
-      setTabSelected(false);
-    }
-  }, [disabled]);
+  const [isSelected, setIsSelected] = useState(false);
 
-  const onClickTab = () => {
+  const handleTabClick = () => {
     if (!disabled) {
-      setTabSelected(true);
+      setIsSelected(true);
     }
   };
 
-  return <Tab {...props} selected={tabSelected} onClick={onClickTab} />;
+  return (
+    <div onClick={handleTabClick}>
+      <Tab {...props} selected={isSelected} />
+    </div>
+  );
 };
 
 export { TabController };

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -1,11 +1,9 @@
 import { useState } from "react";
 import { MdKeyboardArrowDown } from "react-icons/md";
-
 import { OptionItem } from "@inputs/Select/OptionItem";
 import { OptionList } from "@inputs/Select/OptionList";
 import { Stack } from "@layouts/Stack";
 import { Tab, ITabProps } from "@navigation/Tabs/Tab";
-
 import { Types } from "./props";
 import { StyledTabs, StyledIconWrapper } from "./styles";
 
@@ -22,6 +20,16 @@ const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
     selectedTab
   );
 
+  const handleTabClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const clickedTab = e.target as HTMLElement;
+    const tabId = clickedTab
+      .closest("[data-tab-id]")
+      ?.getAttribute("data-tab-id");
+    if (tabId && !clickedTab.hasAttribute("disabled")) {
+      onChange(tabId);
+    }
+  };
+
   if (type === "select") {
     const dropDownOptions = tabs.map((tab) => ({
       id: tab.id,
@@ -35,8 +43,9 @@ const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
         setDisplayList(false);
       }
     };
+
     return (
-      <>
+      <div>
         <StyledTabs type={type}>
           <Stack gap="8px">
             <StyledIconWrapper onClick={() => setDisplayList(!displayList)}>
@@ -46,7 +55,6 @@ const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
               key={selectedTab}
               selected={true}
               id={selectedTab}
-              onClick={() => onChange(selectedTab)}
               label={selectedTabLabel!}
             />
           </Stack>
@@ -62,12 +70,12 @@ const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
             ))}
           </OptionList>
         )}
-      </>
+      </div>
     );
   }
 
   return (
-    <StyledTabs>
+    <StyledTabs onClick={handleTabClick}>
       <Stack gap="24px">
         {tabs.map((tab) => (
           <Tab
@@ -75,7 +83,6 @@ const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
             disabled={tab.disabled}
             selected={tab.id === selectedTab}
             id={tab.id}
-            onClick={() => onChange(tab.id)}
             label={tab.label}
           />
         ))}


### PR DESCRIPTION
This pull request removes the `onClick` prop from the `<Tab />` component. Instead of relying on direct prop passing for click events, we have now transitioned to leveraging event bubbling, ensuring a cleaner and more scalable approach to event management.