### PR TITLE
`<Tabs />:` delete `selectedTabLabel` state 

### DIFF
--- a/src/components/navigation/Tabs/Tab/index.tsx
+++ b/src/components/navigation/Tabs/Tab/index.tsx
@@ -6,19 +6,13 @@ export interface ITabProps {
   id: string;
   disabled?: boolean;
   selected?: boolean;
-  onClick?: () => void;
 }
 
 const Tab = (props: ITabProps) => {
-  const { disabled = false, selected = false, id, onClick, label } = props;
+  const { disabled = false, selected = false, id, label } = props;
 
   return (
-    <StyledTab
-      onClick={disabled ? undefined : onClick}
-      disabled={disabled}
-      selected={selected}
-      id={id}
-    >
+    <StyledTab disabled={disabled} selected={selected} id={id}>
       <Text
         type="label"
         size="medium"

--- a/src/components/navigation/Tabs/Tab/stories/TabController.tsx
+++ b/src/components/navigation/Tabs/Tab/stories/TabController.tsx
@@ -13,11 +13,15 @@ const TabController = (props: ITabProps) => {
 
   const onClickTab = () => {
     if (!disabled) {
-      setTabSelected(true);
+      setTabSelected(!tabSelected);
     }
   };
 
-  return <Tab {...props} selected={tabSelected} onClick={onClickTab} />;
+  return (
+    <div onClick={onClickTab} tabIndex={0}>
+      <Tab {...props} selected={tabSelected} />
+    </div>
+  );
 };
 
 export { TabController };

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -19,21 +19,15 @@ export interface ITabsProps {
 const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
   const [displayList, setDisplayList] = useState(false);
 
+  const handleOptionClick = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const id = e.target.closest("li")?.getAttribute("id");
+    if (id) {
+      setDisplayList(false);
+      onChange(id);
+    }
+  };
+
   if (type === "select") {
-    const dropDownOptions = tabs.map((tab) => ({
-      id: tab.id,
-      label: tab.label,
-      disabled: tab.disabled,
-    }));
-
-    const handleOptionClick = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const id = e.target.closest("li")?.getAttribute("id");
-      if (id) {
-        setDisplayList(false);
-        onChange(id);
-      }
-    };
-
     return (
       <>
         <StyledTabs type={type}>
@@ -52,12 +46,8 @@ const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
         </StyledTabs>
         {displayList && (
           <OptionList onClick={handleOptionClick}>
-            {dropDownOptions.map((optionItem) => (
-              <OptionItem
-                key={optionItem.id}
-                id={optionItem.id}
-                label={optionItem.label}
-              />
+            {tabs.map((tab) => (
+              <OptionItem key={tab.id} id={tab.id} label={tab.label} />
             ))}
           </OptionList>
         )}

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import { MdKeyboardArrowDown } from "react-icons/md";
 
 import { OptionItem } from "@inputs/Select/OptionItem";
@@ -18,9 +18,6 @@ export interface ITabsProps {
 
 const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
   const [displayList, setDisplayList] = useState(false);
-  const [selectedTabLabel, setSelectedTabLabel] = useState<string | null>(
-    selectedTab
-  );
 
   if (type === "select") {
     const dropDownOptions = tabs.map((tab) => ({
@@ -30,11 +27,13 @@ const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
     }));
 
     const handleOptionClick = (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (e) {
-        setSelectedTabLabel(e.target.textContent);
+      const id = e.target.closest("li")?.getAttribute("id");
+      if (id) {
         setDisplayList(false);
+        onChange(id);
       }
     };
+
     return (
       <>
         <StyledTabs type={type}>
@@ -47,7 +46,7 @@ const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
               selected={true}
               id={selectedTab}
               onClick={() => onChange(selectedTab)}
-              label={selectedTabLabel!}
+              label={tabs.find((tab) => tab.id === selectedTab)?.label!}
             />
           </Stack>
         </StyledTabs>

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -7,7 +7,8 @@ import { Stack } from "@layouts/Stack";
 import { Tab, ITabProps } from "@navigation/Tabs/Tab";
 
 import { Types } from "./props";
-import { StyledTabs, StyledIconWrapper } from "./styles";
+import { StyledTabs } from "./styles";
+import { Icon } from "@data/Icon";
 
 export interface ITabsProps {
   tabs: ITabProps[];
@@ -32,9 +33,12 @@ const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
       <>
         <StyledTabs type={type}>
           <Stack gap="8px">
-            <StyledIconWrapper onClick={() => setDisplayList(!displayList)}>
-              <MdKeyboardArrowDown />
-            </StyledIconWrapper>
+            <Icon
+              spacing="wide"
+              onClick={() => setDisplayList(!displayList)}
+              appearance="dark"
+              icon={<MdKeyboardArrowDown />}
+            />
             <Tab
               key={selectedTab}
               selected={true}

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -1,11 +1,9 @@
 import { useState } from "react";
 import { MdKeyboardArrowDown } from "react-icons/md";
-
 import { OptionItem } from "@inputs/Select/OptionItem";
 import { OptionList } from "@inputs/Select/OptionList";
 import { Stack } from "@layouts/Stack";
 import { Tab, ITabProps } from "@navigation/Tabs/Tab";
-
 import { Types } from "./props";
 import { StyledTabs } from "./styles";
 import { Icon } from "@data/Icon";
@@ -28,6 +26,17 @@ const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
     }
   };
 
+  const handleTabClick = (e: React.MouseEvent) => {
+    const targetElement = e.target as Element;
+    const tabElement = targetElement.closest("[id]");
+    if (tabElement) {
+      const id = tabElement.getAttribute("id");
+      if (id && !tabElement.getAttribute("disabled")) {
+        onChange(id);
+      }
+    }
+  };
+
   if (type === "select") {
     return (
       <>
@@ -43,7 +52,6 @@ const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
               key={selectedTab}
               selected={true}
               id={selectedTab}
-              onClick={() => onChange(selectedTab)}
               label={tabs.find((tab) => tab.id === selectedTab)?.label!}
             />
           </Stack>
@@ -60,7 +68,7 @@ const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
   }
 
   return (
-    <StyledTabs>
+    <StyledTabs onClick={handleTabClick}>
       <Stack gap="24px">
         {tabs.map((tab) => (
           <Tab
@@ -68,7 +76,6 @@ const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
             disabled={tab.disabled}
             selected={tab.id === selectedTab}
             id={tab.id}
-            onClick={() => onChange(tab.id)}
             label={tab.label}
           />
         ))}

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { MdKeyboardArrowDown } from "react-icons/md";
 
 import { OptionItem } from "@inputs/Select/OptionItem";

--- a/src/components/navigation/Tabs/stories/TabsController.tsx
+++ b/src/components/navigation/Tabs/stories/TabsController.tsx
@@ -3,10 +3,11 @@ import { Tabs, ITabsProps } from "..";
 
 const TabsController = (props: ITabsProps) => {
   const { tabs, type, selectedTab } = props;
-  const [selectedTabController, setSelectedTab] = useState(selectedTab);
+  const [selectedTabController, setSelectedTabController] =
+    useState(selectedTab);
 
   const onChange = (tabId: string) => {
-    setSelectedTab(tabId);
+    setSelectedTabController(tabId);
   };
 
   return (

--- a/src/components/navigation/Tabs/styles.ts
+++ b/src/components/navigation/Tabs/styles.ts
@@ -36,18 +36,4 @@ const StyledTabs = styled.div`
   }
 `;
 
-const StyledIconWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: ${inube.spacing.s050} ${inube.spacing.s0};
-  & > svg {
-    width: 24px;
-    height: 24px;
-    color: ${({ theme }: IStyledTabsProps) =>
-      theme?.color?.text?.dark?.regular || inube.color.text.dark.regular};
-    cursor: pointer;
-  }
-`;
-
-export { StyledTabs, StyledIconWrapper };
+export { StyledTabs };


### PR DESCRIPTION
This pull request removes the `selectedTabLabel` state from the `<Tabs />` component. After a thorough analysis, it was determined that this state is no longer necessary given the current component architecture and can be managed through other means.