### PR TITLE
`<Tab />:` rename title of stories so it is rendered in storybook inside of Tabs

### DIFF
--- a/src/components/navigation/Tabs/Tab/stories/Tab.stories.tsx
+++ b/src/components/navigation/Tabs/Tab/stories/Tab.stories.tsx
@@ -7,7 +7,7 @@ import { props } from "../props";
 import { presente } from "@shared/themes/presente";
 
 const story = {
-  title: "navigation/Tab",
+  title: "navigation/Tabs/Tab",
   components: [Tab],
   argTypes: props,
 };


### PR DESCRIPTION
This PR addresses the enhancement to render story titles within tabs in our Storybook, ensuring a more organized and intuitive viewing experience for users.