### PR TITLE
Remove INavOneSectionProps & INavMultiSectionsProps in `<Nav />`

### DIFF
--- a/src/components/navigation/Nav/index.tsx
+++ b/src/components/navigation/Nav/index.tsx
@@ -53,10 +53,9 @@ const Links = (props: INavLinkProps) => {
   return <>{LinkElements} </>;
 };
 
-const MultiSections = ({
-  navigation,
-  sections,
-}: Pick<INavProps, "navigation"> & { sections: string[] }) => {
+const MultiSections = ({ navigation }: Pick<INavProps, "navigation">) => {
+  const sections = Object.keys(navigation.sections);
+
   return (
     <Stack direction="column" gap="26px">
       {sections.map((section) => (
@@ -85,19 +84,22 @@ const MultiSections = ({
   );
 };
 
-const OneSection = ({
-  navigation,
-  firstSection,
-}: Pick<INavProps, "navigation"> & { firstSection: string }) => {
+const OneSection = ({ navigation }: Pick<INavProps, "navigation">) => {
+  const section = Object.keys(navigation.sections)[0];
   return (
     <Stack direction="column">
       <Stack key="links" direction="column" justifyContent="center">
         <Stack direction="column">
-          {firstSection && (
-            <Links
-              section={Object.values(navigation.sections[firstSection].links)}
-            />
-          )}
+          <Text
+            padding="16px"
+            as="h2"
+            appearance="gray"
+            type="title"
+            size="small"
+          >
+            {navigation.sections[section].name}
+          </Text>
+          <Links section={Object.values(navigation.sections[section].links)} />
         </Stack>
       </Stack>
     </Stack>
@@ -106,10 +108,6 @@ const OneSection = ({
 
 const Nav = (props: INavProps) => {
   const { navigation, logoutTitle, logoutPath } = props;
-
-  const sections = Object.keys(navigation.sections);
-  const firstSection = sections[0];
-  const totalSections = Object.keys(navigation.sections).length;
 
   return (
     <StyledNav>
@@ -124,10 +122,10 @@ const Nav = (props: INavProps) => {
         >
           {navigation.title}
         </Text>
-        {totalSections > 1 ? (
-          <MultiSections navigation={navigation} sections={sections} />
+        {Object.keys(navigation.sections).length > 1 ? (
+          <MultiSections navigation={navigation} />
         ) : (
-          <OneSection navigation={navigation} firstSection={firstSection} />
+          <OneSection navigation={navigation} />
         )}
         <SeparatorLine />
         <NavLink

--- a/src/components/navigation/Nav/index.tsx
+++ b/src/components/navigation/Nav/index.tsx
@@ -1,21 +1,11 @@
 import { useLocation } from "react-router-dom";
 import { MdLogout } from "react-icons/md";
 
-import { NavLink } from "@navigation/NavLink";
-import { Stack } from "@layouts/Stack";
 import { Text } from "@data/Text";
+import { Stack } from "@layouts/Stack";
+import { NavLink } from "@navigation/NavLink";
 
 import { StyledNav, StyledFooter, SeparatorLine } from "./styles";
-
-export interface INavOneSectionProps {
-  navigation: INavigation;
-  firstSection: string;
-}
-
-export interface INavMultiSectionsProps {
-  navigation: INavigation;
-  sections: string[];
-}
 
 export interface INavLinkProps {
   section: ILink[];
@@ -63,7 +53,10 @@ const Links = (props: INavLinkProps) => {
   return <>{LinkElements} </>;
 };
 
-const MultiSections = ({ navigation, sections }: INavMultiSectionsProps) => {
+const MultiSections = ({
+  navigation,
+  sections,
+}: Pick<INavProps, "navigation"> & { sections: string[] }) => {
   return (
     <Stack direction="column" gap="26px">
       {sections.map((section) => (
@@ -92,7 +85,10 @@ const MultiSections = ({ navigation, sections }: INavMultiSectionsProps) => {
   );
 };
 
-const OneSection = ({ navigation, firstSection }: INavOneSectionProps) => {
+const OneSection = ({
+  navigation,
+  firstSection,
+}: Pick<INavProps, "navigation"> & { firstSection: string }) => {
   return (
     <Stack direction="column">
       <Stack key="links" direction="column" justifyContent="center">

--- a/src/components/navigation/Nav/index.tsx
+++ b/src/components/navigation/Nav/index.tsx
@@ -85,7 +85,8 @@ const MultiSections = ({ navigation }: Pick<INavProps, "navigation">) => {
 };
 
 const OneSection = ({ navigation }: Pick<INavProps, "navigation">) => {
-  const section = Object.keys(navigation.sections)[0];
+  const section = Object.keys(navigation.sections).join();
+
   return (
     <Stack direction="column">
       <Stack key="links" direction="column" justifyContent="center">


### PR DESCRIPTION
We are creating two “sub components” to control two different scenarios in a easier way. This means, having two markups blocks separate and then return one of them depending on the circumstances.

This doesn’t mean that we should increase the complexity of the interfaces. Each of those subcomponents should get the same information the parent receives through props and with that information extract the information needed.