### PR TITLE
`<BreadcrumbMenu />:` refactor to use new color tokens

### DIFF
--- a/src/components/navigation/Breadcrumbs/BreadcrumbMenu/stories/BreadcrumbMenu.stories.tsx
+++ b/src/components/navigation/Breadcrumbs/BreadcrumbMenu/stories/BreadcrumbMenu.stories.tsx
@@ -1,6 +1,8 @@
 import { BrowserRouter } from "react-router-dom";
 import { BreadcrumbMenu, IBreadcrumbMenuProps } from "..";
 import { props } from "../props";
+import { ThemeProvider } from "styled-components";
+import { presente } from "@src/shared/themes/presente";
 
 const story = {
   title: "navigation/Breadcrumbs/BreadcrumbMenu",
@@ -15,7 +17,7 @@ const story = {
   ],
 };
 
-export const Default = (args: IBreadcrumbMenuProps) => (
+const Default = (args: IBreadcrumbMenuProps) => (
   <div style={{ height: "100px", transform: "translateZ(0)" }}>
     <BreadcrumbMenu {...args} />
   </div>
@@ -36,4 +38,18 @@ Default.args = {
   ],
 };
 
+const theme = structuredClone(presente);
+
+const Themed = (args: IBreadcrumbMenuProps) => (
+  <ThemeProvider theme={theme}>
+    <Default {...args} />
+  </ThemeProvider>
+);
+
+Themed.args = {
+  ...Default.args,
+};
+
 export default story;
+
+export { Default, Themed };

--- a/src/components/navigation/Breadcrumbs/BreadcrumbMenu/styles.ts
+++ b/src/components/navigation/Breadcrumbs/BreadcrumbMenu/styles.ts
@@ -1,18 +1,29 @@
 import styled from "styled-components";
-import { colors } from "@shared/colors/colors";
+import { IBreadcrumbMenuProps } from ".";
+import { Themed } from "@shared/types/types";
+import { inube } from "@shared/tokens";
+
+interface IStyledBreadcrumbMenuProps extends IBreadcrumbMenuProps {
+  theme?: Themed;
+}
 
 const StyledBreadcrumbMenu = styled.div`
   position: absolute;
   width: fit-content;
   max-width: 160px;
   min-width: 100px;
-  box-shadow: 0px 2px 4px ${colors.ref.palette.neutralAlpha.n50A};
-  background-color: ${colors.ref.palette.neutral.n0};
+  box-shadow: 0px 2px 4px
+    ${({ theme }: IStyledBreadcrumbMenuProps) =>
+      theme?.color?.stroke?.light?.disabled ||
+      inube.color.stroke.light.disabled};
+  background-color: ${({ theme }: IStyledBreadcrumbMenuProps) =>
+    theme?.color?.stroke?.light?.hover || inube.color.stroke.light.hover};
   border-radius: 4px;
   a {
     &:hover {
       cursor: pointer;
-      background-color: ${colors.ref.palette.neutral.n30};
+      background-color: ${({ theme }: IStyledBreadcrumbMenuProps) =>
+        theme?.color?.surface?.dark?.clear || inube.color.surface.dark.clear};
     }
   }
 `;


### PR DESCRIPTION
As part of our ongoing effort to ensure visual consistency across our UI components, this PR refactors the `<BreadcrumbMenu />` component to incorporate the recently introduced color tokens in our design system.