### PR TITLE
`<BreadcrumbEllipsis />:` delete `defaultTypo` variable

### DIFF
--- a/src/components/navigation/Breadcrumbs/BreadcrumbEllipsis/index.tsx
+++ b/src/components/navigation/Breadcrumbs/BreadcrumbEllipsis/index.tsx
@@ -21,10 +21,8 @@ export interface IBreadcrumbEllipsisProps {
   routes: IRoute[];
 }
 
-const defaultTypo = "large";
-
 const BreadcrumbEllipsis = (props: IBreadcrumbEllipsisProps) => {
-  const { size = defaultTypo, routes } = props;
+  const { size = "large", routes } = props;
   const [showMenu, setShowMenu] = useState(false);
 
   const containerRef = useRef<HTMLDivElement | null>(null);


### PR DESCRIPTION
This PR focuses on simplifying the `<BreadcrumbEllipsis />` component by eliminating the `defaultTypo` variable. This change aims to streamline the codebase, reduce potential areas of confusion, and maintain adherence to best practices.