### PR TITLE
`<BreadcrumbEllipsis />:` delete `IRoute` interface

### DIFF
--- a/src/components/navigation/Breadcrumbs/BreadcrumbEllipsis/index.tsx
+++ b/src/components/navigation/Breadcrumbs/BreadcrumbEllipsis/index.tsx
@@ -9,16 +9,11 @@ import {
   StyledBreadcrumbEllipsis,
   StyledRelativeContainer,
 } from "./styles";
-
-export interface IRoute {
-  label: string;
-  path: string;
-  id: string;
-}
+import { IBreadcrumbItem } from "..";
 
 export interface IBreadcrumbEllipsisProps {
   size?: Typos;
-  routes: IRoute[];
+  routes: IBreadcrumbItem[];
 }
 
 const defaultTypo = "large";


### PR DESCRIPTION
In line with our effort to streamline and simplify our codebase, this PR removes the `IRoute` interface from the `<BreadcrumbEllipsis />` component. By doing so, we aim to reduce redundancy, improve code clarity, and foster better maintainability.