### PR TITLE
`<BreadcrumbMenu />:` delete `IBreadcrumbRoute` interface

### DIFF
--- a/src/components/navigation/Breadcrumbs/BreadcrumbMenu/index.tsx
+++ b/src/components/navigation/Breadcrumbs/BreadcrumbMenu/index.tsx
@@ -2,15 +2,10 @@ import { Stack } from "@layouts/Stack";
 
 import { BreadcrumbMenuLink } from "../BreadcrumbMenuLink";
 import { StyledBreadcrumbMenu } from "./styles";
-
-export interface IBreadcrumbRoute {
-  id: string;
-  path: string;
-  label: string;
-}
+import { IBreadcrumbItem } from "..";
 
 export interface IBreadcrumbMenuProps {
-  routes: IBreadcrumbRoute[];
+  routes: IBreadcrumbItem[];
 }
 
 const BreadcrumbMenu = (props: IBreadcrumbMenuProps) => {


### PR DESCRIPTION
In our pursuit to declutter and enhance the clarity of our codebase, this PR eliminates the `IBreadcrumbRoute` interface from the `<BreadcrumbMenu />` component. This initiative is aimed at reducing unnecessary complexity and ensuring ease of maintenance moving forward.