### PR TITLE
refactor to use new color tokens in `<<BreadcrumbLink />`

### DIFF
--- a/src/components/navigation/Breadcrumbs/BreadcrumbLink/styles.ts
+++ b/src/components/navigation/Breadcrumbs/BreadcrumbLink/styles.ts
@@ -1,7 +1,13 @@
 import styled from "styled-components";
-import { colors } from "@shared/colors/colors";
 import { Link } from "react-router-dom";
+import { Themed } from "@shared/types/types";
+import { colors } from "@shared/colors/colors";
+import { inube } from "@shared/tokens";
 import { IBreadcrumbLinkProps } from "./index";
+
+interface IStyledBreadcrumbLinkProps extends IBreadcrumbLinkProps {
+  themed: Themed;
+}
 
 const StyledContainerLink = styled.li`
   display: inline-block;
@@ -13,7 +19,8 @@ const StyledBreadcrumbLink = styled(Link)`
     props["data-is-active"] ? colors.sys.text.dark : colors.sys.text.secondary};
   &:hover {
     text-decoration: underline;
-    text-decoration-color: ${colors.sys.actions.secondary.stroke};
+    text-decoration-color: ${({ themed }: IStyledBreadcrumbLinkProps) =>
+      themed?.color?.text?.gray?.regular || inube.color.text.gray.regular};
   }
 `;
 


### PR DESCRIPTION
implement the use of the new color tokens, which allows for greater adaptability and standardization in the handling of component styles.