### PR TITLE
`<BreadcrumbMenuLink />:` refactor to use new color and spacing tokens

### DIFF
--- a/src/components/navigation/Breadcrumbs/BreadcrumbMenu/styles.ts
+++ b/src/components/navigation/Breadcrumbs/BreadcrumbMenu/styles.ts
@@ -12,13 +12,18 @@ const StyledBreadcrumbMenu = styled.div`
   width: fit-content;
   max-width: 160px;
   min-width: 100px;
-  box-shadow: 0px 2px 4px
-    ${({ theme }: IStyledBreadcrumbMenuProps) =>
-      theme?.color?.stroke?.light?.disabled ||
-      inube.color.stroke.light.disabled};
+  box-shadow: ${({ theme }: IStyledBreadcrumbMenuProps) =>
+    `${theme?.spacing?.s0 || inube.spacing.s0} 
+     ${theme?.spacing?.s025 || inube.spacing.s025} 
+     ${theme?.spacing?.s050 || inube.spacing.s050} 
+     ${
+       theme?.color?.stroke?.light?.disabled ||
+       inube.color.stroke.light.disabled
+     }`};
   background-color: ${({ theme }: IStyledBreadcrumbMenuProps) =>
     theme?.color?.stroke?.light?.hover || inube.color.stroke.light.hover};
-  border-radius: 4px;
+  border-radius: ${({ theme }: IStyledBreadcrumbMenuProps) =>
+    `${theme?.spacing?.s050 || inube.spacing.s050}`};
   a {
     &:hover {
       cursor: pointer;

--- a/src/components/navigation/Breadcrumbs/BreadcrumbMenuLink/stories/BreadcrumbMenuLink.stories.tsx
+++ b/src/components/navigation/Breadcrumbs/BreadcrumbMenuLink/stories/BreadcrumbMenuLink.stories.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter } from "react-router-dom";
-
+import { presente } from "@shared/themes/presente";
+import { ThemeProvider } from "styled-components";
 import { BreadcrumbMenuLink, IBreadcrumbMenuLinkProps } from "..";
 import { props } from "../props";
 
@@ -16,7 +17,7 @@ const story = {
   ],
 };
 
-export const Default = (args: IBreadcrumbMenuLinkProps) => (
+const Default = (args: IBreadcrumbMenuLinkProps) => (
   <BreadcrumbMenuLink {...args} />
 );
 Default.args = {
@@ -26,4 +27,18 @@ Default.args = {
   typo: "large",
 };
 
+const theme = structuredClone(presente);
+
+const Themed = (args: IBreadcrumbMenuLinkProps) => (
+  <ThemeProvider theme={theme}>
+    <Default {...args} />
+  </ThemeProvider>
+);
+
+Themed.args = {
+  ...Default.args,
+};
+
 export default story;
+
+export { Default, Themed };

--- a/src/components/navigation/Breadcrumbs/BreadcrumbMenuLink/styles.ts
+++ b/src/components/navigation/Breadcrumbs/BreadcrumbMenuLink/styles.ts
@@ -1,10 +1,11 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
-import { IBreadcrumbMenuLinkProps } from ".";
+
 import { Themed } from "@shared/types/types";
 import { inube } from "@shared/tokens";
+import { IRoute } from "../props";
 
-interface IStyledBreadcrumbMenuLink extends IBreadcrumbMenuLinkProps {
+interface IStyledBreadcrumbMenuLink extends IRoute {
   theme?: Themed;
 }
 

--- a/src/components/navigation/Breadcrumbs/BreadcrumbMenuLink/styles.ts
+++ b/src/components/navigation/Breadcrumbs/BreadcrumbMenuLink/styles.ts
@@ -1,22 +1,33 @@
 import styled from "styled-components";
-import { colors } from "@shared/colors/colors";
 import { Link } from "react-router-dom";
+import { IBreadcrumbMenuLinkProps } from ".";
+import { Themed } from "@shared/types/types";
+import { inube } from "@shared/tokens";
+
+interface IStyledBreadcrumbMenuLink extends IBreadcrumbMenuLinkProps {
+  theme?: Themed;
+}
 
 const StyledContainerLink = styled.li`
   display: inline-block;
   > * {
     height: 32px;
     > label {
-      color: ${colors.sys.text.secondary};
+      color: ${({ theme }: IStyledBreadcrumbMenuLink) =>
+        theme?.color?.text?.gray?.regular || inube.color.text.gray.regular};
       cursor: pointer;
-      padding: 8px 12px 8px 12px;
+      padding: ${({ theme }: IStyledBreadcrumbMenuLink) =>
+        `${theme?.spacing?.s100 || inube.spacing.s100} ${
+          theme?.spacing?.s150 || inube.spacing.s150
+        }`};
     }
   }
 `;
 
 const StyledBreadcrumbMenuLink = styled(Link)`
   text-decoration: none;
-  color: ${colors.sys.text.secondary};
+  color: ${({ theme }: IStyledBreadcrumbMenuLink) =>
+    theme?.color?.text?.gray?.regular || inube.color.text.gray.regular};
 `;
 
 export { StyledContainerLink, StyledBreadcrumbMenuLink };

--- a/src/components/navigation/Breadcrumbs/index.tsx
+++ b/src/components/navigation/Breadcrumbs/index.tsx
@@ -55,7 +55,7 @@ const Breadcrumbs = (props: IBreadcrumbsProps) => {
 
   return (
     <StyledBreadcrumbs>
-      {crumbs.map(({ path, label, isActive }) => (
+      {crumbs.map(({ path, label }) => (
         <BreadcrumbLink
           key={path}
           path={path}

--- a/src/components/navigation/Breadcrumbs/styles.ts
+++ b/src/components/navigation/Breadcrumbs/styles.ts
@@ -3,6 +3,9 @@ import styled from "styled-components";
 const StyledBreadcrumbs = styled.ul`
   padding: 0;
   margin: 0;
+  & > li {
+    display: inline-flex;
+  }
   & > li:not(:last-child)::after,
   & > div:not(:last-child)::after {
     pointer-events: none;


### PR DESCRIPTION
In our continuous effort to maintain visual consistency and adherence to our design system, this PR refactors the `<BreadcrumbMenuLink />` component to incorporate the latest color and spacing tokens.