### PR TITLE
Rename the `handleClick` prop to `onClick` in `<BreadcrumbLink />`

### DIFF
--- a/src/components/navigation/Breadcrumbs/BreadcrumbLink/index.tsx
+++ b/src/components/navigation/Breadcrumbs/BreadcrumbLink/index.tsx
@@ -9,20 +9,20 @@ export interface IBreadcrumbLinkProps {
   path: string;
   id: string;
   typo?: Typos;
-  handleClick?: () => void;
+  onClick?: () => void;
 }
 
 const BreadcrumbLink = (props: IBreadcrumbLinkProps) => {
-  const { label, path, id, typo = "large", handleClick } = props;
+  const { label, path, id, typo = "large", onClick } = props;
   const [appearance, setAppearance] = useState<"gray" | "dark">("gray");
 
-  const onClick = () => {
+  const handleClick = () => {
     setAppearance("dark");
-    handleClick && handleClick();
+    onClick && onClick();
   };
 
   return (
-    <StyledContainerLink id={id} onClick={onClick}>
+    <StyledContainerLink id={id} onClick={handleClick}>
       <Text type="label" size={typo} appearance="gray">
         <StyledBreadcrumbLink to={path}>
           <Text type="label" size="large" appearance={appearance}>

--- a/src/components/navigation/Breadcrumbs/BreadcrumbLink/props.ts
+++ b/src/components/navigation/Breadcrumbs/BreadcrumbLink/props.ts
@@ -11,7 +11,6 @@ const parameters = {
 
 const props = {
   id: {
-    control: { type: "text" },
     description: "shall be the id for the text",
   },
 

--- a/src/components/navigation/Breadcrumbs/BreadcrumbLink/props.ts
+++ b/src/components/navigation/Breadcrumbs/BreadcrumbLink/props.ts
@@ -14,16 +14,8 @@ const props = {
     control: { type: "text" },
     description: "shall be the id for the text",
   },
-  isActive: {
-    options: [true, false],
-    control: { type: "boolean" },
-    description:
-      "if the switch is disabled or not. This prevents any interaction.",
-    table: {
-      defaultValue: { summary: "false" },
-    },
-  },
-  handleClick: {
+
+  onClick: {
     options: ["logState"],
     control: { type: "func" },
     description: "shall be determine the behavior of the click event",

--- a/src/components/navigation/Breadcrumbs/BreadcrumbLink/stories/BreadcrumbLink.stories.tsx
+++ b/src/components/navigation/Breadcrumbs/BreadcrumbLink/stories/BreadcrumbLink.stories.tsx
@@ -24,7 +24,7 @@ Default.args = {
   path: "/privileges",
   id: "privileges",
   size: "large",
-  onclick: action("onClick"),
+  onClick: action("onClick"),
 };
 
 export default story;

--- a/src/components/navigation/Breadcrumbs/BreadcrumbLink/stories/BreadcrumbLink.stories.tsx
+++ b/src/components/navigation/Breadcrumbs/BreadcrumbLink/stories/BreadcrumbLink.stories.tsx
@@ -24,7 +24,7 @@ Default.args = {
   path: "/privileges",
   id: "privileges",
   size: "large",
-  handleClick: action("onClick"),
+  onclick: action("onClick"),
 };
 
 export default story;

--- a/src/components/navigation/Breadcrumbs/index.tsx
+++ b/src/components/navigation/Breadcrumbs/index.tsx
@@ -55,7 +55,7 @@ const Breadcrumbs = (props: IBreadcrumbsProps) => {
 
   return (
     <StyledBreadcrumbs>
-      {crumbs.map(({ path, label, isActive }) => (
+      {crumbs.map(({ path, label }) => (
         <BreadcrumbLink
           key={path}
           path={path}


### PR DESCRIPTION
The name of the `handleClick`` prop is **changed** to `onClick to be more consistent with the functionality of the prop.