### PR TITLE
Remove aria-label attribute in `<Pagination />`

### DIFF
--- a/src/components/data/Table/Pagination/index.tsx
+++ b/src/components/data/Table/Pagination/index.tsx
@@ -31,11 +31,7 @@ const Pagination = (props: IPaginationProps) => {
   } = props;
 
   return (
-    <Stack
-      justifyContent="flex-end"
-      alignItems="center"
-      aria-label="Pagination"
-    >
+    <Stack justifyContent="flex-end" alignItems="center">
       <Text type="body" size="small" padding="16px 0px" appearance="dark">
         {firstEntryInPage + 1} - {lastEntryInPage} of {totalRecords}
       </Text>


### PR DESCRIPTION
feed accessibility attributes that are not needed at the moment, avoiding unnecessary code