### PR TITLE
`<Table />:` define only the interface for `Table` not for `TableUI`

### DIFF
--- a/src/components/data/Table/index.tsx
+++ b/src/components/data/Table/index.tsx
@@ -1,10 +1,9 @@
 import { useMemo, useState } from "react";
-
 import { Pagination } from "./Pagination";
-import { IAction, IBreakpoint, TableUI } from "./interface";
 import { Stack } from "@layouts/Stack";
-import { ITitle } from "./interface";
 import { IEntry } from "./DisplayEntry";
+import { IAction, IBreakpoint, ITitle } from "./props";
+import { TableUI } from "./interface";
 
 export interface ITableProps {
   id: string;

--- a/src/components/data/Table/index.tsx
+++ b/src/components/data/Table/index.tsx
@@ -15,7 +15,6 @@ export interface ITableProps {
   breakpoints?: IBreakpoint[];
   content?: React.ReactElement;
   infoTitle?: string;
-  actionsTitle?: string;
 }
 
 const Table = (props: ITableProps) => {
@@ -29,7 +28,6 @@ const Table = (props: ITableProps) => {
     breakpoints,
     content,
     infoTitle,
-    actionsTitle,
   } = props;
 
   const filteredEntries = useMemo(() => {
@@ -95,7 +93,6 @@ const Table = (props: ITableProps) => {
           breakpoints={breakpoints!}
           content={content}
           infoTitle={infoTitle!}
-          actionsTitle={actionsTitle!}
         />
         {filteredEntries.length > pageLength && (
           <Pagination

--- a/src/components/data/Table/interface.tsx
+++ b/src/components/data/Table/interface.tsx
@@ -15,33 +15,8 @@ import {
   StyledThTitle,
   StyledTd,
 } from "./styles";
-
-export interface ITitle {
-  id: string;
-  titleName: string;
-  priority: number;
-}
-
-export interface IAction {
-  id: string;
-  actionName: string;
-  content: (entry: any) => JSX.Element;
-}
-
-export interface IBreakpoint {
-  breakpoint: string;
-  totalColumns: number;
-}
-
-export interface ITableUIProps {
-  titles: ITitle[];
-  actions: IAction[];
-  entries: IEntry[];
-  breakpoints: IBreakpoint[];
-  content?: React.ReactElement;
-  infoTitle: string;
-  actionsTitle: string;
-}
+import { ITableProps } from ".";
+import { IAction, IBreakpoint, ITitle } from "./props";
 
 function findCurrentMediaQuery(currentMediaQuery: Record<string, boolean>) {
   const lastIndexMedia = Object.values(currentMediaQuery).lastIndexOf(true);
@@ -104,20 +79,20 @@ function ShowAction(
   );
 }
 
-const TableUI = (props: ITableUIProps) => {
+const TableUI = (props: Omit<ITableProps, "id">) => {
   const { titles, actions, entries, breakpoints, content } = props;
 
   const mediaActionOpen = useMediaQuery("(max-width: 850px)");
 
   const queriesArray = useMemo(
-    () => breakpoints.map((breakpoint) => breakpoint.breakpoint),
+    () => breakpoints!.map((breakpoint) => breakpoint.breakpoint),
     [breakpoints]
   );
 
   const media = useMediaQueries(queriesArray);
 
   const TitleColumns = useMemo(
-    () => totalTitleColumns(titles, breakpoints, media),
+    () => totalTitleColumns(titles, breakpoints!, media),
     [titles, breakpoints, media]
   );
 

--- a/src/components/data/Table/props.ts
+++ b/src/components/data/Table/props.ts
@@ -1,3 +1,20 @@
+export interface ITitle {
+  id: string;
+  titleName: string;
+  priority: number;
+}
+
+export interface IAction {
+  id: string;
+  actionName: string;
+  content: (entry: any) => JSX.Element;
+}
+
+export interface IBreakpoint {
+  breakpoint: string;
+  totalColumns: number;
+}
+
 const parameters = {
   docs: {
     description: {

--- a/src/components/data/Table/stories/Table.Paginations.stories.tsx
+++ b/src/components/data/Table/stories/Table.Paginations.stories.tsx
@@ -232,7 +232,6 @@ Paginations.args = {
   breakpoints: breakPointsMuck,
   modalTitle: "Form",
   infoTitle: "Information",
-  actionsTitle: "Actions",
 };
 
 export default story;

--- a/src/components/data/Table/stories/Table.stories.tsx
+++ b/src/components/data/Table/stories/Table.stories.tsx
@@ -81,7 +81,6 @@ Default.args = {
   breakpoints: breakPointsMuck,
   modalTitle: "Form",
   infoTitle: "Information",
-  actionsTitle: "Actions",
   content: <LoremModal />,
 };
 


### PR DESCRIPTION
Aiming to streamline our codebase and enhance readability, this PR focuses on refining our interface definitions for the `<Table />` component. We are opting to define an interface exclusively for `<Table />` while opting not to define one for `<TableUI />`, promoting a clean and maintainable approach towards type definition in our components.