### PR TITLE
`Refactor:` Update and Remove Props in `<Grid />` Component

### DIFF
--- a/src/components/layouts/Grid/index.tsx
+++ b/src/components/layouts/Grid/index.tsx
@@ -5,7 +5,6 @@ import {
   Height,
   JustifyContent,
   JustifyItems,
-  TemplateAreas,
   Width,
 } from "./props";
 import { StyledGrid } from "./styles";
@@ -13,7 +12,6 @@ import { StyledGrid } from "./styles";
 export interface IGridProps {
   templateColumns?: string;
   templateRows?: string;
-  templateAreas?: TemplateAreas;
   gap?: string;
   justifyItems?: JustifyItems;
   alignItems?: AlignItems;
@@ -33,14 +31,13 @@ const Grid = (props: IGridProps) => {
   const {
     templateColumns = "auto",
     templateRows = "auto",
-    templateAreas = "none",
     gap = "s0",
-    justifyItems = "start",
-    alignItems = "start",
+    justifyItems = "stretch",
+    alignItems = "stretch",
     justifyContent = "start",
     alignContent = "start",
-    autoColumns = "auto",
-    autoRows = "row",
+    autoColumns = "0px",
+    autoRows = "0px",
     autoFlow = "row",
     margin = "s0",
     padding = "s0",
@@ -53,7 +50,6 @@ const Grid = (props: IGridProps) => {
     <StyledGrid
       templateColumns={templateColumns}
       templateRows={templateRows}
-      templateAreas={templateAreas}
       gap={gap}
       justifyItems={justifyItems}
       alignItems={alignItems}

--- a/src/components/layouts/Grid/props.ts
+++ b/src/components/layouts/Grid/props.ts
@@ -1,6 +1,3 @@
-export const templateAreasProperties = ["none", "header main footer"] as const;
-export type TemplateAreas = typeof templateAreasProperties[number];
-
 export const justifyItemsProperties = [
   "center",
   "start",
@@ -131,16 +128,6 @@ export const props = {
     description: "Defines the size and layout of the rows in the grid.",
     table: {
       defaultValue: { summary: "auto" },
-    },
-  },
-
-  templateAreas: {
-    options: templateAreasProperties,
-    control: { type: "select" },
-    description:
-      "Defines the overall layout of a grid in terms of named areas.",
-    table: {
-      defaultValue: { summary: "none" },
     },
   },
 

--- a/src/components/layouts/Grid/stories/Grid.stories.tsx
+++ b/src/components/layouts/Grid/stories/Grid.stories.tsx
@@ -20,7 +20,6 @@ Default.args = {
   templateColumns: "repeat(3, 1fr)",
   gap: "s350",
   templateRows: "auto",
-  templateAreas: "none",
   justifyItems: "start",
   alignItems: "start",
   justifyContent: "flex-start",

--- a/src/components/layouts/Grid/styles.ts
+++ b/src/components/layouts/Grid/styles.ts
@@ -7,7 +7,6 @@ const StyledGrid = styled.div`
   grid-template-columns: ${({ templateColumns }: IGridProps) =>
     templateColumns};
   grid-template-rows: ${({ templateRows }: IGridProps) => templateRows};
-  grid-template-areas: ${({ templateAreas }: IGridProps) => templateAreas};
   gap: ${({ gap }: IGridProps) => {
     const gapValue = gap!.split(" ");
     return gapValue


### PR DESCRIPTION
This PR focuses on a series of prop updates and removals in the `<Grid />` component, aimed at simplifying its API and ensuring default values are in alignment with expected layout and design patterns.

Changes:

- Removed the `templateAreas` prop to streamline grid definition.
- Established "stretch" as the default value for `justifyItems`.
- Set "stretch" as the default value for alignItems.
- Designated "0px" as the default value for `autoColumns`.
- Implemented "0px" as the default value for `autoRows`.