### PR TITLE
Move the dependent interfaces to index.tsx in `<Table/>`

### DIFF
--- a/src/components/data/Table/DisplayActions/index.tsx
+++ b/src/components/data/Table/DisplayActions/index.tsx
@@ -6,11 +6,11 @@ export interface IEntry {
   [key: string]: string;
 }
 
-export interface IDisplayEntryProps {
+export interface IDisplayActionsProps {
   content?: React.ReactElement;
 }
 
-const DisplayEntry = ({ content }: IDisplayEntryProps) => {
+const DisplayActions = ({ content }: IDisplayActionsProps) => {
   const [showModal, setShowModal] = useState(false);
 
   const handleToggleModal = () => {
@@ -25,4 +25,4 @@ const DisplayEntry = ({ content }: IDisplayEntryProps) => {
   );
 };
 
-export { DisplayEntry };
+export { DisplayActions };

--- a/src/components/data/Table/DisplayActions/index.tsx
+++ b/src/components/data/Table/DisplayActions/index.tsx
@@ -1,16 +1,8 @@
 import { useState } from "react";
 import { MdOpenInNew } from "react-icons/md";
+import { ITableProps } from "..";
 
-export interface IActions {
-  id: string;
-  [key: string]: string;
-}
-
-export interface IDisplayActionsProps {
-  content?: React.ReactElement;
-}
-
-const DisplayActions = ({ content }: IDisplayActionsProps) => {
+const DisplayActions = ({ content }: Pick<ITableProps, "content">) => {
   const [showModal, setShowModal] = useState(false);
 
   const handleToggleModal = () => {

--- a/src/components/data/Table/DisplayActions/index.tsx
+++ b/src/components/data/Table/DisplayActions/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { MdOpenInNew } from "react-icons/md";
 
-export interface IEntry {
+export interface IActions {
   id: string;
   [key: string]: string;
 }

--- a/src/components/data/Table/index.tsx
+++ b/src/components/data/Table/index.tsx
@@ -1,10 +1,38 @@
 import { useMemo, useState } from "react";
 
 import { Pagination } from "./Pagination";
-import { IAction, IBreakpoint, TableUI } from "./interface";
+
 import { Stack } from "@layouts/Stack";
-import { ITitle } from "./interface";
-import { IEntry } from "./DisplayEntry";
+
+import { IEntry } from "./DisplayActions";
+import { TableUI } from "./interface";
+
+export interface ITitle {
+  id: string;
+  titleName: string;
+  priority: number;
+}
+
+export interface IAction {
+  id: string;
+  actionName: string;
+  content: (entry: IEntry) => JSX.Element;
+}
+
+export interface IBreakpoint {
+  breakpoint: string;
+  totalColumns: number;
+}
+
+export interface ITableUIProps {
+  titles: ITitle[];
+  actions: IAction[];
+  entries: IEntry[];
+  breakpoints: IBreakpoint[];
+  content?: React.ReactElement;
+  infoTitle: string;
+  actionsTitle: string;
+}
 
 export interface ITableProps {
   id: string;

--- a/src/components/data/Table/index.tsx
+++ b/src/components/data/Table/index.tsx
@@ -4,8 +4,12 @@ import { Pagination } from "./Pagination";
 
 import { Stack } from "@layouts/Stack";
 
-import { IActions } from "./DisplayActions";
 import { TableUI } from "./interface";
+
+export interface IActions {
+  id: string;
+  [key: string]: string;
+}
 
 export interface ITitle {
   id: string;

--- a/src/components/data/Table/index.tsx
+++ b/src/components/data/Table/index.tsx
@@ -4,7 +4,7 @@ import { Pagination } from "./Pagination";
 
 import { Stack } from "@layouts/Stack";
 
-import { IEntry } from "./DisplayActions";
+import { IActions } from "./DisplayActions";
 import { TableUI } from "./interface";
 
 export interface ITitle {
@@ -16,7 +16,7 @@ export interface ITitle {
 export interface IAction {
   id: string;
   actionName: string;
-  content: (entry: IEntry) => JSX.Element;
+  content: (entry: IActions) => JSX.Element;
 }
 
 export interface IBreakpoint {
@@ -27,7 +27,7 @@ export interface IBreakpoint {
 export interface ITableUIProps {
   titles: ITitle[];
   actions: IAction[];
-  entries: IEntry[];
+  entries: IActions[];
   breakpoints: IBreakpoint[];
   content?: React.ReactElement;
   infoTitle: string;
@@ -38,7 +38,7 @@ export interface ITableProps {
   id: string;
   titles: ITitle[];
   actions: IAction[];
-  entries: IEntry[];
+  entries: IActions[];
   filter?: string;
   pageLength?: number;
   breakpoints?: IBreakpoint[];

--- a/src/components/data/Table/interface.tsx
+++ b/src/components/data/Table/interface.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from "react";
-import { DisplayEntry } from "./DisplayEntry";
 
-import { useMediaQueries } from "@hooks/useMediaQueries";
-import { useMediaQuery } from "@hooks/useMediaQuery";
 import { Text } from "@data/Text";
-import { IEntry } from "./DisplayEntry";
+import { useMediaQuery } from "@hooks/useMediaQuery";
+import { useMediaQueries } from "@hooks/useMediaQueries";
 
+import { DisplayActions, IEntry } from "./DisplayActions";
+import { IAction, IBreakpoint, ITableUIProps, ITitle } from ".";
 import {
   StyledTable,
   StyledThead,
@@ -15,33 +15,6 @@ import {
   StyledThTitle,
   StyledTd,
 } from "./styles";
-
-export interface ITitle {
-  id: string;
-  titleName: string;
-  priority: number;
-}
-
-export interface IAction {
-  id: string;
-  actionName: string;
-  content: (entry: any) => JSX.Element;
-}
-
-export interface IBreakpoint {
-  breakpoint: string;
-  totalColumns: number;
-}
-
-export interface ITableUIProps {
-  titles: ITitle[];
-  actions: IAction[];
-  entries: IEntry[];
-  breakpoints: IBreakpoint[];
-  content?: React.ReactElement;
-  infoTitle: string;
-  actionsTitle: string;
-}
 
 function findCurrentMediaQuery(currentMediaQuery: Record<string, boolean>) {
   const lastIndexMedia = Object.values(currentMediaQuery).lastIndexOf(true);
@@ -99,7 +72,7 @@ function ShowAction(
     </>
   ) : (
     <StyledTd>
-      <DisplayEntry content={content} />
+      <DisplayActions content={content} />
     </StyledTd>
   );
 }

--- a/src/components/data/Table/interface.tsx
+++ b/src/components/data/Table/interface.tsx
@@ -4,7 +4,7 @@ import { Text } from "@data/Text";
 import { useMediaQuery } from "@hooks/useMediaQuery";
 import { useMediaQueries } from "@hooks/useMediaQueries";
 
-import { DisplayActions, IEntry } from "./DisplayActions";
+import { DisplayActions, IActions } from "./DisplayActions";
 import { IAction, IBreakpoint, ITableUIProps, ITitle } from ".";
 import {
   StyledTable,
@@ -58,7 +58,7 @@ function showActionTitle(actionTitle: IAction[], mediaQuery: boolean) {
 
 function ShowAction(
   actionContent: IAction[],
-  entry: IEntry,
+  entry: IActions,
   mediaQuery: boolean,
   content: React.ReactElement
 ) {

--- a/src/components/data/Table/interface.tsx
+++ b/src/components/data/Table/interface.tsx
@@ -4,8 +4,8 @@ import { Text } from "@data/Text";
 import { useMediaQuery } from "@hooks/useMediaQuery";
 import { useMediaQueries } from "@hooks/useMediaQueries";
 
-import { DisplayActions, IActions } from "./DisplayActions";
-import { IAction, IBreakpoint, ITableUIProps, ITitle } from ".";
+import { DisplayActions } from "./DisplayActions";
+import { IAction, IActions, IBreakpoint, ITableUIProps, ITitle } from ".";
 import {
   StyledTable,
   StyledThead,

--- a/src/components/data/Table/interface.tsx
+++ b/src/components/data/Table/interface.tsx
@@ -16,7 +16,7 @@ import {
   StyledTd,
 } from "./styles";
 
-function findCurrentMediaQuery(currentMediaQuery: Record<string, boolean>) {
+function findCurrentMediaQuery(currentMediaQuery: { [key: string]: boolean }) {
   const lastIndexMedia = Object.values(currentMediaQuery).lastIndexOf(true);
   return lastIndexMedia !== -1 ? lastIndexMedia : 0;
 }


### PR DESCRIPTION
The typing interfaces are moved to the index.tsx file, from `<Table />` , 

The `<DiplayEntries />` component is renamed `<DiplayActions />`, this in order to sever the relationship of actions and entries, as this is data that a third party passes to the component. 