### PR TITLE
Split onStepChange in two in `<Assisted />`

### DIFF
--- a/src/components/feedback/Assisted/index.tsx
+++ b/src/components/feedback/Assisted/index.tsx
@@ -28,7 +28,8 @@ interface IProgressBarProps {
 export interface IAssistedProps {
   steps: IStep[];
   currentStepId: IStep["id"];
-  onStepChange: (id: IStep["id"]) => void;
+  handlePrev: (id: IStep["id"]) => void;
+  handleNex: (id: IStep["id"]) => void;
   sequential?: boolean;
   completedStepIds?: number[];
   titleButtonBefore?: string;
@@ -36,16 +37,23 @@ export interface IAssistedProps {
   size?: "medium" | "large";
 }
 
-const handleStepChange = (
+const prevStepChanege = (
   currentStep: IStep["id"],
   steps: IAssistedProps["steps"],
-  onStepChange: IAssistedProps["onStepChange"],
-  direction: "previous" | "next"
+  handlePrev: IAssistedProps["handlePrev"]
 ) => {
-  if (direction === "previous" && currentStep > 0) {
-    onStepChange(steps?.[currentStep - 1]?.id);
-  } else if (direction === "next" && currentStep < steps.length - 1) {
-    onStepChange(steps?.[currentStep + 1]?.id);
+  if (currentStep > 0) {
+    handlePrev(steps?.[currentStep - 1]?.id);
+  }
+};
+
+const nextStepChanege = (
+  currentStep: IStep["id"],
+  steps: IAssistedProps["steps"],
+  handleNex: IAssistedProps["handleNex"]
+) => {
+  if (currentStep < steps.length - 1) {
+    handleNex(steps?.[currentStep + 1]?.id);
   }
 };
 
@@ -66,7 +74,8 @@ const Assisted = (props: IAssistedProps) => {
   const {
     steps,
     currentStepId,
-    onStepChange,
+    handlePrev,
+    handleNex,
     size = "large",
     sequential = false,
     titleButtonBefore,
@@ -90,13 +99,7 @@ const Assisted = (props: IAssistedProps) => {
             onClick={
               sequential || !currentStepIndex
                 ? undefined
-                : () =>
-                    handleStepChange(
-                      currentStepIndex,
-                      steps,
-                      onStepChange,
-                      "previous"
-                    )
+                : () => prevStepChanege(currentStepIndex, steps, handlePrev)
             }
             appearance={!currentStepIndex ? "gray" : "primary"}
           >
@@ -116,12 +119,7 @@ const Assisted = (props: IAssistedProps) => {
               icon={<MdArrowBack style={{ padding: "2px 0px" }} />}
               size="20px"
               onClick={() =>
-                handleStepChange(
-                  currentStepIndex,
-                  steps,
-                  onStepChange,
-                  "previous"
-                )
+                prevStepChanege(currentStepIndex, steps, handlePrev)
               }
             />
           )}
@@ -148,7 +146,7 @@ const Assisted = (props: IAssistedProps) => {
               icon={<MdArrowForward style={{ padding: "0px 2px" }} />}
               size="20px"
               onClick={() =>
-                handleStepChange(currentStepIndex, steps, onStepChange, "next")
+                nextStepChanege(currentStepIndex, steps, handleNex)
               }
             />
           )}
@@ -183,13 +181,7 @@ const Assisted = (props: IAssistedProps) => {
             onClick={
               sequential
                 ? undefined
-                : () =>
-                    handleStepChange(
-                      currentStepIndex,
-                      steps,
-                      onStepChange,
-                      "next"
-                    )
+                : () => nextStepChanege(currentStepIndex, steps, handleNex)
             }
           >
             {titleButtonAfter}

--- a/src/components/feedback/Assisted/index.tsx
+++ b/src/components/feedback/Assisted/index.tsx
@@ -37,7 +37,7 @@ export interface IAssistedProps {
   size?: "medium" | "large";
 }
 
-const prevStepChanege = (
+const onPrev = (
   currentStep: IStep["id"],
   steps: IAssistedProps["steps"],
   handlePrev: IAssistedProps["handlePrev"]
@@ -47,7 +47,7 @@ const prevStepChanege = (
   }
 };
 
-const nextStepChanege = (
+const onNext = (
   currentStep: IStep["id"],
   steps: IAssistedProps["steps"],
   handleNex: IAssistedProps["handleNex"]
@@ -99,7 +99,7 @@ const Assisted = (props: IAssistedProps) => {
             onClick={
               sequential || !currentStepIndex
                 ? undefined
-                : () => prevStepChanege(currentStepIndex, steps, handlePrev)
+                : () => onPrev(currentStepIndex, steps, handlePrev)
             }
             appearance={!currentStepIndex ? "gray" : "primary"}
           >
@@ -118,9 +118,7 @@ const Assisted = (props: IAssistedProps) => {
               appearance={!currentStepIndex ? "gray" : "primary"}
               icon={<MdArrowBack style={{ padding: "2px 0px" }} />}
               size="20px"
-              onClick={() =>
-                prevStepChanege(currentStepIndex, steps, handlePrev)
-              }
+              onClick={() => onPrev(currentStepIndex, steps, handlePrev)}
             />
           )}
           <StyledStepIndicator>
@@ -145,9 +143,7 @@ const Assisted = (props: IAssistedProps) => {
               appearance="primary"
               icon={<MdArrowForward style={{ padding: "0px 2px" }} />}
               size="20px"
-              onClick={() =>
-                nextStepChanege(currentStepIndex, steps, handleNex)
-              }
+              onClick={() => onNext(currentStepIndex, steps, handleNex)}
             />
           )}
         </Stack>
@@ -181,7 +177,7 @@ const Assisted = (props: IAssistedProps) => {
             onClick={
               sequential
                 ? undefined
-                : () => nextStepChanege(currentStepIndex, steps, handleNex)
+                : () => onNext(currentStepIndex, steps, handleNex)
             }
           >
             {titleButtonAfter}

--- a/src/components/feedback/Assisted/props.ts
+++ b/src/components/feedback/Assisted/props.ts
@@ -10,7 +10,7 @@ const parameters = {
 const props = {
   steps: {
     description:
-      "(Array of Objects): An array to represent each step in the journey. Each object in the array represents a step and should have the following structure: id, label, description (Optional).",
+      "(Array of objects): An array to represent each step of the journey. Each object in the array represents one step and must have the following structure: id, label, description (Optional). The order of the steps depends on the order in the array,",
   },
   currentStepId: {
     description:

--- a/src/components/feedback/Assisted/stories/Assisted.Controller.tsx
+++ b/src/components/feedback/Assisted/stories/Assisted.Controller.tsx
@@ -6,7 +6,11 @@ const AssistedController = (props: IAssistedProps) => {
 
   const [currentStep, setCurrentStep] = useState(currentStepId);
 
-  const onStepChange = (id: number) => {
+  const handlePrev = (id: number) => {
+    setCurrentStep(id);
+  };
+
+  const handleNext = (id: number) => {
     setCurrentStep(id);
   };
 
@@ -15,7 +19,8 @@ const AssistedController = (props: IAssistedProps) => {
       {...props}
       steps={steps}
       currentStepId={currentStep}
-      onStepChange={onStepChange}
+      handlePrev={handlePrev}
+      handleNex={handleNext}
     />
   );
 };


### PR DESCRIPTION
The parent component may need to do very different things depending on whether the user clicked on the Next button or the Prev button.

So, to avoid a unique complex handler function in the parent we can create there two functions: handleNext() and handlePrev().

We can then split the onStepChange assisted prop and provide both an onNext and onPrev props.