### PR TITLE
`<Header />:` Extend component to render links

### DIFF
--- a/src/components/navigation/Header/index.tsx
+++ b/src/components/navigation/Header/index.tsx
@@ -3,7 +3,7 @@ import { User } from "@data/User";
 import { Stack } from "@layouts/Stack";
 import { FullscreenNav, INavigation } from "@navigation/FullscreenNav";
 import { StyledHeader } from "./styles";
-import { NavLink } from "../NavLink";
+import { BreadcrumbLink } from "../Breadcrumbs/BreadcrumbLink";
 
 export interface IHeaderProps {
   portalId: string;
@@ -11,11 +11,12 @@ export interface IHeaderProps {
   logoURL: JSX.Element;
   userName: string;
   client: string;
+  links: Record<string, { id: string; label: string; path: string }>;
 }
 
 const Header = (props: IHeaderProps) => {
-  const { portalId, navigation, logoURL, userName, client } = props;
-
+  const { portalId, navigation, logoURL, userName, client, links } = props;
+  const tranformedLink = Object.values(links);
   const [mobile, tablet, desktop] = Object.values(
     useMediaQueries([
       "(min-width: 320px)",
@@ -38,12 +39,21 @@ const Header = (props: IHeaderProps) => {
           )}
           {logoURL}
         </Stack>
-        <NavLink id={"link"} label={"link"} path={"link"} />
-        <User
-          userName={userName}
-          client={client}
-          size={mobile && !tablet ? "small" : "large"}
-        />
+        <Stack justifyContent="space-between" gap="23px">
+          {tranformedLink.map((link) => (
+            <BreadcrumbLink
+              key={link.id}
+              label={link.label}
+              path={link.path}
+              id={link.id}
+            />
+          ))}
+          <User
+            userName={userName}
+            client={client}
+            size={mobile && !tablet ? "small" : "large"}
+          />
+        </Stack>
       </Stack>
     </StyledHeader>
   );

--- a/src/components/navigation/Header/index.tsx
+++ b/src/components/navigation/Header/index.tsx
@@ -3,6 +3,7 @@ import { User } from "@data/User";
 import { Stack } from "@layouts/Stack";
 import { FullscreenNav, INavigation } from "@navigation/FullscreenNav";
 import { StyledHeader } from "./styles";
+import { NavLink } from "../NavLink";
 
 export interface IHeaderProps {
   portalId: string;
@@ -37,6 +38,7 @@ const Header = (props: IHeaderProps) => {
           )}
           {logoURL}
         </Stack>
+        <NavLink id={"link"} label={"link"} path={"link"} />
         <User
           userName={userName}
           client={client}

--- a/src/components/navigation/Header/index.tsx
+++ b/src/components/navigation/Header/index.tsx
@@ -4,6 +4,7 @@ import { Stack } from "@layouts/Stack";
 import { FullscreenNav, INavigation } from "@navigation/FullscreenNav";
 import { StyledHeader } from "./styles";
 import { BreadcrumbLink } from "../Breadcrumbs/BreadcrumbLink";
+import { Links } from "./props";
 
 export interface IHeaderProps {
   portalId: string;
@@ -11,7 +12,7 @@ export interface IHeaderProps {
   logoURL: JSX.Element;
   userName: string;
   client: string;
-  links: Record<string, { id: string; label: string; path: string }>;
+  links: Links;
 }
 
 const Header = (props: IHeaderProps) => {

--- a/src/components/navigation/Header/index.tsx
+++ b/src/components/navigation/Header/index.tsx
@@ -17,7 +17,7 @@ export interface IHeaderProps {
 
 const Header = (props: IHeaderProps) => {
   const { portalId, navigation, logoURL, userName, client, links } = props;
-  const tranformedLink = Object.values(links);
+  const linksArray: Links[] = Object.values(links);
   const [mobile, tablet, desktop] = Object.values(
     useMediaQueries([
       "(min-width: 320px)",
@@ -41,7 +41,7 @@ const Header = (props: IHeaderProps) => {
           {logoURL}
         </Stack>
         <Stack justifyContent="space-between" gap="23px">
-          {tranformedLink.map((link) => (
+          {linksArray.map((link) => (
             <BreadcrumbLink
               key={link.id}
               label={link.label}

--- a/src/components/navigation/Header/props.ts
+++ b/src/components/navigation/Header/props.ts
@@ -1,3 +1,7 @@
+import { IBreadcrumbLinkProps } from "../Breadcrumbs/BreadcrumbLink";
+
+export type Links = IBreadcrumbLinkProps;
+
 const parameters = {
   docs: {
     description: {

--- a/src/components/navigation/Header/stories/Header.stories.tsx
+++ b/src/components/navigation/Header/stories/Header.stories.tsx
@@ -101,9 +101,18 @@ Default.args = {
   logoURL: <Logo />,
   userName: "Leonardo Garzón",
   client: "Sistemas Enlínea S.A",
+  links: {
+    documents: {
+      id: "dataUpdate",
+      label: "Data update",
+      path: "/dataUpdate",
+    },
+  },
 };
 
-const theme = structuredClone(presente);
+const theme = {
+  ...presente,
+};
 
 const Themed = (args: IHeaderProps) => (
   <ThemeProvider theme={theme}>

--- a/src/components/navigation/Header/styles.ts
+++ b/src/components/navigation/Header/styles.ts
@@ -22,11 +22,15 @@ const StyledHeader = styled.header`
     display: flex;
     align-items: center;
   }
-
+  & li {
+    display: flex;
+    align-items: center;
+    padding: ${inube.spacing.s0} ${inube.spacing.s500};
+  }
   & > div > div:first-child {
     padding-left: ${inube.spacing.s150};
   }
-  & > div > div:last-child {
+  & > div > div > div:last-child {
     padding: ${inube.spacing.s100} ${inube.spacing.s200};
     border-left: 1px solid
       ${({ theme }: IStyledHeaderProps) =>

--- a/src/components/navigation/Tabs/stories/Tabs.stories.tsx
+++ b/src/components/navigation/Tabs/stories/Tabs.stories.tsx
@@ -29,7 +29,9 @@ Default.args = {
   type: "tabs",
 };
 
-const theme = structuredClone(presente);
+const theme = {
+  ...presente,
+};
 
 const Themed = (args: ITabsProps) => (
   <ThemeProvider theme={theme}>


### PR DESCRIPTION
To enhance our `<Header />` component's capabilities and versatility, this PR introduces functionality that allows it to render links. This expansion addresses common use cases where headers often double as navigation or action points, providing a more interactive experience for users.