### PR TITLE
Selete size prop refactor responsive in `<Assisted />`

### DIFF
--- a/src/components/feedback/Assisted/index.tsx
+++ b/src/components/feedback/Assisted/index.tsx
@@ -31,7 +31,6 @@ export interface IAssistedProps {
   currentStepId: IStep["id"];
   handlePrev: (id: IStep["id"]) => void;
   handleNex: (id: IStep["id"]) => void;
-  completedStepIds?: number[];
   titleButtonBefore?: string;
   titleButtonAfter?: string;
 }

--- a/src/components/feedback/Assisted/index.tsx
+++ b/src/components/feedback/Assisted/index.tsx
@@ -1,10 +1,12 @@
 import { MdArrowBack, MdArrowForward, MdCheckCircle } from "react-icons/md";
 
+import { useMediaQuery } from "@hooks/useMediaQuery";
+import { inube } from "@shared/tokens";
+
 import { Icon } from "@data/Icon";
 import { Text } from "@data/Text";
 import { Button } from "@inputs/Button";
 import { Stack } from "@layouts/Stack";
-import { inube } from "@shared/tokens";
 
 import {
   StyledAssistedContainer,
@@ -22,7 +24,6 @@ type IStep = {
 interface IProgressBarProps {
   currentStep: IStep["id"];
   arrayLength: number;
-  size?: IAssistedProps["size"];
 }
 
 export interface IAssistedProps {
@@ -30,11 +31,9 @@ export interface IAssistedProps {
   currentStepId: IStep["id"];
   handlePrev: (id: IStep["id"]) => void;
   handleNex: (id: IStep["id"]) => void;
-  sequential?: boolean;
   completedStepIds?: number[];
   titleButtonBefore?: string;
   titleButtonAfter?: string;
-  size?: "medium" | "large";
 }
 
 const onPrev = (
@@ -58,11 +57,10 @@ const onNext = (
 };
 
 const ProgressBar = (props: IProgressBarProps) => {
-  const { currentStep, arrayLength, size } = props;
+  const { currentStep, arrayLength } = props;
   return (
-    <StyledProgressBar size={size}>
+    <StyledProgressBar>
       <StyledProgressIndicator
-        size={size}
         currentStep={currentStep}
         arrayLength={arrayLength}
       />
@@ -76,11 +74,11 @@ const Assisted = (props: IAssistedProps) => {
     currentStepId,
     handlePrev,
     handleNex,
-    size = "large",
-    sequential = false,
     titleButtonBefore = "Prev",
     titleButtonAfter = "Next",
   } = props;
+
+  const measure = useMediaQuery("(min-width: 600px)");
 
   const currentStep = steps.find((step) => step?.id === currentStepId);
 
@@ -89,15 +87,15 @@ const Assisted = (props: IAssistedProps) => {
   );
 
   return (
-    <StyledAssistedContainer size={size}>
-      {size === "large" && (
+    <StyledAssistedContainer measure={measure}>
+      {measure && (
         <Stack alignItems="center">
           <Button
             spacing="wide"
             variant="none"
             iconBefore={<MdArrowBack />}
             onClick={
-              sequential || !currentStepIndex
+              !currentStepIndex
                 ? undefined
                 : () => onPrev(currentStepIndex, steps, handlePrev)
             }
@@ -109,11 +107,11 @@ const Assisted = (props: IAssistedProps) => {
       )}
       <Stack
         direction="column"
-        width={size === "medium" ? "288px" : "100%"}
+        width={!measure ? "288px" : "100%"}
         margin="s0 s0 s075 s0"
       >
         <Stack gap={inube.spacing.s100}>
-          {size === "medium" && (
+          {!measure && (
             <Icon
               appearance={!currentStepIndex ? "gray" : "primary"}
               icon={<MdArrowBack style={{ padding: "2px 0px" }} />}
@@ -135,10 +133,10 @@ const Assisted = (props: IAssistedProps) => {
               />
             )}
           </StyledStepIndicator>
-          <Text type="title" size={size === "large" ? "medium" : "small"}>
+          <Text type="title" size={measure ? "medium" : "small"}>
             {currentStep?.label}
           </Text>
-          {size === "medium" && (
+          {!measure && (
             <Icon
               appearance="primary"
               icon={<MdArrowForward style={{ padding: "0px 2px" }} />}
@@ -149,11 +147,10 @@ const Assisted = (props: IAssistedProps) => {
         </Stack>
         <Stack alignItems="center" gap={inube.spacing.s100}>
           <ProgressBar
-            size={size}
             currentStep={currentStepIndex + 1}
             arrayLength={steps.length}
           />
-          {size === "large" && (
+          {measure && (
             <Text type="label">
               {currentStepIndex + 1}/{steps.length}
             </Text>
@@ -168,17 +165,13 @@ const Assisted = (props: IAssistedProps) => {
           {currentStep?.description}
         </Text>
       </Stack>
-      {size === "large" && (
+      {measure && (
         <Stack alignItems="center">
           <Button
             spacing="wide"
             variant="none"
             iconAfter={<MdArrowForward />}
-            onClick={
-              sequential
-                ? undefined
-                : () => onNext(currentStepIndex, steps, handleNex)
-            }
+            onClick={() => onNext(currentStepIndex, steps, handleNex)}
           >
             {titleButtonAfter}
           </Button>

--- a/src/components/feedback/Assisted/props.ts
+++ b/src/components/feedback/Assisted/props.ts
@@ -17,9 +17,22 @@ const props = {
       "(string | number): An identifier that matches one of the id values within the steps array to indicate the current step.",
   },
 
-  completedStepIds: {
+  handlePrev: {
     description:
-      " (Array of string or number): (Optional) An array of step id values that have already been completed. Helps in visually indicating to the user which steps are already done.",
+      "(Function): (Optional) A function that will be called when the user clicks on the previous button. If not provided, the button will not be rendered.",
+  },
+
+  handleNex: {
+    descriptions:
+      "(Function): (Optional) A function that will be called when the user clicks on the next button.",
+  },
+  titleButtonBefore: {
+    description:
+      "(string): (Optional) A string to be displayed in the button before the label of the current step.",
+  },
+  titleButtonAfter: {
+    description:
+      "(string): (Optional) A string to be displayed in the button after the label of the current step.",
   },
 };
 

--- a/src/components/feedback/Assisted/props.ts
+++ b/src/components/feedback/Assisted/props.ts
@@ -16,10 +16,7 @@ const props = {
     description:
       "(string | number): An identifier that matches one of the id values within the steps array to indicate the current step.",
   },
-  onStepChange: {
-    desciption:
-      "(function): A callback function that gets triggered when a step is changed. It should accept a single argument, which is the id of the step to which the user navigates.",
-  },
+
   completedStepIds: {
     description:
       " (Array of string or number): (Optional) An array of step id values that have already been completed. Helps in visually indicating to the user which steps are already done.",

--- a/src/components/feedback/Assisted/stories/Assisted.stories.tsx
+++ b/src/components/feedback/Assisted/stories/Assisted.stories.tsx
@@ -56,7 +56,6 @@ Default.args = {
   titleButtonBefore: "Anterior",
   titleButtonAfter: "Próximo",
   currentStepId: 3,
-  size: "large",
 };
 
 const theme = structuredClone(presente);

--- a/src/components/feedback/Assisted/stories/Assisted.stories.tsx
+++ b/src/components/feedback/Assisted/stories/Assisted.stories.tsx
@@ -58,7 +58,9 @@ Default.args = {
   currentStepId: 3,
 };
 
-const theme = structuredClone(presente);
+const theme = {
+  ...presente,
+};
 
 const Themed = (args: IAssistedProps) => (
   <ThemeProvider theme={theme}>

--- a/src/components/feedback/Assisted/styles.ts
+++ b/src/components/feedback/Assisted/styles.ts
@@ -7,19 +7,19 @@ interface IStyledAssistedProps extends IAssistedProps {
   theme?: Themed;
   arrayLength: number;
   currentStep: number;
+  measure: boolean;
 }
 
 const StyledAssistedContainer = styled.div`
   display: flex;
   border-radius: 8px;
   padding: ${inube.spacing.s200};
-  width: ${({ size }: IStyledAssistedProps) =>
-    size === "medium" && "fit-content"};
+  width: ${({ measure }: IStyledAssistedProps) => !measure && "fit-content"};
   background-color: ${({ theme }: IStyledAssistedProps) =>
     theme?.color?.surface?.gray?.clear || inube.color.surface.gray?.clear};
 
-  ${({ size }: IStyledAssistedProps) =>
-    size === "medium" &&
+  ${({ measure }: IStyledAssistedProps) =>
+    !measure &&
     css`
       & > div > div > figure:last-child {
         margin-left: auto;
@@ -40,8 +40,8 @@ const StyledProgressIndicator = styled.div`
   border-radius: 8px;
   transition: width 0.5s;
   height: 16px;
-  width: ${({ size, arrayLength, currentStep }: IStyledAssistedProps) => {
-    if (size === "medium" && currentStep === 1) {
+  width: ${({ arrayLength, currentStep }: IStyledAssistedProps) => {
+    if (currentStep === 1) {
       return "6%";
     }
     if (currentStep === 1) {


### PR DESCRIPTION
The parent shouldn’t be responsible for defining the size of the component.

That would require that each page that needs to use the assisted would have to create a media query and individually define where to make the shift between small and large.

In this case, the Assisted component should define that shift by itself.