### PR TITLE
Use Grid component in layout `<Assisted />`

### DIFF
--- a/src/components/feedback/Assisted/index.tsx
+++ b/src/components/feedback/Assisted/index.tsx
@@ -109,7 +109,7 @@ const Assisted = (props: IAssistedProps) => {
         width={!measure ? "288px" : "100%"}
         margin="s0 s0 s075 s0"
       >
-        <Stack gap={inube.spacing.s100}>
+        <Grid templateColumns="auto auto 1fr auto" gap="s100">
           {!measure && (
             <Icon
               appearance={!currentStepIndex ? "gray" : "primary"}
@@ -143,7 +143,7 @@ const Assisted = (props: IAssistedProps) => {
               onClick={() => onNext(currentStepIndex, steps, handleNex)}
             />
           )}
-        </Stack>
+        </Grid>
         <Stack alignItems="center" gap={inube.spacing.s100}>
           <ProgressBar
             currentStep={currentStepIndex + 1}

--- a/src/components/feedback/Assisted/index.tsx
+++ b/src/components/feedback/Assisted/index.tsx
@@ -3,11 +3,11 @@ import { MdArrowBack, MdArrowForward, MdCheckCircle } from "react-icons/md";
 import { Icon } from "@data/Icon";
 import { Text } from "@data/Text";
 import { Button } from "@inputs/Button";
+import { Grid } from "@layouts/Grid";
 import { Stack } from "@layouts/Stack";
 import { inube } from "@shared/tokens";
 
 import {
-  StyledAssistedContainer,
   StyledProgressBar,
   StyledProgressIndicator,
   StyledStepIndicator,
@@ -89,7 +89,7 @@ const Assisted = (props: IAssistedProps) => {
   );
 
   return (
-    <StyledAssistedContainer size={size}>
+    <Grid templateColumns="auto 1fr auto">
       {size === "large" && (
         <Stack alignItems="center">
           <Button
@@ -184,7 +184,7 @@ const Assisted = (props: IAssistedProps) => {
           </Button>
         </Stack>
       )}
-    </StyledAssistedContainer>
+    </Grid>
   );
 };
 

--- a/src/components/feedback/Assisted/styles.ts
+++ b/src/components/feedback/Assisted/styles.ts
@@ -1,4 +1,4 @@
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import { inube } from "@src/shared/tokens";
 import { Themed } from "@shared/types/types";
 import { IAssistedProps } from ".";
@@ -8,24 +8,6 @@ interface IStyledAssistedProps extends IAssistedProps {
   arrayLength: number;
   currentStep: number;
 }
-
-const StyledAssistedContainer = styled.div`
-  display: flex;
-  border-radius: 8px;
-  padding: ${inube.spacing.s200};
-  width: ${({ size }: IStyledAssistedProps) =>
-    size === "medium" && "fit-content"};
-  background-color: ${({ theme }: IStyledAssistedProps) =>
-    theme?.color?.surface?.gray?.clear || inube.color.surface.gray?.clear};
-
-  ${({ size }: IStyledAssistedProps) =>
-    size === "medium" &&
-    css`
-      & > div > div > figure:last-child {
-        margin-left: auto;
-      }
-    `}
-`;
 
 const StyledProgressBar = styled.div`
   border-radius: 10px;
@@ -69,9 +51,4 @@ const StyledStepIndicator = styled.div`
     inube.color.stroke.primary?.regular};
 `;
 
-export {
-  StyledAssistedContainer,
-  StyledProgressBar,
-  StyledProgressIndicator,
-  StyledStepIndicator,
-};
+export { StyledProgressBar, StyledProgressIndicator, StyledStepIndicator };


### PR DESCRIPTION
Using the Grid component, this allows you to arrange the elements to be displayed in `grid-template-columns: auto 1fr auto`, this will remove any CSS layout property of StyledAssistedContainer, organize the large structure of the component with a grid.