### PR TITLE
All the steps are divided equally `<Assisted />`

### DIFF
--- a/src/components/feedback/Assisted/styles.ts
+++ b/src/components/feedback/Assisted/styles.ts
@@ -40,15 +40,8 @@ const StyledProgressIndicator = styled.div`
   border-radius: 8px;
   transition: width 0.5s;
   height: 16px;
-  width: ${({ arrayLength, currentStep }: IStyledAssistedProps) => {
-    if (currentStep === 1) {
-      return "6%";
-    }
-    if (currentStep === 1) {
-      return "2%";
-    }
-    return `${(currentStep / arrayLength) * 100}%`;
-  }};
+  width: ${({ arrayLength, currentStep }: IStyledAssistedProps) =>
+    `${(currentStep / arrayLength) * 100}%`};
   background: ${({ theme }: IStyledAssistedProps) =>
     theme?.color?.surface?.primary?.regular ||
     inube.color.surface.primary?.regular};


### PR DESCRIPTION
The width of the bar is always calculated as actual step / total steps.

This means that if the assist has two steps, the first step will use 50% of the bar width.