### PR TITLE
`<Tag />:` develop component

### DIFF
--- a/src/components/data/Tag/Tag.stories.tsx
+++ b/src/components/data/Tag/Tag.stories.tsx
@@ -1,5 +1,4 @@
 import { ThemeProvider } from "styled-components";
-import { MdAdb } from "react-icons/md";
 
 import { props, parameters } from "./props";
 import { presente } from "@shared/themes/presente";

--- a/src/components/data/Tag/Tag.stories.tsx
+++ b/src/components/data/Tag/Tag.stories.tsx
@@ -1,0 +1,36 @@
+import { ThemeProvider } from "styled-components";
+import { MdAdb } from "react-icons/md";
+
+import { props, parameters } from "./props";
+import { presente } from "@shared/themes/presente";
+import { ITagProps, Tag } from ".";
+
+const story = {
+  title: "data/Tag",
+  component: Tag,
+  parameters,
+  argTypes: props,
+};
+
+export const Default = (args: ITagProps) => <Tag {...args} />;
+
+Default.args = {
+  appearance: "primary",
+  label: "Tag",
+};
+
+const theme = {
+  ...presente,
+};
+
+export const Themed = (args: ITagProps) => (
+  <ThemeProvider theme={theme}>
+    <Tag {...args} />
+  </ThemeProvider>
+);
+
+Themed.args = {
+  ...Default.args,
+};
+
+export default story;

--- a/src/components/data/Tag/index.tsx
+++ b/src/components/data/Tag/index.tsx
@@ -1,0 +1,28 @@
+import { StyledTag } from "./styles";
+import { Appearance } from "./props";
+import { Text } from "@data/Text";
+
+const darkTextAppearances = ["warning", "gray", "light"];
+
+export interface ITagProps {
+  appearance: Appearance;
+  label: string;
+}
+
+const Tag = (props: ITagProps) => {
+  const { appearance, label } = props;
+
+  return (
+    <StyledTag appearance={appearance}>
+      <Text
+        type="label"
+        appearance={darkTextAppearances.includes(appearance) ? "dark" : "light"}
+        size="small"
+      >
+        {label}
+      </Text>
+    </StyledTag>
+  );
+};
+
+export { Tag };

--- a/src/components/data/Tag/props.ts
+++ b/src/components/data/Tag/props.ts
@@ -1,0 +1,33 @@
+const appearances = [
+  "primary",
+  "success",
+  "error",
+  "warning",
+  "help",
+  "dark",
+  "gray",
+  "light",
+] as const;
+
+export type Appearance = typeof appearances[number];
+
+const parameters = {
+  docs: {
+    description: {
+      component: "Icons used to communicate actions and decisions graphically",
+    },
+  },
+};
+
+const props = {
+  label: {
+    description: "Controls the text that the tag will display",
+  },
+  appearance: {
+    control: "select",
+    options: appearances,
+    description: "Controls the background color of the tag",
+  },
+};
+
+export { props, parameters };

--- a/src/components/data/Tag/styles.ts
+++ b/src/components/data/Tag/styles.ts
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+import { inube } from "@shared/tokens";
+import { ITagProps } from ".";
+import { Themed } from "@shared/types/types";
+
+interface IStyledTag extends ITagProps {
+  theme?: Themed;
+}
+
+const StyledTag = styled.div`
+  display: inline-block;
+  padding: 0 ${inube.spacing.s050};
+  background-color: ${({ theme, appearance }: IStyledTag) =>
+    theme?.color?.surface?.[appearance]?.regular ||
+    inube.color.surface[appearance].regular};
+
+  border-radius: 4px;
+`;
+
+export { StyledTag };


### PR DESCRIPTION
We're thrilled to unveil the new `<Tag />` component in this PR. This component is devised to represent short, interactive labels for content categorization, keywords, or other small pieces of information.