### PR TITLE
Directly pass onPrev prop function in `<Assisted />`

### DIFF
--- a/src/components/feedback/Assisted/index.tsx
+++ b/src/components/feedback/Assisted/index.tsx
@@ -93,11 +93,7 @@ const Assisted = (props: IAssistedProps) => {
             spacing="wide"
             variant="none"
             iconBefore={<MdArrowBack />}
-            onClick={
-              !currentStepIndex
-                ? undefined
-                : () => onPrev(currentStepIndex, steps, handlePrev)
-            }
+            onClick={() => onPrev(currentStepIndex, steps, handlePrev)}
             appearance={!currentStepIndex ? "gray" : "primary"}
           >
             {titleButtonBefore}


### PR DESCRIPTION
This is done within the function itself, on the other hand when you are in the initial step the `<Button />` is disabled, so it does not allow you to click on it.