### PR TITLE
`<Button />:` appearance in disabled state depending on variant

### DIFF
--- a/src/components/inputs/Button/index.tsx
+++ b/src/components/inputs/Button/index.tsx
@@ -86,6 +86,8 @@ const ButtonStructure = (props: IButtonProps) => {
               size="18px"
               appearance={childrenAppearence(variant, appearance)}
               disabled={disabled}
+              cursorHover={cursorHover}
+              parentHover={parentHover}
             />
           )}
           <Text
@@ -94,6 +96,8 @@ const ButtonStructure = (props: IButtonProps) => {
             appearance={childrenAppearence(variant, appearance)}
             disabled={disabled}
             ellipsis={true}
+            cursorHover={cursorHover}
+            parentHover={parentHover}
           >
             {children}
           </Text>
@@ -104,6 +108,8 @@ const ButtonStructure = (props: IButtonProps) => {
               size="18px"
               appearance={childrenAppearence(variant, appearance)}
               disabled={disabled}
+              cursorHover={cursorHover}
+              parentHover={parentHover}
             />
           )}
         </Stack>

--- a/src/components/inputs/Button/styles.ts
+++ b/src/components/inputs/Button/styles.ts
@@ -96,23 +96,6 @@ const StyledButton = styled.button`
     );
   }};
 
-  & > * > p,
-  figure {
-    color: ${({
-      theme,
-      appearance,
-      variant,
-      disabled,
-      parentHover,
-    }: IStyledButtonProps) => {
-      if (!disabled && parentHover && variant !== "filled")
-        return (
-          theme?.color?.stroke?.[appearance!]?.hover ||
-          inube.color.stroke[appearance!].hover
-        );
-    }};
-  }
-
   cursor: ${({ disabled, loading }: IStyledButtonProps) => {
     if (disabled) {
       return "not-allowed";
@@ -161,32 +144,6 @@ const StyledButton = styled.button`
         return "transparent";
       }
     }};
-
-    & > * > p,
-    figure {
-      color: ${({
-        theme,
-        appearance,
-        variant,
-        disabled,
-        cursorHover,
-        parentHover,
-      }: IStyledButtonProps) => {
-        if (!disabled && parentHover && variant !== "filled")
-          return (
-            theme?.color?.stroke?.[appearance!]?.hover ||
-            inube.color.stroke[appearance!].hover
-          );
-        if (!disabled && cursorHover) {
-          if (variant !== "filled") {
-            return (
-              theme?.color?.stroke?.[appearance!]?.hover ||
-              inube.color.stroke[appearance!].hover
-            );
-          }
-        }
-      }};
-    }
   }
 `;
 

--- a/src/components/inputs/Button/styles.ts
+++ b/src/components/inputs/Button/styles.ts
@@ -73,6 +73,9 @@ const StyledButton = styled.button`
     parentHover,
   }: IStyledButtonProps) => {
     if (disabled) {
+      if (variant !== "outlined") {
+        return "transparent";
+      }
       return (
         theme?.color?.stroke?.[appearance!]?.disabled ||
         inube.color.stroke[appearance!].disabled
@@ -92,6 +95,23 @@ const StyledButton = styled.button`
       inube.color.stroke[appearance!].regular
     );
   }};
+
+  & > * > p,
+  figure {
+    color: ${({
+      theme,
+      appearance,
+      variant,
+      disabled,
+      parentHover,
+    }: IStyledButtonProps) => {
+      if (!disabled && parentHover && variant !== "filled")
+        return (
+          theme?.color?.stroke?.[appearance!]?.hover ||
+          inube.color.stroke[appearance!].hover
+        );
+    }};
+  }
 
   cursor: ${({ disabled, loading }: IStyledButtonProps) => {
     if (disabled) {
@@ -141,6 +161,32 @@ const StyledButton = styled.button`
         return "transparent";
       }
     }};
+
+    & > * > p,
+    figure {
+      color: ${({
+        theme,
+        appearance,
+        variant,
+        disabled,
+        cursorHover,
+        parentHover,
+      }: IStyledButtonProps) => {
+        if (!disabled && parentHover && variant !== "filled")
+          return (
+            theme?.color?.stroke?.[appearance!]?.hover ||
+            inube.color.stroke[appearance!].hover
+          );
+        if (!disabled && cursorHover) {
+          if (variant !== "filled") {
+            return (
+              theme?.color?.stroke?.[appearance!]?.hover ||
+              inube.color.stroke[appearance!].hover
+            );
+          }
+        }
+      }};
+    }
   }
 `;
 


### PR DESCRIPTION
This PR emphasizes enhancing the visual feedback of the `<Button />` component when it's in a disabled state, with the appearance being influenced by the button's variant. Ensuring a clear distinction between different button variants, even in a disabled state, provides a more intuitive user experience.