### PR TITLE
Refactor appearance of Prev `<Button />` in `<Assisted />`

### DIFF
--- a/src/components/feedback/Assisted/index.tsx
+++ b/src/components/feedback/Assisted/index.tsx
@@ -94,7 +94,8 @@ const Assisted = (props: IAssistedProps) => {
             variant="none"
             iconBefore={<MdArrowBack />}
             onClick={() => onPrev(currentStepIndex, steps, handlePrev)}
-            appearance={!currentStepIndex ? "gray" : "primary"}
+            appearance="primary"
+            disabled={currentStepIndex === 0}
           >
             {titleButtonBefore}
           </Button>

--- a/src/components/feedback/Assisted/index.tsx
+++ b/src/components/feedback/Assisted/index.tsx
@@ -26,13 +26,18 @@ interface IProgressBarProps {
   arrayLength: number;
 }
 
+type ITitleButton = {
+  before?: string;
+  after?: string;
+  finish?: string;
+};
+
 export interface IAssistedProps {
   steps: IStep[];
   currentStepId: IStep["id"];
   handlePrev: (id: IStep["id"]) => void;
   handleNext: (id: IStep["id"]) => void;
-  titleButtonBefore?: string;
-  titleButtonAfter?: string;
+  titleButtonText?: ITitleButton;
 }
 
 const onPrev = (
@@ -73,8 +78,11 @@ const Assisted = (props: IAssistedProps) => {
     currentStepId,
     handlePrev,
     handleNext,
-    titleButtonBefore = "Prev",
-    titleButtonAfter = "Next",
+    titleButtonText: { before, after, finish } = {
+      before: "Prev",
+      after: "Next",
+      finish: "Send",
+    },
   } = props;
 
   const measure = useMediaQuery("(min-width: 600px)");
@@ -97,7 +105,7 @@ const Assisted = (props: IAssistedProps) => {
             appearance="primary"
             disabled={currentStepIndex === 0}
           >
-            {titleButtonBefore}
+            {before}
           </Button>
         </Stack>
       )}
@@ -170,7 +178,7 @@ const Assisted = (props: IAssistedProps) => {
             iconAfter={<MdArrowForward />}
             onClick={() => onNext(currentStepIndex, steps, handleNext)}
           >
-            {titleButtonAfter}
+            {currentStepIndex === steps.length - 1 ? finish : after}
           </Button>
         </Stack>
       )}

--- a/src/components/feedback/Assisted/index.tsx
+++ b/src/components/feedback/Assisted/index.tsx
@@ -109,10 +109,11 @@ const Assisted = (props: IAssistedProps) => {
         <Grid templateColumns="auto auto 1fr auto" gap="s100">
           {!measure && (
             <Icon
-              appearance={!currentStepIndex ? "gray" : "primary"}
+              appearance="primary"
               icon={<MdArrowBack style={{ padding: "2px 0px" }} />}
               size="20px"
               onClick={() => onPrev(currentStepIndex, steps, handlePrev)}
+              disabled={currentStepIndex === 0}
             />
           )}
           <StyledStepIndicator>

--- a/src/components/feedback/Assisted/index.tsx
+++ b/src/components/feedback/Assisted/index.tsx
@@ -98,7 +98,8 @@ const Assisted = (props: IAssistedProps) => {
                 ? undefined
                 : () => onPrev(currentStepIndex, steps, handlePrev)
             }
-            appearance={!currentStepIndex ? "gray" : "primary"}
+            appearance={"primary"}
+            disabled={!currentStepIndex}
           >
             {titleButtonBefore}
           </Button>

--- a/src/components/feedback/Assisted/stories/Assisted.stories.tsx
+++ b/src/components/feedback/Assisted/stories/Assisted.stories.tsx
@@ -53,9 +53,12 @@ const Default = (args: IAssistedProps) => <AssistedController {...args} />;
 
 Default.args = {
   steps: stepsMock,
-  titleButtonBefore: "Anterior",
-  titleButtonAfter: "Próximo",
   currentStepId: 3,
+  titleButtonText: {
+    before: "Anterior",
+    after: "Siguiente",
+    finish: "Enviar",
+  },
 };
 
 const theme = {


### PR DESCRIPTION
The button should always be to appearance primary, but  the disabled prop should depend on whether the user is in the first step or not.

When checking for the disabled prop, don’t use currentStepIndex as a truthy or falsy value. Directly compare the index with the first step (this means, don’t use !currentStepIndex in the condition).