### PR TITLE
Replace `<StyledContainerLabel />` by `<Stack />` into `<Select />`

### DIFF
--- a/src/components/inputs/Select/interface.tsx
+++ b/src/components/inputs/Select/interface.tsx
@@ -13,12 +13,7 @@ import { Stack } from "@layouts/Stack";
 import { Size } from "./props";
 import { OptionList } from "./OptionList";
 import { ISelectProps } from ".";
-import {
-  StyledContainer,
-  StyledContainerLabel,
-  StyledInputContainer,
-  StyledInput,
-} from "./styles";
+import { StyledContainer, StyledInputContainer, StyledInput } from "./styles";
 import { OptionItem } from "./OptionItem";
 
 export interface ISelectInterfaceProps extends ISelectProps {
@@ -86,19 +81,20 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
 
   return (
     <StyledContainer fullwidth={fullwidth} disabled={disabled} ref={ref}>
-      <StyledContainerLabel
+      <Stack
         alignItems="center"
-        wrap="wrap"
-        size={size}
-        disabled={disabled}
+        margin="s0 s0 s050 s0"
+        padding="s0 s0 s0 s200"
+        gap="2px"
       >
         {label && (
           <Label
             htmlFor={id}
             disabled={disabled}
             focused={focused}
-            invalid={status === "invalid" ? true : false}
+            invalid={status === "invalid"}
             size={getTypo(size!)}
+            margin="0px 0px 0px 2px"
           >
             {label}
           </Label>
@@ -109,7 +105,7 @@ const SelectUI = forwardRef((props: ISelectInterfaceProps, ref) => {
             (Requerido)
           </Text>
         )}
-      </StyledContainerLabel>
+      </Stack>
 
       <StyledInputContainer
         disabled={disabled}

--- a/src/components/inputs/Select/styles.ts
+++ b/src/components/inputs/Select/styles.ts
@@ -23,18 +23,10 @@ const StyledContainer = styled.div`
     disabled && "not-allowed"};
   width: ${({ fullwidth }: IStyledSelectInterfaceProps) =>
     fullwidth ? "100%" : "300px"};
-`;
 
-const StyledContainerLabel = styled.div`
-  display: flex;
-  align-items: center;
-  margin-bottom: 4px;
-  padding-left: 16px;
-  pointer-events: ${({ disabled }: IStyledSelectInterfaceProps) =>
-    disabled && "none"};
-
-  & label {
-    margin-right: 5px;
+  & > label {
+    cursor: ${({ disabled }: IStyledSelectInterfaceProps) =>
+      disabled && "not-allowed"};
   }
 `;
 
@@ -76,8 +68,7 @@ const StyledInputContainer = styled.div`
       inube.color.stroke.divider.regular
     );
   }};
-  pointer-events: ${({ disabled }: IStyledSelectInterfaceProps) =>
-    disabled ? "none" : "auto"};
+
   opacity: ${({ disabled }: IStyledSelectInterfaceProps) =>
     disabled ? "0.5" : "none"};
   cursor: ${({ disabled }: IStyledSelectInterfaceProps) =>
@@ -134,9 +125,4 @@ const StyledInput = styled.input`
   }
 `;
 
-export {
-  StyledContainer,
-  StyledContainerLabel,
-  StyledInputContainer,
-  StyledInput,
-};
+export { StyledContainer, StyledInputContainer, StyledInput };


### PR DESCRIPTION
The `StyledContainer` component could be replaced by the `<Stack />` component, although it should be noted that when the `<Select />` component is disabled, the `<Label />` component will not be able to generate cursor interaction.