### PR TITLE
`Fix`: Correct `<Nav/>` Marker Positioning to Align with Figma Standards

### DIFF
--- a/src/components/navigation/Nav/index.tsx
+++ b/src/components/navigation/Nav/index.tsx
@@ -112,37 +112,39 @@ const Nav = (props: INavProps) => {
 
   return (
     <StyledNav>
-      <Stack direction="column">
-        <Text
-          padding="0px"
-          margin="32px 16px 16px 16px"
-          as="h2"
-          appearance="gray"
-          type="title"
-          size="small"
-        >
-          {navigation.title}
-        </Text>
-        {Object.keys(navigation.sections).length > 1 ? (
-          <MultiSections navigation={navigation} />
-        ) : (
-          <OneSection navigation={navigation} />
-        )}
-        <SeparatorLine />
-        <NavLink
-          id="logout"
-          label={logoutTitle}
-          icon={<MdLogout />}
-          path={logoutPath}
-        />
-      </Stack>
-      <StyledFooter>
-        <Stack justifyContent="center">
-          <Text type="label" size="medium" appearance="gray" padding="24px">
-            ©2023 - Inube
+      <Stack direction="column" justifyContent="space-between" height="100%">
+        <Stack direction="column">
+          <Text
+            padding="0px"
+            margin="32px 16px 16px 16px"
+            as="h2"
+            appearance="gray"
+            type="title"
+            size="small"
+          >
+            {navigation.title}
           </Text>
+          {Object.keys(navigation.sections).length > 1 ? (
+            <MultiSections navigation={navigation} />
+          ) : (
+            <OneSection navigation={navigation} />
+          )}
+          <SeparatorLine />
+          <NavLink
+            id="logout"
+            label={logoutTitle}
+            icon={<MdLogout />}
+            path={logoutPath}
+          />
         </Stack>
-      </StyledFooter>
+        <StyledFooter>
+          <Stack justifyContent="center">
+            <Text type="label" size="medium" appearance="gray" padding="24px">
+              ©2023 - Inube
+            </Text>
+          </Stack>
+        </StyledFooter>
+      </Stack>
     </StyledNav>
   );
 };


### PR DESCRIPTION
This pull request (PR) resolves a misalignment issue in the `<Nav/>` component's marker, as detailed in [Issue #622](https://github.com/selsa-inube/design-system/issues/622). The objective is to realign the marker's positioning to conform with the established Figma design standards, thereby maintaining visual consistency and compliance with our user interface (UI) design guidelines.