### PR TITLE
Remove background colorin `<Nav />`

### DIFF
--- a/src/components/navigation/Nav/styles.ts
+++ b/src/components/navigation/Nav/styles.ts
@@ -11,8 +11,6 @@ const StyledNav = styled.div`
   height: 100%;
   width: 248px;
   box-sizing: border-box;
-  background-color: ${({ theme }: IStyledNavLinkProps) =>
-    theme?.color?.surface?.nav?.regular || inube.color.surface.nav.regular};
   border-right: 1px solid
     ${({ theme }: IStyledNavLinkProps) =>
       theme?.color?.stroke?.divider?.regular ||


### PR DESCRIPTION
The background color of the component is adjusted to avoid interfering with the styles of adjacent components. 