### PR TITLE
Adjust container height in `<Textfield>`

### DIFF
--- a/src/components/inputs/Textfield/styles.ts
+++ b/src/components/inputs/Textfield/styles.ts
@@ -13,8 +13,6 @@ const StyledContainer = styled.div`
   cursor: ${({ disabled }: IStyledTextfieldProps) => disabled && "not-allowed"};
   width: ${({ fullwidth }: IStyledTextfieldProps) =>
     fullwidth ? "100%" : "280px"};
-  height: ${({ size }: IStyledTextfieldProps) =>
-    size === "compact" ? "80px" : "92px"};
 `;
 
 const StyledContainerLabel = styled.div`


### PR DESCRIPTION
implement improvements in the Textfield component to increase its usability, such as handling the component height, as this was causing layout and spacing errors in the `<Textfield>` sibling components