### PR TITLE
`Fix:` Correct `<Textfield/>` Input Background Color in Read-Only Mode

### DIFF
--- a/src/components/inputs/Textfield/index.tsx
+++ b/src/components/inputs/Textfield/index.tsx
@@ -144,6 +144,7 @@ const Textfield = (props: ITextfieldProps) => {
         status={status}
         iconBefore={iconBefore}
         iconAfter={iconAfter}
+        readOnly={readOnly}
       >
         {iconBefore && (
           <Icon

--- a/src/components/inputs/Textfield/styles.ts
+++ b/src/components/inputs/Textfield/styles.ts
@@ -9,6 +9,9 @@ interface IStyledTextfieldProps extends ITextfieldProps {
   theme?: Themed;
 }
 
+const setBackgroundColor = ({ readOnly }: IStyledTextfieldProps) =>
+  readOnly && inube.color.surface.gray.clear;
+
 const StyledContainer = styled.div`
   cursor: ${({ disabled }: IStyledTextfieldProps) => disabled && "not-allowed"};
   width: ${({ fullwidth }: IStyledTextfieldProps) =>
@@ -34,6 +37,7 @@ const StyledInputContainer = styled.div`
   pointer-events: ${({ disabled }: IStyledTextfieldProps) =>
     disabled && "none"};
   opacity: ${({ disabled }: IStyledTextfieldProps) => disabled && "0.5"};
+  background-color: ${setBackgroundColor};
   grid-template-columns: ${({
     iconBefore,
     iconAfter,
@@ -89,8 +93,7 @@ const StyledInput = styled.input`
   font-weight: ${inube.typography.body.large.weight};
   line-height: ${inube.typography.body.large.lineHeight};
   letter-spacing: ${inube.typography.body.large.tracking};
-  background-color: ${({ readOnly }: IStyledTextfieldProps) =>
-    readOnly && inube.color.surface.gray.clear};
+  background-color: ${setBackgroundColor};
   color: ${({ disabled, theme }: IStyledTextfieldProps) =>
     disabled
       ? theme?.color?.text?.gray?.disabled || inube.color.text.gray.disabled


### PR DESCRIPTION
This PR addresses an issue with the `<Textfield/>` background color of input fields when they are in read-only mode. The current background color does not distinctly indicate that the input is in a non-interactive state, which can lead to user confusion. This update ensures that the background color clearly reflects the read-only status of the inputs, aligning with our UI design principles for clarity and user experience.