### PR TITLE
Adjust the over-positioning `<OptionList />`

### DIFF
--- a/src/components/inputs/Select/OptionList/styled.ts
+++ b/src/components/inputs/Select/OptionList/styled.ts
@@ -9,10 +9,11 @@ interface IStyledOptionListProps extends OptionListProps {
 const StyledOptionList = styled.ul`
   display: flex;
   flex-direction: column;
-  width: inherit;
+  width: -webkit-fill-available;
   padding: 4px 0px;
-  position: relative;
+  position: absolute;
   z-index: 1;
+  border-radius: 4px;
   background: ${({ theme }: IStyledOptionListProps) => {
     return (
       theme?.color?.surface?.light?.clear || inube.color.surface.light.clear
@@ -20,7 +21,6 @@ const StyledOptionList = styled.ul`
   }};
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.3),
     0px 2px 6px 2px rgba(0, 0, 0, 0.15);
-  border-radius: 4px;
 `;
 
 export { StyledOptionList };


### PR DESCRIPTION
The positioning property of the component is adjusted so that it is displayed above the other components and does not displace them.