### PR TITLE
`Fix:` Remove `Incremental Buttons` Added by Browser to Number Input

### DIFF
--- a/src/components/inputs/Textfield/styles.ts
+++ b/src/components/inputs/Textfield/styles.ts
@@ -101,7 +101,10 @@ const StyledInput = styled.input`
     size === "compact" ? "40px" : "48px"};
 
   border: none;
-
+  &[type="number"] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+  }
   ::placeholder {
     color: ${({ theme }: IStyledTextfieldProps) =>
       theme?.color?.text?.gray?.regular || inube.color.text.gray.regular};
@@ -122,6 +125,12 @@ const StyledInput = styled.input`
 
   &:-webkit-autofill {
     -webkit-background-clip: text;
+  }
+
+  &::-webkit-outer-spin-button,
+  ::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
   }
 `;
 


### PR DESCRIPTION
This PR solves `ids945` and also addresses an issue where the browser automatically adds incremental buttons (up and down arrows) to `number-typed input fields`. These buttons may interfere with the user interface and functionality of our application. The fix involves removing these incremental buttons to ensure a consistent and unobstructed user experience.
