### PR TITLE
Fix: Correct `<Tabs/>` fix Tab behavior

### DIFF
--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -39,7 +39,6 @@ const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
       const tabElement = targetElement.closest("[id]");
       if (tabElement && tabElement.tagName.toLowerCase() === "li") {
         const id = tabElement.getAttribute("id");
-        console.log(tabElement.getAttribute("disabled"), "disabled");
         if (id && tabElement.getAttribute("disabled") === null) {
           onChange(id);
         }

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -34,12 +34,14 @@ const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
   };
 
   const handleTabClick = (e: React.MouseEvent) => {
-    const targetElement = e.target as Element;
-    const tabElement = targetElement.closest("[id]");
-    if (tabElement) {
-      const id = tabElement.getAttribute("id");
-      if (id && !tabElement.getAttribute("disabled")) {
-        onChange(id);
+    const targetElement = e.target;
+    if (targetElement instanceof HTMLElement) {
+      const tabElement = targetElement.closest("[id]");
+      if (tabElement && tabElement.tagName.toLowerCase() === "li") {
+        const id = tabElement.getAttribute("id");
+        if (id && !tabElement.getAttribute("disabled")) {
+          onChange(id);
+        }
       }
     }
   };

--- a/src/components/navigation/Tabs/index.tsx
+++ b/src/components/navigation/Tabs/index.tsx
@@ -39,7 +39,8 @@ const Tabs = ({ tabs, type = "tabs", selectedTab, onChange }: ITabsProps) => {
       const tabElement = targetElement.closest("[id]");
       if (tabElement && tabElement.tagName.toLowerCase() === "li") {
         const id = tabElement.getAttribute("id");
-        if (id && !tabElement.getAttribute("disabled")) {
+        console.log(tabElement.getAttribute("disabled"), "disabled");
+        if (id && tabElement.getAttribute("disabled") === null) {
           onChange(id);
         }
       }


### PR DESCRIPTION
Correct the behavior that occurred in the "tabs" component when clicking in the gap or outside the tabs changes in a strange way. This is done by refactoring the `handleTabClick()` function. 