### PR TITLE
Mobile Responsiveness Issue with `<Assisted/>` Component Display

### DIFF
--- a/src/components/feedback/Assisted/index.tsx
+++ b/src/components/feedback/Assisted/index.tsx
@@ -90,7 +90,7 @@ const Assisted = (props: IAssistedProps) => {
         </Stack>
       )}
 
-      <Stack direction="column" width="100%" margin="s0 s0 s075 s0">
+      <Stack direction="column" margin="s0 s0 s075 s0">
         <Grid templateColumns="auto auto 1fr auto" gap="s100">
           {!measure && (
             <Icon

--- a/src/components/feedback/Assisted/index.tsx
+++ b/src/components/feedback/Assisted/index.tsx
@@ -74,7 +74,7 @@ const Assisted = (props: IAssistedProps) => {
   );
 
   return (
-    <Grid templateColumns="auto 1fr auto">
+    <Grid templateColumns={!measure ? "1fr" : "auto 1fr auto"}>
       {measure && (
         <Stack alignItems="center">
           <Button
@@ -90,11 +90,7 @@ const Assisted = (props: IAssistedProps) => {
         </Stack>
       )}
 
-      <Stack
-        direction="column"
-        width={!measure ? "288px" : "100%"}
-        margin="s0 s0 s075 s0"
-      >
+      <Stack direction="column" width="100%" margin="s0 s0 s075 s0">
         <Grid templateColumns="auto auto 1fr auto" gap="s100">
           {!measure && (
             <Icon


### PR DESCRIPTION
Adjust the layout of the `<Assisted />` component inside its container when it is on mobile screens.