### PR TITLE
 update to add ellipsis to title text in `<Assisted />`

### DIFF
--- a/src/components/feedback/Assisted/index.tsx
+++ b/src/components/feedback/Assisted/index.tsx
@@ -115,7 +115,7 @@ const Assisted = (props: IAssistedProps) => {
               />
             )}
           </StyledStepIndicator>
-          <Text type="title" size={measure ? "medium" : "small"}>
+          <Text type="title" size={measure ? "medium" : "small"} ellipsis>
             {currentStep?.label}
           </Text>
           {!measure && (


### PR DESCRIPTION
The text should be adapted according to the size of the container, avoiding that when the name of the step is too big it breaks the layout of the component.