### PR TITLE
Inconsistent `<BreadcrumbLink/>` Appearance Based on Condition Fulfillment

### DIFF
--- a/src/components/navigation/Breadcrumbs/index.tsx
+++ b/src/components/navigation/Breadcrumbs/index.tsx
@@ -47,12 +47,13 @@ const Breadcrumbs = (props: IBreadcrumbsProps) => {
 
   return (
     <StyledBreadcrumbs>
-      {crumbs.map(({ path, label }) => (
+      {crumbs.map(({ path, label }, index) => (
         <BreadcrumbLink
           key={path}
           path={path}
           id={path}
           label={capitalizeString(label)}
+          appearance={index === crumbs.length - 1 ? "dark" : "gray"}
         />
       ))}
     </StyledBreadcrumbs>


### PR DESCRIPTION
correcting the appearance of the last `<BreadcrumbLink />`, changing its appearance to `darck`, this change is made to adapt to the required layouts and needs. 