### PR TITLE
Enhancement of `<Nav/>` Component for Background Color Compatibility

### DIFF
--- a/src/components/navigation/Nav/styles.ts
+++ b/src/components/navigation/Nav/styles.ts
@@ -10,6 +10,8 @@ interface IStyledNavLinkProps extends INavLinkProps {
 const StyledNav = styled.div`
   width: 248px;
   box-sizing: border-box;
+  background-color: ${({ theme }: IStyledNavLinkProps) =>
+    theme?.color?.surface?.nav?.regular || inube.color.surface.nav.regular};
   border-right: 1px solid
     ${({ theme }: IStyledNavLinkProps) =>
       theme?.color?.stroke?.divider?.regular ||


### PR DESCRIPTION
The `<Nav/>` component presently lacks the capability to handle a background color attribute. It is essential to update this component so that it aligns with our Figma design specifications. Specifically, the background color property should be integrated and linked to the 'surface-token nav' to ensure consistent and accurate styling across our application. This enhancement will enable better design conformity and visual appeal as per our design guidelines.